### PR TITLE
makefile surgery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,39 +1,22 @@
-DEPS := $(wildcard amazonka-*)
+DEPS ?= core amazonka $(wildcard amazonka-*)
 
-.PHONY: install full-clean clean
+.PHONY: full-clean
 
-build: $(addprefix build-,$(DEPS)) build-amazonka
+define forward
+$1: cabal.sandbox.config $$(addprefix $1-,$$(DEPS))
 
-build-%:
-	@make -C $* build
+$1-%:
+	@make -C $$* $1
 
-install: cabal.sandbox.config $(addprefix install-,$(DEPS)) install-amazonka
+.PHONY: $1
+endef
 
-install-%:
-	@make -C $* install
+FORWARD := build configure deps install sdist upload clean
 
-configure: configure-core configure-amazonka $(addprefix configure-,$(DEPS))
-
-configure-%:
-	@make -C $* configure
+$(foreach c,$(FORWARD),$(eval $(call forward, $c)))
 
 full-clean: clean
 	rm -rf cabal.sandbox.config .cabal-sandbox
-
-clean: $(addprefix clean-,$(DEPS)) clean-amazonka
-
-clean-%:
-	@make -C $* clean
-
-sdist: sdist-core sdist-amazonka $(addprefix sdist-,$(DEPS))
-
-sdist-%:
-	@make -C $* sdist
-
-upload: upload-core upload-amazonka $(addprefix upload-,$(DEPS))
-
-upload-%:
-	@make -C $* upload
 
 cabal.sandbox.config:
 	cabal sandbox init

--- a/share/library.mk
+++ b/share/library.mk
@@ -6,19 +6,21 @@ SHELL   := /usr/bin/env bash
 NAME    ?= $(notdir $(CURDIR:a/%=%))
 VERSION ?= $(shell sed -n 's/^version: *\(.*\)$$/\1/p' $(NAME).cabal)
 
-CABAL_SANDBOX_CONFIG := $(TOP)/cabal.sandbox.config
+CABAL_INSTALL_DEFARGS ?= -j --disable-documentation --disable-library-coverage
+CABAL_SANDBOX_CONFIG  := $(TOP)/cabal.sandbox.config
 
 export CABAL_SANDBOX_CONFIG
 
 build:
 	cabal build -j
 
-install: add-sources
-	cabal install -j \
- --disable-documentation \
- --disable-library-coverage \
+deps: add-sources
+	cabal install $(CABAL_INSTALL_DEFARGS) \
  --only-dependencies \
  --force-reinstalls # https://github.com/haskell/cabal/issues/2101
+
+install: add-sources
+	cabal install $(CABAL_INSTALL_DEFARGS)
 
 add-sources:
 	cabal sandbox add-source $(TOP)/core


### PR DESCRIPTION
in a nutshell: simplifies bootstrap workflow into smth like
```console
% make -w deps install DEPS="core amazonka amazonka-elb amazonka-ec2" CABAL_INSTALL_DEFARGS="-j --disable-coverage"
```

makefiles: consistent deps; split library.mk install into {install,deps}
also:
- collapse subdir forwarding into a single macro
- introduce overridable CABAL_INSTALL_DEFARGS
(useful when using cabal-install 1.22 to use --disable-coverage)