### PR TITLE
Explicitly translating _regions.json to select endpoints and credential scopes

### DIFF
--- a/core/src/Network/AWS/Prelude.hs
+++ b/core/src/Network/AWS/Prelude.hs
@@ -39,11 +39,6 @@ module Network.AWS.Prelude
     , Semigroup
     , Whole
 
-    -- * Endpoints
-    , global
-    , regional
-    , custom
-
     -- * Shared
     , Empty           (..)
     , Service         (..)

--- a/core/src/Network/AWS/Signing/V2.hs
+++ b/core/src/Network/AWS/Signing/V2.hs
@@ -67,8 +67,9 @@ instance AWSSigner V2 where
             & requestHeaders .~ headers
             & requestBody    .~ _bdyBody _rqBody
 
-        meth  = toBS _rqMethod
-        host' = toBS (endpoint svc r)
+        meth = toBS _rqMethod
+
+        Endpoint host' _ = endpoint svc r
 
         authorised = pair "Signature" (urlEncode True signature) query
 

--- a/core/src/Network/AWS/Signing/V3.hs
+++ b/core/src/Network/AWS/Signing/V3.hs
@@ -70,7 +70,7 @@ instance AWSSigner V3 where
             & requestHeaders .~ headers
             & requestBody    .~ _bdyBody _rqBody
 
-        host' = toBS (endpoint (serviceOf x) r)
+        Endpoint host' _ = endpoint (serviceOf x) r
 
         headers = sortBy (comparing fst)
             . hdr hAMZAuth authorisation


### PR DESCRIPTION
The previous naive assumptions about global vs regional endpoints fall apart when confronted with the various edge cases around the URL format for newer regions.

This PR fixes that by translating the `_regions.json` model by hand, and additionally explicitly returning the credential scope to use for signing.

> In reference to #13 
