### PR TITLE
Case insensitive matches when parsing nullary constructor branches

### DIFF
--- a/core/src/Network/AWS/Data/Internal/Text.hs
+++ b/core/src/Network/AWS/Data/Internal/Text.hs
@@ -15,7 +15,7 @@
 module Network.AWS.Data.Internal.Text
     ( FromText (..)
     , fromText
-    , AText.takeText
+    , takeCI
     , matchCI
 
     , ToText   (..)
@@ -48,6 +48,10 @@ import           Numeric.Natural
 fromText :: FromText a => Text -> Either String a
 fromText = AText.parseOnly parser
 {-# INLINE fromText #-}
+
+takeCI :: Parser (CI Text)
+takeCI = CI.mk <$> AText.takeText
+{-# INLINE takeCI #-}
 
 matchCI :: Text -> a -> Parser a
 matchCI x y = AText.asciiCI x <* AText.endOfInput >> return y

--- a/core/src/Network/AWS/Error.hs
+++ b/core/src/Network/AWS/Error.hs
@@ -85,7 +85,7 @@ data ErrorType
       deriving (Eq, Ord, Enum, Show, Generic)
 
 instance FromText ErrorType where
-    parser = takeText >>= \case
+    parser = takeCI >>= \case
         "Receiver" -> pure Receiver
         "Sender"   -> pure Sender
         e          -> fail $ "Failure parsing ErrorType from " ++ show e

--- a/core/src/Network/AWS/Types.hs
+++ b/core/src/Network/AWS/Types.hs
@@ -431,7 +431,7 @@ instance Default Region where
     def = NorthVirginia
 
 instance FromText Region where
-    parser = takeText >>= \case
+    parser = takeCI >>= \case
         "eu-west-1"          -> pure Ireland
         "eu-central-1"       -> pure Frankfurt
         "ap-northeast-1"     -> pure Tokyo

--- a/gen/templates/_include/nullary.ede
+++ b/gen/templates/_include/nullary.ede
@@ -9,7 +9,7 @@ data {{ type.name }}
 instance Hashable {{ type.name }}
 
 instance FromText {{ type.name }} where
-    parser = takeText >>= \case
+    parser = takeCI >>= \case
     {% for branch in type.branches %}
         "{{ branch.value | concat("\"") | justifyLeft(type.valuePad) }} -> pure {{ branch.key }}
     {% endfor %}


### PR DESCRIPTION
In reference to #48 