### PR TITLE
Utilise http-conduit RequestBody constructors directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: haskell
-ghc:      7.8.3
+ghc:      7.8.4
 install:  []
 script:   [make travis]

--- a/amazonka/amazonka.cabal
+++ b/amazonka/amazonka.cabal
@@ -36,24 +36,28 @@ library
 
     other-modules:
           Network.AWS.Internal.Auth
+        , Network.AWS.Internal.Body
         , Network.AWS.Internal.Env
         , Network.AWS.Internal.Log
         , Network.AWS.Internal.Retry
 
     build-depends:
-          amazonka-core     == 0.2.3.*
-        , base              >= 4.7     && < 5
-        , bytestring        >= 0.9
-        , conduit           >= 1.1     && < 1.3
-        , exceptions        == 0.6.*
-        , http-conduit      >= 2.1.4   && < 2.3
-        , lens              >= 4.4     && < 5
-        , mmorph            >= 1       && < 2
-        , monad-control     >= 1       && < 2
-        , mtl               >= 2.2.1   && < 2.3
-        , resourcet         >= 1.1     && < 1.3
-        , retry             >= 0.5
-        , text              >= 1.1
-        , time              >= 1.5
-        , transformers      == 0.4.*
-        , transformers-base >= 0.4.2
+          amazonka-core      == 0.2.3.*
+        , base               >= 4.7     && < 5
+        , bytestring         >= 0.9
+        , conduit            >= 1.1     && < 1.3
+        , conduit-extra      == 1.1.*
+        , cryptohash         == 0.11.*
+        , cryptohash-conduit >= 0.1.1
+        , exceptions         == 0.6.*
+        , http-conduit       >= 2.1.4   && < 2.3
+        , lens               >= 4.4     && < 5
+        , mmorph             >= 1       && < 2
+        , monad-control      >= 1       && < 2
+        , mtl                >= 2.2.1   && < 2.3
+        , resourcet          >= 1.1     && < 1.3
+        , retry              >= 0.5
+        , text               >= 1.1
+        , time               >= 1.5
+        , transformers       == 0.4.*
+        , transformers-base  >= 0.4.2

--- a/amazonka/src/Control/Monad/Trans/AWS.hs
+++ b/amazonka/src/Control/Monad/Trans/AWS.hs
@@ -87,6 +87,11 @@ module Control.Monad.Trans.AWS
     , verify
     , verifyWith
 
+    -- ** Streaming body helpers
+    , sourceFile
+    , sourceHandle
+    , sourceBody
+
     -- * Types
     , ToBuilder   (..)
     , module Network.AWS.Types
@@ -108,12 +113,13 @@ import           Data.ByteString              (ByteString)
 import           Data.Conduit                 hiding (await)
 import           Data.Time
 import qualified Network.AWS                  as AWS
-import           Network.AWS.Data             (ToBuilder(..))
+import           Network.AWS.Data             (ToBuilder (..))
 import           Network.AWS.Error
 import           Network.AWS.Internal.Auth
+import           Network.AWS.Internal.Body
 import           Network.AWS.Internal.Env
+import           Network.AWS.Internal.Log     hiding (debug, info, trace)
 import qualified Network.AWS.Internal.Log     as Log
-import           Network.AWS.Internal.Log     hiding (info, debug, trace)
 import           Network.AWS.Types
 import           Network.AWS.Waiters
 import qualified Network.HTTP.Conduit         as Client

--- a/amazonka/src/Control/Monad/Trans/AWS.hs
+++ b/amazonka/src/Control/Monad/Trans/AWS.hs
@@ -88,9 +88,10 @@ module Control.Monad.Trans.AWS
     , verifyWith
 
     -- ** Streaming body helpers
-    , sourceFile
-    , sourceHandle
     , sourceBody
+    , sourceHandle
+    , sourceFile
+    , sourceFileIO
 
     -- * Types
     , ToBuilder   (..)

--- a/amazonka/src/Network/AWS.hs
+++ b/amazonka/src/Network/AWS.hs
@@ -55,9 +55,10 @@ module Network.AWS
     , newLogger
 
     -- ** Streaming body helpers
-    , sourceFile
-    , sourceHandle
     , sourceBody
+    , sourceHandle
+    , sourceFile
+    , sourceFileIO
 
     -- * Types
     , module Network.AWS.Types

--- a/amazonka/src/Network/AWS.hs
+++ b/amazonka/src/Network/AWS.hs
@@ -54,6 +54,11 @@ module Network.AWS
     -- * Logging
     , newLogger
 
+    -- ** Streaming body helpers
+    , sourceFile
+    , sourceHandle
+    , sourceBody
+
     -- * Types
     , module Network.AWS.Types
     , module Network.AWS.Error
@@ -70,14 +75,15 @@ import           Data.Time
 import           Network.AWS.Data
 import           Network.AWS.Error
 import           Network.AWS.Internal.Auth
+import           Network.AWS.Internal.Body
 import           Network.AWS.Internal.Env
 import           Network.AWS.Internal.Log
 import           Network.AWS.Internal.Retry
 import qualified Network.AWS.Signing          as Sign
 import           Network.AWS.Types
 import           Network.AWS.Waiters
-import qualified Network.HTTP.Conduit         as Client
 import           Network.HTTP.Conduit         hiding (Request, Response)
+import qualified Network.HTTP.Conduit         as Client
 
 -- | This creates a new environment without debug logging and uses 'getAuth'
 -- to expand/discover the supplied 'Credentials'.

--- a/amazonka/src/Network/AWS/Internal/Body.hs
+++ b/amazonka/src/Network/AWS/Internal/Body.hs
@@ -1,0 +1,49 @@
+-- Module      : Network.AWS.Internal.Body
+-- Copyright   : (c) 2013-2015 Brendan Hay <brendan.g.hay@gmail.com>
+-- License     : This Source Code Form is subject to the terms of
+--               the Mozilla Public License, v. 2.0.
+--               A copy of the MPL can be found in the LICENSE file or
+--               you can obtain it at http://mozilla.org/MPL/2.0/.
+-- Maintainer  : Brendan Hay <brendan.g.hay@gmail.com>
+-- Stability   : experimental
+-- Portability : non-portable (GHC extensions)
+
+module Network.AWS.Internal.Body where
+
+import           Control.Applicative
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Resource
+import           Crypto.Hash
+import qualified Crypto.Hash.Conduit          as Conduit
+import           Data.ByteString              (ByteString)
+import           Data.Conduit
+import qualified Data.Conduit.Binary          as Conduit
+import           Data.Int
+import           Network.AWS.Data
+import           Network.HTTP.Conduit
+import           System.IO
+
+-- | Safely construct a 'RqBody' from a 'FilePath', calculating the SHA256 hash
+-- and file size.
+--
+-- /Note:/ While this function will perform in constant space, it will read the
+-- entirety of the file contents _twice_. Firstly to calculate the SHA256 and
+-- lastly to stream the contents to the socket during sending.
+sourceFile :: MonadIO m => FilePath -> m RqBody
+sourceFile f = liftIO $ sourceBody
+    <$> runResourceT (Conduit.sourceFile f $$ Conduit.sinkHash)
+    <*> fmap fromIntegral (withBinaryFile f ReadMode hFileSize)
+    <*> pure (Conduit.sourceFile f)
+
+-- | Unsafely construct a 'RqBody' from a 'Handle', calculating the SHA256 hash
+-- and file size.
+sourceHandle :: Digest SHA256 -> Int64 -> Handle -> RqBody
+sourceHandle h n = sourceBody h n . Conduit.sourceHandle
+
+-- | Unsafely construct a 'RqBody' from a source, manually specifying the
+-- SHA256 hash and file size.
+sourceBody :: Digest SHA256
+           -> Int64
+           -> Source (ResourceT IO) ByteString
+           -> RqBody
+sourceBody h n = RqBody h . requestBodySource n

--- a/core/amazonka-core.cabal
+++ b/core/amazonka-core.cabal
@@ -81,7 +81,6 @@ library
         , conduit              >= 1.1    && < 1.3
         , conduit-extra        == 1.1.*
         , cryptohash           == 0.11.*
-        , cryptohash-conduit   >= 0.1.1
         , data-default-class   >= 0.0.1
         , hashable             >= 1.2
         , http-client          >= 0.4.3  && < 0.5


### PR DESCRIPTION
This fixes #77 and additionally migrates the `cryptohash-conduit` dependency from `core` to `amazonka`.