### PR TITLE
Not in the 2014-10-01 spec but I did receive this error today:

### DIFF
--- a/amazonka-ec2/gen/Network/AWS/EC2/Types.hs
+++ b/amazonka-ec2/gen/Network/AWS/EC2/Types.hs
@@ -9836,6 +9836,9 @@ data OfferingTypeValues
     = HeavyUtilization  -- ^ Heavy Utilization
     | LightUtilization  -- ^ Light Utilization
     | MediumUtilization -- ^ Medium Utilization
+    | NoUpfront         -- ^ No Upfront
+    | PartialUpfront    -- ^ Partial Upfront
+    | AllUpfront        -- ^ All Upfront
       deriving (Eq, Ord, Show, Generic, Enum)
 
 instance Hashable OfferingTypeValues
@@ -9845,6 +9848,9 @@ instance FromText OfferingTypeValues where
         "heavy utilization"  -> pure HeavyUtilization
         "light utilization"  -> pure LightUtilization
         "medium utilization" -> pure MediumUtilization
+        "no upfront"         -> pure NoUpfront
+        "partial upfront"    -> pure PartialUpfront
+        "all upfront"        -> pure AllUpfront
         e                    -> fail $
             "Failure parsing OfferingTypeValues from " ++ show e
 
@@ -9853,6 +9859,9 @@ instance ToText OfferingTypeValues where
         HeavyUtilization  -> "Heavy Utilization"
         LightUtilization  -> "Light Utilization"
         MediumUtilization -> "Medium Utilization"
+        NoUpfront         -> "No Upfront"
+        PartialUpfront    -> "Partial Upfront"
+        AllUpfront        -> "All Upfront"
 
 instance ToByteString OfferingTypeValues
 instance ToHeader     OfferingTypeValues


### PR DESCRIPTION
SerializerError "EC2" "Failed reading: Failure parsing
OfferingTypeValues from \"no upfront\""

Adding the no upfront type fixed the error.

Amazon did change their pricing model for reserved instances in Nov/Dec
time frame.  I can't remember the exact date.  They now offer "no
upfront" RIs where you pay a reduced rate if your machines are long
lived.