### PR TITLE
Add sum_values field to type overrides

### DIFF
--- a/amazonka-ec2/gen/Network/AWS/EC2/Types.hs
+++ b/amazonka-ec2/gen/Network/AWS/EC2/Types.hs
@@ -9833,26 +9833,35 @@ instance ToQuery PropagatingVgw where
         ]
 
 data OfferingTypeValues
-    = HeavyUtilization  -- ^ Heavy Utilization
+    = AllUpfront        -- ^ All Upfront
+    | HeavyUtilization  -- ^ Heavy Utilization
     | LightUtilization  -- ^ Light Utilization
     | MediumUtilization -- ^ Medium Utilization
+    | NoUpfront         -- ^ No Upfront
+    | PartialUpfront    -- ^ Partial Upfront
       deriving (Eq, Ord, Show, Generic, Enum)
 
 instance Hashable OfferingTypeValues
 
 instance FromText OfferingTypeValues where
     parser = takeLowerText >>= \case
+        "all upfront"        -> pure AllUpfront
         "heavy utilization"  -> pure HeavyUtilization
         "light utilization"  -> pure LightUtilization
         "medium utilization" -> pure MediumUtilization
+        "no upfront"         -> pure NoUpfront
+        "partial upfront"    -> pure PartialUpfront
         e                    -> fail $
             "Failure parsing OfferingTypeValues from " ++ show e
 
 instance ToText OfferingTypeValues where
     toText = \case
+        AllUpfront        -> "All Upfront"
         HeavyUtilization  -> "Heavy Utilization"
         LightUtilization  -> "Light Utilization"
         MediumUtilization -> "Medium Utilization"
+        NoUpfront         -> "No Upfront"
+        PartialUpfront    -> "Partial Upfront"
 
 instance ToByteString OfferingTypeValues
 instance ToHeader     OfferingTypeValues

--- a/gen/output/ec2.json
+++ b/gen/output/ec2.json
@@ -19365,8 +19365,11 @@
                 ],
                 "branches": {
                     "MediumUtilization": "Medium Utilization",
+                    "NoUpfront": "No Upfront",
+                    "AllUpfront": "All Upfront",
                     "HeavyUtilization": "Heavy Utilization",
-                    "LightUtilization": "Light Utilization"
+                    "LightUtilization": "Light Utilization",
+                    "PartialUpfront": "Partial Upfront"
                 },
                 "valuePad": 19,
                 "name": "OfferingTypeValues",

--- a/gen/overrides/ec2.json
+++ b/gen/overrides/ec2.json
@@ -223,6 +223,13 @@
                 "State",
                 "Type"
             ]
+        },
+        "OfferingTypeValues": {
+            "sum_values": {
+                "NoUpfront": "No Upfront",
+                "PartialUpfront": "Partial Upfront",
+                "AllUpfront": "All Upfront"
+            }
         }
     }
 }

--- a/gen/src/Gen/AST.hs
+++ b/gen/src/Gen/AST.hs
@@ -463,6 +463,7 @@ overriden = flip (Map.foldlWithKey' run)
           renameTo   k (o ^. oRenameTo)
         . replacedBy k (o ^. oReplacedBy)
         . sumPrefix  k (o ^. oSumPrefix)
+        . sumValues  k (o ^. oSumValues)
         . Map.adjust (dataFields %~ fld) k
         $ r
       where
@@ -509,7 +510,19 @@ overriden = flip (Map.foldlWithKey' run)
                 | z == x    -> TType y
                 | otherwise -> TType z
 
-    sumPrefix :: Text -> Maybe Text -> HashMap Text Data -> HashMap Text Data
+    sumValues :: Text
+              -> HashMap Text Text
+              -> HashMap Text Data
+              -> HashMap Text Data
+    sumValues k xs = Map.adjust f k
+      where
+        f (Nullary n ys) = Nullary n (ys <> xs)
+        f x              = x
+
+    sumPrefix :: Text
+              -> Maybe Text
+              -> HashMap Text Data
+              -> HashMap Text Data
     sumPrefix _ Nothing  = id
     sumPrefix k (Just y) = Map.adjust f k
       where

--- a/gen/src/Gen/Types.hs
+++ b/gen/src/Gen/Types.hs
@@ -429,6 +429,7 @@ data Override = Override
     { _oRenameTo   :: Maybe Text             -- ^ Rename type
     , _oReplacedBy :: Maybe Text             -- ^ Existing type that supplants this type
     , _oSumPrefix  :: Maybe Text             -- ^ Sum constructor prefix
+    , _oSumValues  :: HashMap Text Text      -- ^ Supplemental sum constructors.
     , _oRequired   :: HashSet (CI Text)      -- ^ Required fields
     , _oRenamed    :: HashMap (CI Text) Text -- ^ Rename fields
     } deriving (Eq, Show)
@@ -440,8 +441,9 @@ instance FromJSON Override where
         <$> o .:? "rename_to"
         <*> o .:? "replaced_by"
         <*> o .:? "sum_prefix"
-        <*> o .:? "required" .!= mempty
-        <*> o .:? "renamed"  .!= mempty
+        <*> o .:? "sum_values" .!= mempty
+        <*> o .:? "required"   .!= mempty
+        <*> o .:? "renamed"    .!= mempty
 
 data Overrides = Overrides
     { _oLibrary           :: !Library


### PR DESCRIPTION
Allows manual specification of additional nullary constructor branches.

Includes an initial change to the EC2 type `OfferingTypeValues` which was the motivating example for this PR.

Fixes #64.