### PR TITLE
gen/overrides: RootDeviceName is not required in Instance

### DIFF
--- a/gen/overrides/ec2.json
+++ b/gen/overrides/ec2.json
@@ -156,7 +156,6 @@
                 "Monitoring",
                 "Architecture",
                 "RootDeviceType",
-                "RootDeviceName",
                 "VirtualizationType",
                 "Hypervisor",
                 "EbsOptimized",


### PR DESCRIPTION
Not sure if regenerated code belongs here though.