### PR TITLE
Add old-locale flag and time 1.5 compatibility modules

### DIFF
--- a/amazonka/amazonka.cabal
+++ b/amazonka/amazonka.cabal
@@ -58,6 +58,5 @@ library
         , resourcet          >= 1.1     && < 1.3
         , retry              >= 0.5
         , text               >= 1.1
-        , time               >= 1.5
         , transformers       == 0.4.*
         , transformers-base  >= 0.4.2

--- a/amazonka/amazonka.cabal
+++ b/amazonka/amazonka.cabal
@@ -58,5 +58,6 @@ library
         , resourcet          >= 1.1     && < 1.3
         , retry              >= 0.5
         , text               >= 1.1
+        , time               >= 1.2     && < 1.6
         , transformers       == 0.4.*
         , transformers-base  >= 0.4.2

--- a/amazonka/src/Control/Monad/Trans/AWS.hs
+++ b/amazonka/src/Control/Monad/Trans/AWS.hs
@@ -112,7 +112,7 @@ import           Control.Monad.Trans.Resource
 import           Control.Retry                (limitRetries)
 import           Data.ByteString              (ByteString)
 import           Data.Conduit                 hiding (await)
-import           Data.Time
+import           Data.Time                    (UTCTime)
 import qualified Network.AWS                  as AWS
 import           Network.AWS.Data             (ToBuilder (..))
 import           Network.AWS.Error

--- a/amazonka/src/Network/AWS.hs
+++ b/amazonka/src/Network/AWS.hs
@@ -72,7 +72,7 @@ import           Control.Monad.Trans.Resource
 import           Data.ByteString              (ByteString)
 import           Data.Conduit                 hiding (await)
 import           Data.Monoid
-import           Data.Time
+import           Data.Time                    (UTCTime, getCurrentTime)
 import           Network.AWS.Data
 import           Network.AWS.Error
 import           Network.AWS.Internal.Auth

--- a/amazonka/src/Network/AWS/Internal/Auth.hs
+++ b/amazonka/src/Network/AWS/Internal/Auth.hs
@@ -28,7 +28,7 @@ import           Data.Monoid
 import           Data.Text                  (Text)
 import qualified Data.Text                  as Text
 import qualified Data.Text.Encoding         as Text
-import           Data.Time
+import           Data.Time                  (diffUTCTime, getCurrentTime)
 import           Network.AWS.Data
 import           Network.AWS.EC2.Metadata
 import           Network.AWS.Types

--- a/core/amazonka-core.cabal
+++ b/core/amazonka-core.cabal
@@ -141,4 +141,3 @@ test-suite tests
         , tasty-hunit
         , template-haskell
         , text
-        , time

--- a/core/amazonka-core.cabal
+++ b/core/amazonka-core.cabal
@@ -24,8 +24,12 @@ description:
     heavy development and not intended for public consumption, caveat emptor!
 
 source-repository head
-    type:     git
-    location: git://github.com/brendanhay/amazonka.git
+    type:              git
+    location:          git://github.com/brendanhay/amazonka.git
+
+flag old-locale
+    description:       Use old-locale and time < 1.5
+    default:           False
 
 library
     default-language:  Haskell2010
@@ -49,7 +53,9 @@ library
         , Network.AWS.Waiters
 
     other-modules:
-          Network.AWS.Data.Internal.Base64
+          Network.AWS.Compat.Internal.Locale
+        , Network.AWS.Compat.Internal.Time
+        , Network.AWS.Data.Internal.Base64
         , Network.AWS.Data.Internal.Body
         , Network.AWS.Data.Internal.ByteString
         , Network.AWS.Data.Internal.Header
@@ -70,37 +76,45 @@ library
         , Network.AWS.Signing.Internal.V4
 
     build-depends:
-          aeson                == 0.8.*
-        , attoparsec           >= 0.12   && < 0.15
-        , base                 >= 4.7    && < 5
-        , base16-bytestring    >= 0.1    && < 1
-        , base64-bytestring    >= 1      && < 2
-        , bifunctors           >= 4.1    && < 5
+          aeson                >  0.7.0.6 && < 0.9
+        , attoparsec           >= 0.12    && < 0.15
+        , base                 >= 4.7     && < 5
+        , base16-bytestring    >= 0.1     && < 1
+        , base64-bytestring    >= 1       && < 2
+        , bifunctors           >= 4.1     && < 5
         , bytestring           >= 0.9
-        , case-insensitive     >= 1.2    && < 2
-        , conduit              >= 1.1    && < 1.3
+        , case-insensitive     >= 1.2     && < 2
+        , conduit              >= 1.1     && < 1.3
         , conduit-extra        == 1.1.*
         , cryptohash           == 0.11.*
         , data-default-class   >= 0.0.1
         , hashable             >= 1.2
-        , http-client          >= 0.4.3  && < 0.5
+        , http-client          >= 0.4.3   && < 0.5
         , http-types           >= 0.8
-        , lens                 >= 4.4    && < 5
-        , mmorph               >= 1      && < 2
-        , mtl                  >= 2.2.1  && < 2.3
+        , lens                 >= 4.4     && < 5
+        , mmorph               >= 1       && < 2
+        , mtl                  >= 2.2.1   && < 2.3
         , resourcet            == 1.1.*
         , scientific           == 0.3.*
         , semigroups           >= 0.12
         , tagged               >= 0.7
         , text                 >= 1.1
-        , time                 >= 1.5
         , transformers         == 0.4.*
         , unordered-containers >= 0.2.5
         , vector               >= 0.10.9
         , xml-conduit          == 1.2.*
 
     if !impl(ghc>=7.9)
-        build-depends: nats >= 0.1.3
+        build-depends:
+              nats >= 0.1.3
+
+    if flag(old-locale)
+        build-depends:
+              old-locale == 1.*
+            , time       >= 1.2 && < 1.5
+    else
+        build-depends:
+              time       >= 1.5 && < 1.6
 
 test-suite tests
     type:              exitcode-stdio-1.0

--- a/core/src/Network/AWS/Compat/Internal/Locale.hs
+++ b/core/src/Network/AWS/Compat/Internal/Locale.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE CPP #-}
+
+-- Module      : Network.AWS.Data.Compat.Internal.Locale
+-- Copyright   : (c) 2013-2015 Brendan Hay <brendan.g.hay@gmail.com>
+-- License     : This Source Code Form is subject to the terms of
+--               the Mozilla Public License, v. 2.0.
+--               A copy of the MPL can be found in the LICENSE file or
+--               you can obtain it at http://mozilla.org/MPL/2.0/.
+-- Maintainer  : Brendan Hay <brendan.g.hay@gmail.com>
+-- Stability   : experimental
+-- Portability : non-portable (GHC extensions)
+
+module Network.AWS.Compat.Internal.Locale
+    ( defaultTimeLocale
+    , iso8601DateFormat
+    ) where
+
+#if MIN_VERSION_time(1,5,0)
+import           Data.Time.Format (defaultTimeLocale, iso8601DateFormat)
+#else
+import           System.Locale    (defaultTimeLocale, iso8601DateFormat)
+#endif

--- a/core/src/Network/AWS/Compat/Internal/Time.hs
+++ b/core/src/Network/AWS/Compat/Internal/Time.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE CPP #-}
+
+-- Module      : Network.AWS.Compat.Internal.Time
+-- Copyright   : (c) 2013-2015 Brendan Hay <brendan.g.hay@gmail.com>
+-- License     : This Source Code Form is subject to the terms of
+--               the Mozilla Public License, v. 2.0.
+--               A copy of the MPL can be found in the LICENSE file or
+--               you can obtain it at http://mozilla.org/MPL/2.0/.
+-- Maintainer  : Brendan Hay <brendan.g.hay@gmail.com>
+-- Stability   : experimental
+-- Portability : non-portable (GHC extensions)
+
+module Network.AWS.Compat.Internal.Time
+    ( parseTime
+    ) where
+
+#if MIN_VERSION_time(1,5,0)
+import           Data.Time.Format (ParseTime, TimeLocale, parseTimeM)
+
+parseTime :: ParseTime a => TimeLocale -> String -> String -> Maybe a
+parseTime = parseTimeM True
+#else
+import           Data.Time.Format (parseTime)
+#endif

--- a/core/src/Network/AWS/Data/Internal/Time.hs
+++ b/core/src/Network/AWS/Data/Internal/Time.hs
@@ -23,7 +23,6 @@ module Network.AWS.Data.Internal.Time
     , Time   (..)
     , _Time
 
-    , UTCTime
     , RFC822
     , ISO8601
     , BasicTime
@@ -40,8 +39,12 @@ import qualified Data.ByteString.Char8                as BS
 import           Data.Scientific
 import           Data.Tagged
 import qualified Data.Text                            as Text
-import           Data.Time
+import           Data.Time                            (UTCTime)
 import           Data.Time.Clock.POSIX
+import           Data.Time.Format                     (formatTime)
+import           Network.AWS.Compat.Internal.Locale   (defaultTimeLocale,
+                                                       iso8601DateFormat)
+import           Network.AWS.Compat.Internal.Time     (parseTime)
 import           Network.AWS.Data.Internal.ByteString
 import           Network.AWS.Data.Internal.JSON
 import           Network.AWS.Data.Internal.Query
@@ -102,7 +105,7 @@ instance FromText POSIX where
 parseFormattedTime :: forall a. TimeFormat (Time a) => Parser (Time a)
 parseFormattedTime = do
     x <- Text.unpack <$> AText.takeText
-    p (parseTimeM True defaultTimeLocale (untag f) x) x
+    p (parseTime defaultTimeLocale (untag f) x) x
   where
     p :: Maybe UTCTime -> String -> Parser (Time a)
     p Nothing  s = fail   ("Unable to parse " ++ untag f ++ " from " ++ s)

--- a/core/src/Network/AWS/Data/Internal/Time.hs
+++ b/core/src/Network/AWS/Data/Internal/Time.hs
@@ -23,11 +23,16 @@ module Network.AWS.Data.Internal.Time
     , Time   (..)
     , _Time
 
+    , UTCTime
     , RFC822
     , ISO8601
     , BasicTime
     , AWSTime
     , POSIX
+
+    , parseTime
+    , defaultTimeLocale
+    , iso8601DateFormat
     ) where
 
 import           Control.Applicative

--- a/core/test/Test/AWS/Data/Time.hs
+++ b/core/test/Test/AWS/Data/Time.hs
@@ -15,12 +15,12 @@
 
 module Test.AWS.Data.Time (tests) where
 
-import Data.Aeson
-import Data.Time
-import Network.AWS.Prelude
-import Test.AWS.Types
-import Test.Tasty
-import Test.Tasty.HUnit
+import           Data.Aeson
+import           Network.AWS.Data
+import           Network.AWS.Prelude
+import           Test.AWS.Types
+import           Test.Tasty
+import           Test.Tasty.HUnit
 
 tests :: TestTree
 tests = testGroup "time"

--- a/share/library.mk
+++ b/share/library.mk
@@ -15,9 +15,7 @@ build:
 	cabal build -j
 
 deps: add-sources
-	cabal install $(CABAL_INSTALL_DEFARGS) \
- --only-dependencies \
- --force-reinstalls # https://github.com/haskell/cabal/issues/2101
+	cabal install $(CABAL_INSTALL_DEFARGS) --only-dependencies
 
 install: add-sources
 	cabal install $(CABAL_INSTALL_DEFARGS)


### PR DESCRIPTION
This allows `amazonka-core` to switch between using `old-locale` and `time < 1.5` or just `time >= 1.5` via a build flag.

This also allows the `aeson` dependency to be relaxed to a more meaningful range (in terms of usage).

Fixes #85.