### PR TITLE
Don't derive the Whole typeclass

### DIFF
--- a/amazonka-elb/gen/Network/AWS/ELB/Types.hs
+++ b/amazonka-elb/gen/Network/AWS/ELB/Types.hs
@@ -1274,7 +1274,7 @@ instance ToQuery AdditionalAttribute where
 
 newtype ConnectionSettings = ConnectionSettings
     { _csIdleTimeout :: Nat
-    } deriving (Eq, Ord, Show, Enum, Num, Integral, Whole, Real)
+    } deriving (Eq, Ord, Show, Enum, Num, Integral, Real)
 
 -- | 'ConnectionSettings' constructor.
 --

--- a/core/src/Network/AWS/Data/Internal/Numeric.hs
+++ b/core/src/Network/AWS/Data/Internal/Numeric.hs
@@ -34,7 +34,6 @@ newtype Nat = Nat { unNat :: Natural }
         , Num
         , Real
         , Integral
-        , Whole
         , ToByteString
         , FromText
         , ToText

--- a/core/src/Network/AWS/Prelude.hs
+++ b/core/src/Network/AWS/Prelude.hs
@@ -36,7 +36,6 @@ module Network.AWS.Prelude
     , Generic
     , IsString     (..)
     , Semigroup
-    , Whole
 
     -- * Retries
     , Retry        (..)
@@ -75,7 +74,7 @@ import GHC.Generics              (Generic)
 import Network.HTTP.Client       (HttpException, RequestBody)
 import Network.HTTP.Types.Method (StdMethod(..))
 import Network.HTTP.Types.Status (Status(..))
-import Numeric.Natural           (Natural, Whole)
+import Numeric.Natural           (Natural)
 
 import Control.Applicative       as Export
 import Data.Bifunctor            as Export

--- a/gen/output/elb.json
+++ b/gen/output/elb.json
@@ -2492,7 +2492,6 @@
                     "Enum",
                     "Num",
                     "Integral",
-                    "Whole",
                     "Real"
                 ],
                 "listElement": null,

--- a/gen/src/Gen/Output.hs
+++ b/gen/src/Gen/Output.hs
@@ -73,7 +73,6 @@ data Derive
     | Enum'
     | Num'
     | Integral'
-    | Whole'
     | Real'
     | RealFrac'
     | RealFloat'
@@ -527,7 +526,7 @@ instance DerivingOf Prim where
         PInt     -> [Eq', Ord', Num', Enum', Integral', Real']
         PInteger -> [Eq', Ord', Num', Enum', Integral', Real']
         PDouble  -> [Eq', Ord', Num', Enum', RealFrac', RealFloat', Real']
-        PNatural -> [Eq', Ord', Num', Enum', Integral', Whole', Real']
+        PNatural -> [Eq', Ord', Num', Enum', Integral', Real']
         PTime _  -> [Eq', Ord']
         PBlob    -> [Eq']
         _        -> []
@@ -562,7 +561,6 @@ instance DerivingOf Type where
             , Real'
             , RealFrac'
             , RealFloat'
-            , Whole'
             , IsString'
             ]
 
@@ -581,7 +579,6 @@ instance DerivingOf Data where
               , Real'
               , RealFrac'
               , RealFloat'
-              , Whole'
               , IsString'
               , Generic'
               ]


### PR DESCRIPTION
It was not preserved when Numeric.Natural was brought into base, which
practically means it is difficult if not impossible to build this
against newer GHCs, and also suggests that the class itself is not all
that useful.