### PR TITLE
core: loosen nats dependency

### DIFF
--- a/core/amazonka-core.cabal
+++ b/core/amazonka-core.cabal
@@ -102,7 +102,7 @@ library
         , xml-conduit          == 1.2.*
 
     if !impl(ghc>=7.9)
-        build-depends: nats >= 0.1.3 && < 1
+        build-depends: nats >= 0.1.3
 
 test-suite tests
     type:              exitcode-stdio-1.0


### PR DESCRIPTION
Now that we don't derive Whole, nats 1 is OK