### PR TITLE
Fixes for POSIX time parsing.

### DIFF
--- a/core/src/Network/AWS/Data/Internal/Text.hs
+++ b/core/src/Network/AWS/Data/Internal/Text.hs
@@ -24,21 +24,23 @@ module Network.AWS.Data.Internal.Text
 
 import           Control.Applicative
 import           Crypto.Hash
-import           Data.Attoparsec.Text             (Parser)
-import qualified Data.Attoparsec.Text             as AText
-import           Data.ByteString                  (ByteString)
-import           Data.CaseInsensitive             (CI)
-import qualified Data.CaseInsensitive             as CI
+import           Data.Attoparsec.Text              (Parser)
+import qualified Data.Attoparsec.Text              as AText
+import           Data.ByteString                   (ByteString)
+import           Data.CaseInsensitive              (CI)
+import qualified Data.CaseInsensitive              as CI
 import           Data.Int
 import           Data.Monoid
-import           Data.Text                        (Text)
-import qualified Data.Text                        as Text
-import qualified Data.Text.Encoding               as Text
-import qualified Data.Text.Lazy                   as LText
-import           Data.Text.Lazy.Builder           (Builder)
-import qualified Data.Text.Lazy.Builder           as Build
-import qualified Data.Text.Lazy.Builder.Int       as Build
-import qualified Data.Text.Lazy.Builder.RealFloat as Build
+import           Data.Scientific
+import           Data.Text                         (Text)
+import qualified Data.Text                         as Text
+import qualified Data.Text.Encoding                as Text
+import qualified Data.Text.Lazy                    as LText
+import           Data.Text.Lazy.Builder            (Builder)
+import qualified Data.Text.Lazy.Builder            as Build
+import qualified Data.Text.Lazy.Builder.Int        as Build
+import qualified Data.Text.Lazy.Builder.RealFloat  as Build
+import qualified Data.Text.Lazy.Builder.Scientific as Build
 import           Network.HTTP.Client
 import           Network.HTTP.Types
 import           Numeric.Natural
@@ -58,6 +60,7 @@ instance FromText Text       where parser = AText.takeText
 instance FromText ByteString where parser = Text.encodeUtf8 <$> AText.takeText
 instance FromText Int        where parser = AText.decimal
 instance FromText Integer    where parser = AText.decimal
+instance FromText Scientific where parser = AText.scientific
 instance FromText Natural    where parser = AText.decimal
 instance FromText Double     where parser = AText.rational
 
@@ -94,6 +97,7 @@ instance ToText Int        where toText = shortText . Build.decimal
 instance ToText Int64      where toText = shortText . Build.decimal
 instance ToText Integer    where toText = shortText . Build.decimal
 instance ToText Natural    where toText = shortText . Build.decimal
+instance ToText Scientific where toText = shortText . Build.scientificBuilder
 instance ToText Double     where toText = shortText . Build.realFloat
 instance ToText StdMethod  where toText = toText . renderStdMethod
 instance ToText (Digest a) where toText = toText . digestToHexByteString

--- a/core/test/Test/AWS/Data/Numeric.hs
+++ b/core/test/Test/AWS/Data/Numeric.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE RecordWildCards    #-}
+
 -- Module      : Test.AWS.Data.Numeric
 -- Copyright   : (c) 2013-2014 Brendan Hay <brendan.g.hay@gmail.com>
 -- License     : This Source Code Form is subject to the terms of
@@ -7,9 +10,6 @@
 -- Maintainer  : Brendan Hay <brendan.g.hay@gmail.com>
 -- Stability   : experimental
 -- Portability : non-portable (GHC extensions)
-
-{-# LANGUAGE OverloadedStrings  #-}
-{-# LANGUAGE RecordWildCards #-}
 
 module Test.AWS.Data.Numeric (tests) where
 

--- a/core/test/Test/AWS/Types.hs
+++ b/core/test/Test/AWS/Types.hs
@@ -12,6 +12,7 @@
 
 module Test.AWS.Types where
 
+import Data.Aeson
 import Network.AWS.Data
 import Network.AWS.Prelude
 import Test.Tasty.HUnit
@@ -24,3 +25,6 @@ instance FromXML a => FromXML (Entries a) where
 
 assertXML :: (FromXML a, Show a, Eq a) => LazyByteString -> a -> Assertion
 assertXML s x = (decodeXML s >>= parseXML) @?= Right x
+
+assertJSON :: (FromJSON a, Show a, Eq a) => LazyByteString -> a -> Assertion
+assertJSON s x = eitherDecode' s @?= Right x


### PR DESCRIPTION
0. Removes Scientific truncation, where 1.415335333E9 is truncated to
   1 when parsed as an integer.
1. Returned POSIX JSON values should be parsed as numbers and not
   strings.