### PR TITLE
Default timestamp formats are dependent on metadata protocol.

### DIFF
--- a/gen/src/Gen/AST.hs
+++ b/gen/src/Gen/AST.hs
@@ -189,7 +189,7 @@ dataTypes o a inp = res (runState run ds)
     share = shared inp
 
     datas = overriden overrides $
-        shapes proto (defaultTS (inp ^. mTimestampFormat)) (inp ^. inpShapes)
+        shapes proto (defaultTS proto (inp ^. mTimestampFormat)) (inp ^. inpShapes)
 
     proto     = inp ^. mProtocol
     url       = o ^. oOperationUrl

--- a/gen/src/Gen/Types.hs
+++ b/gen/src/Gen/Types.hs
@@ -129,8 +129,17 @@ instance FromJSON Timestamp where
 timestamp :: Timestamp -> Text
 timestamp = Text.pack . show
 
-defaultTS :: Maybe Timestamp -> Timestamp
-defaultTS = fromMaybe ISO8601
+-- | If a timestamp format isn't defined by the API, give a default
+-- timestamp format based on the Metadata protocol. JSON formats use
+-- unix epochs, all others use ISO8601.
+--
+defaultTS :: Protocol -> Maybe Timestamp -> Timestamp
+defaultTS Json = fromMaybe POSIX
+defaultTS RestJson = fromMaybe POSIX
+defaultTS Xml = fromMaybe ISO8601
+defaultTS RestXml = fromMaybe ISO8601
+defaultTS Query = fromMaybe ISO8601
+defaultTS Ec2 = fromMaybe ISO8601
 
 data Checksum
     = MD5


### PR DESCRIPTION
Addresses issue mentioned in #43 where DynamoDB creation timestamps expect
unix epochs and not ISO timestamps.

Ref: https://github.com/aws/aws-sdk-js/blob/master/lib/model/shape.js#L238
