### PR TITLE
ghc-7.8.4 comes with time-1.4.x.  Do we really need time 1.5.x?

### DIFF
--- a/amazonka/amazonka.cabal
+++ b/amazonka/amazonka.cabal
@@ -54,6 +54,6 @@ library
         , resourcet         >= 1.1     && < 1.3
         , retry             >= 0.5
         , text              >= 1.1
-        , time              >= 1.5
+        , time              >= 1.4
         , transformers      == 0.4.*
         , transformers-base >= 0.4.2

--- a/core/amazonka-core.cabal
+++ b/core/amazonka-core.cabal
@@ -95,7 +95,7 @@ library
         , semigroups           >= 0.12
         , tagged               >= 0.7
         , text                 >= 1.1
-        , time                 >= 1.5
+        , time                 >= 1.4
         , transformers         == 0.4.*
         , unordered-containers >= 0.2.3
         , vector               >= 0.10.9


### PR DESCRIPTION
Requiring time-1.5.x creates some cabal hell for some projects.