### PR TITLE
Relax mtl/transformer constraints and apply transformers-compat for ExceptT compatibility

### DIFF
--- a/amazonka/amazonka.cabal
+++ b/amazonka/amazonka.cabal
@@ -49,7 +49,7 @@ library
         , conduit-extra      == 1.1.*
         , cryptohash         == 0.11.*
         , cryptohash-conduit >= 0.1.1
-        , exceptions         == 0.6.*
+        , exceptions         >= 0.6
         , http-conduit       >= 2.1.4   && < 2.3
         , lens               >= 4.4     && < 5
         , mmorph             >= 1       && < 2

--- a/amazonka/amazonka.cabal
+++ b/amazonka/amazonka.cabal
@@ -42,22 +42,23 @@ library
         , Network.AWS.Internal.Retry
 
     build-depends:
-          amazonka-core      == 0.3.2.*
-        , base               >= 4.7     && < 5
-        , bytestring         >= 0.9
-        , conduit            >= 1.1     && < 1.3
-        , conduit-extra      == 1.1.*
-        , cryptohash         == 0.11.*
-        , cryptohash-conduit >= 0.1.1
-        , exceptions         >= 0.6
-        , http-conduit       >= 2.1.4   && < 2.3
-        , lens               >= 4.4     && < 5
-        , mmorph             >= 1       && < 2
-        , monad-control      >= 1       && < 2
-        , mtl                >= 2.2.1   && < 2.3
-        , resourcet          >= 1.1     && < 1.3
-        , retry              >= 0.5
-        , text               >= 1.1
-        , time               >= 1.2     && < 1.6
-        , transformers       == 0.4.*
-        , transformers-base  >= 0.4.2
+          amazonka-core       == 0.3.2.*
+        , base                >= 4.7     && < 5
+        , bytestring          >= 0.9
+        , conduit             >= 1.1     && < 1.3
+        , conduit-extra       == 1.1.*
+        , cryptohash          == 0.11.*
+        , cryptohash-conduit  >= 0.1.1
+        , exceptions          >= 0.6
+        , http-conduit        >= 2.1.4   && < 2.3
+        , lens                >= 4.4     && < 5
+        , mmorph              >= 1       && < 2
+        , monad-control       >= 1       && < 2
+        , mtl                 >= 2.1.3.1
+        , resourcet           >= 1.1     && < 1.3
+        , retry               >= 0.5
+        , text                >= 1.1
+        , time                >= 1.2     && < 1.6
+        , transformers        >= 0.2
+        , transformers-base   >= 0.4.2
+        , transformers-compat >= 0.3

--- a/amazonka/src/Network/AWS.hs
+++ b/amazonka/src/Network/AWS.hs
@@ -66,13 +66,16 @@ module Network.AWS
     ) where
 
 import           Control.Applicative
+import           Control.Monad
 import           Control.Monad.Catch
-import           Control.Monad.Except
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Class
+import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.Resource
 import           Data.ByteString              (ByteString)
 import           Data.Conduit                 hiding (await)
 import           Data.Monoid
-import           Data.Time                    (UTCTime, getCurrentTime)
+import           Data.Time                    (getCurrentTime)
 import           Network.AWS.Data
 import           Network.AWS.Error
 import           Network.AWS.Internal.Auth

--- a/amazonka/src/Network/AWS/EC2/Metadata.hs
+++ b/amazonka/src/Network/AWS/EC2/Metadata.hs
@@ -37,7 +37,9 @@ module Network.AWS.EC2.Metadata
 import           Control.Applicative
 import           Control.Exception
 import           Control.Monad
-import           Control.Monad.Except
+import           Control.Monad.Error        (catchError, throwError)
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Except
 import           Data.ByteString            (ByteString)
 import qualified Data.ByteString.Char8      as BS
 import qualified Data.ByteString.Lazy       as LBS

--- a/amazonka/src/Network/AWS/Internal/Auth.hs
+++ b/amazonka/src/Network/AWS/Internal/Auth.hs
@@ -20,7 +20,10 @@ module Network.AWS.Internal.Auth where
 
 import           Control.Applicative
 import           Control.Concurrent
-import           Control.Monad.Except
+import           Control.Monad
+import           Control.Monad.Error        (catchError, throwError)
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Except
 import qualified Data.ByteString.Char8      as BS
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import           Data.IORef

--- a/core/amazonka-core.cabal
+++ b/core/amazonka-core.cabal
@@ -93,13 +93,14 @@ library
         , http-types           >= 0.8
         , lens                 >= 4.4     && < 5
         , mmorph               >= 1       && < 2
-        , mtl                  >= 2.2.1   && < 2.3
+        , mtl                  >= 2.1.3.1
         , resourcet            == 1.1.*
         , scientific           == 0.3.*
         , semigroups           >= 0.12
         , tagged               >= 0.7
         , text                 >= 1.1
-        , transformers         == 0.4.*
+        , transformers         >= 0.2
+        , transformers-compat  >= 0.3
         , unordered-containers >= 0.2.5
         , vector               >= 0.10.9
         , xml-conduit          == 1.2.*


### PR DESCRIPTION
This ensures the `stackage-curator check` command can create a build plan for the dependencies.

References: fpco/stackage#489