### PR TITLE
Make ErrorCode optional

### DIFF
--- a/core/src/Network/AWS/Error.hs
+++ b/core/src/Network/AWS/Error.hs
@@ -77,7 +77,7 @@ newtype ErrorCode = ErrorCode Text
     deriving (Eq, Ord, Show, FromXML, FromJSON, IsString, Generic)
 
 class AWSErrorCode a where
-    awsErrorCode :: a -> ErrorCode
+    awsErrorCode :: a -> Maybe ErrorCode
 
 data ErrorType
     = Receiver
@@ -96,7 +96,7 @@ instance FromXML ErrorType where
 data RESTError = RESTError
     { _restRequestId :: Text
     , _restType      :: Maybe ErrorType
-    , _restCode      :: ErrorCode
+    , _restCode      :: Maybe ErrorCode
     , _restMessage   :: Text
     } deriving (Eq, Show, Generic)
 
@@ -111,7 +111,7 @@ instance FromXML RESTError where
         f y = RESTError
             <$> x .@  "RequestId"
             <*> y .@? "Type"
-            <*> y .@  "Code"
+            <*> y .@? "Code"
             <*> y .@  "Message"
 
 restError :: FromXML (Er a)
@@ -130,7 +130,7 @@ restError f Service{..} s
 
 data JSONError = JSONError
     { _jsonType    :: Maybe Text
-    , _jsonCode    :: ErrorCode
+    , _jsonCode    :: Maybe ErrorCode
     , _jsonMessage :: Text
     } deriving (Eq, Show, Generic)
 
@@ -144,12 +144,12 @@ instance FromJSON JSONError where
       where
         rest o = JSONError
              <$> o .:? "Type"
-             <*> o .:  "Code"
+             <*> o .:? "Code"
              <*> o .:  "Message"
 
         post o = JSONError
              <$> o .:? "__type"
-             <*> o .:  "code"
+             <*> o .:? "code"
              <*> o .:  "message"
 
 jsonError :: FromJSON (Er a)

--- a/core/src/Network/AWS/Waiters.hs
+++ b/core/src/Network/AWS/Waiters.hs
@@ -88,8 +88,8 @@ matchStatus x a _ = \case
 matchError :: AWSErrorCode (Er (Sv a)) => ErrorCode -> Accept -> Acceptor a
 matchError c a _ = \case
     Left (ServiceError _ _ e)
-        | c == awsErrorCode e -> Just a
-    _                         -> Nothing
+        | Just c == awsErrorCode e -> Just a
+    _                              -> Nothing
 
 match :: (Rs a -> Bool) -> Accept -> Acceptor a
 match f a _ = \case

--- a/gen/templates/_include/service.ede
+++ b/gen/templates/_include/service.ede
@@ -36,7 +36,7 @@ instance AWSService {{ service.abbrev }} where
         check (statusCode -> s) (awsErrorCode -> e)
         {% for policy in service.retryPolicies %}
           {% if policy.value.error | defined %}
-            | s == {{ policy.value.code }} && "{{ policy.value.error }}" == e = True -- {{ policy.key | toTitle }}
+            | s == {{ policy.value.code }} && Just "{{ policy.value.error }}" == e = True -- {{ policy.key | toTitle }}
           {% endif %}
         {% endfor %}
         {% for policy in service.retryPolicies %}


### PR DESCRIPTION
Motivating example:

```haskell
> runAWST aws $ sendCatch (describeStream "foo")
Right (Left (SerializerError "Kinesis" "key \"code\" not present:\n{\"__type\":\"ResourceNotFoundException\",\"message\":\"Stream foo under account XXX not found.\"}"))
```

This change would require re-generating the bindings for _every_ `amazonka-*` library. Let me know if that should be included in the PR.