### PR TITLE
Correct "normalisation" of non-valued query parameters for signing

### DIFF
--- a/core/src/Network/AWS/Data/Internal/Query.hs
+++ b/core/src/Network/AWS/Data/Internal/Query.hs
@@ -101,9 +101,9 @@ renderQuery = intercalate . sort . enc Nothing
         | otherwise   = enc (Just k') x
     enc k (Value (Just (urlEncode True -> v)))
         | Just n <- k = [n <> vsep <> v]
-        | otherwise   = [v]
+        | otherwise   = [v <> vsep]
     enc k _
-        | Just n <- k = [n]
+        | Just n <- k = [n <> vsep]
         | otherwise   = []
 
     intercalate []     = mempty


### PR DESCRIPTION
Both V2 and V4 signing demand that query parameters without values be normalised to pair form, ie. `param=`. The current code prevents use of endpoints such as [S3.CreateMultipartUpload](http://hackage.haskell.org/package/amazonka-s3-0.3.4/docs/Network-AWS-S3-CreateMultipartUpload.html).

I was tempted to separate query serialisation for signing from that for creating the actual request (eg. by giving a `newtype`'d `ToByteString` instance), but it seems like the normalised form is accepted in requests.