### PR TITLE
Use locationName for XML list over 'member'

### DIFF
--- a/gen/src/Gen/AST.hs
+++ b/gen/src/Gen/AST.hs
@@ -680,11 +680,12 @@ shapes proto time m =
             flatten = x ^. lstFlattened
                   <|> x ^. lstMember . refFlattened
 
-            ann | proto == Query = "member"
-                | otherwise      =
+            ann =
                     fromMaybe fld $
                             x ^. lstMember . refLocationName
                         <|> r ^. refLocationName
+                        -- Fallback to 'member' only if there is no locationName
+                        <|> if proto == Query then Just "member" else Nothing
 
     flat :: Maybe Bool -> Type -> Type
     flat _ | proto == Ec2 = TFlatten


### PR DESCRIPTION
We discovered that SQS.ReceiveMessageResponse wasn't deserialising from XML. It turns out `List "member"` should have been `List "Message"`.

https://github.com/brendanhay/amazonka/blob/1adc27543f335341059b96e952f4f7c34abb500b/amazonka-sqs/gen/Network/AWS/SQS/ReceiveMessage.hs#L190

It looks like amazonka should be using the [locationName](https://github.com/brendanhay/amazonka/blob/develop/gen/input/sqs/2012-11-05.normal.json#L1115) from the `MessageList` shape.

I fear that this change will break some/all `ToQuery` instances because they (I believe) share the same information, and I suspect that `member` was correct. Will this require different/extra generation for one of both of `ToQuery` and `FromXML` in regards to `List`?