### PR TITLE
These attributes need to be CaptialCase not mixedCase.

### DIFF
--- a/gen/input/ec2/2014-10-01.normal.json
+++ b/gen/input/ec2/2014-10-01.normal.json
@@ -8083,7 +8083,7 @@
         "ClientToken":{
           "shape":"String",
           "documentation":"<p>A unique, case-sensitive token you provide to ensure idempotency of your modification request.</p>",
-          "locationName":"clientToken"
+          "locationName":"ClientToken"
         },
         "ReservedInstancesIds":{
           "shape":"ReservedInstancesIdStringList",
@@ -9567,22 +9567,22 @@
         "AvailabilityZone":{
           "shape":"String",
           "documentation":"<p>The Availability Zone for the modified Reserved Instances.</p>",
-          "locationName":"availabilityZone"
+          "locationName":"AvailabilityZone"
         },
         "Platform":{
           "shape":"String",
           "documentation":"<p>The network platform of the modified Reserved Instances, which is either EC2-Classic or EC2-VPC.</p>",
-          "locationName":"platform"
+          "locationName":"Platform"
         },
         "InstanceCount":{
           "shape":"Integer",
           "documentation":"<p>The number of modified Reserved Instances.</p>",
-          "locationName":"instanceCount"
+          "locationName":"InstanceCount"
         },
         "InstanceType":{
           "shape":"InstanceType",
           "documentation":"<p>The instance type for the modified Reserved Instances.</p>",
-          "locationName":"instanceType"
+          "locationName":"InstanceType"
         }
       },
       "documentation":"<p>Describes the configuration settings for the modified Reserved Instances.</p>"


### PR DESCRIPTION
The JSON spec file is wrong here on the 'locationName' for these attributes.  The EC2 API spec page shows the proper
CapitalCase style.  http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyReservedInstances.html I get errors modifying reserved instances with specific mention of the unknown mixedCase attributes.  If I change them to CapitalCase, then I can use the EC2 API without complaints.

You probably don't want to accept this P/R as is (because I just edited the Boto json files).  Tell me how to fix this outside of the 3rd party JSON so I can fix my P/R.
