### PR TITLE
Increase EC2 metadata timeout to 2 seconds

### DIFF
--- a/amazonka/src/Network/AWS/EC2/Metadata.hs
+++ b/amazonka/src/Network/AWS/EC2/Metadata.hs
@@ -325,5 +325,5 @@ get m url = ExceptT . liftIO $ req `catch` err
 request :: Manager -> Text -> IO ByteString
 request m url = do
     rq <- parseUrl (Text.unpack url)
-    rs <- httpLbs (rq { responseTimeout = Just 2 }) m
+    rs <- httpLbs (rq { responseTimeout = Just 2000000 {- 2 seconds -} }) m
     return . LBS.toStrict $ responseBody rs

--- a/amazonka/src/Network/AWS/EC2/Metadata.hs
+++ b/amazonka/src/Network/AWS/EC2/Metadata.hs
@@ -325,5 +325,5 @@ get m url = ExceptT . liftIO $ req `catch` err
 request :: Manager -> Text -> IO ByteString
 request m url = do
     rq <- parseUrl (Text.unpack url)
-    rs <- httpLbs (rq { responseTimeout = Just 2000000 {- 2 seconds -} }) m
+    rs <- httpLbs rq m
     return . LBS.toStrict $ responseBody rs


### PR DESCRIPTION
I'm assuming it wasn't intentional to make it 2 _microseconds_? What was the expected value?