### PR TITLE
core/gen: transform enums using toLower before pattern-matching them

### DIFF
--- a/core/src/Network/AWS/Data/Internal/Text.hs
+++ b/core/src/Network/AWS/Data/Internal/Text.hs
@@ -20,6 +20,8 @@ module Network.AWS.Data.Internal.Text
 
     , ToText   (..)
     , showText
+
+    , Text.toLower
     ) where
 
 import           Control.Applicative
@@ -35,7 +37,7 @@ import           Data.Scientific
 import           Data.Text                         (Text)
 import qualified Data.Text                         as Text
 import qualified Data.Text.Encoding                as Text
-import qualified Data.Text.Lazy                    as LText
+import qualified Data.Text.Lazy                    as LText hiding (toLower)
 import           Data.Text.Lazy.Builder            (Builder)
 import qualified Data.Text.Lazy.Builder            as Build
 import qualified Data.Text.Lazy.Builder.Int        as Build

--- a/gen/templates/_include/nullary.ede
+++ b/gen/templates/_include/nullary.ede
@@ -9,9 +9,9 @@ data {{ type.name }}
 instance Hashable {{ type.name }}
 
 instance FromText {{ type.name }} where
-    parser = takeText >>= \case
+    parser = toLower <$> takeText >>= \case
     {% for branch in type.branches %}
-        "{{ branch.value | concat("\"") | justifyLeft(type.valuePad) }} -> pure {{ branch.key }}
+        "{{ branch.value | toLower | concat("\"") | justifyLeft(type.valuePad) }} -> pure {{ branch.key }}
     {% endfor %}
         {{ "e" | justifyLeft(type.valuePad) }}  -> fail $
             "Failure parsing {{ type.name }} from " ++ show e


### PR DESCRIPTION
this helps avoid errors like:

```haskell
*Main> getEnv Singapore Discover >>= flip runAWST (send describeInstances)
Left (SerializerError "EC2" "Failed reading: Failure parsing PlatformValues from \"windows\"")
```

and probably many more errors like that in the future.