### PR TITLE
gen: create AWSPager instance for all request types

### DIFF
--- a/gen/templates/_include/pager.ede
+++ b/gen/templates/_include/pager.ede
@@ -36,4 +36,8 @@ instance AWSPager {{ request.name }} where
         {{ token.key }} = rs ^. {{ token.value.output }}
    {% endfor %}
   {% endcase %}
+{% else %}
+
+instance AWSPager {{ request.name }} where
+  page _ _ = Nothing
 {% endif %}


### PR DESCRIPTION
This allows code to uniformly use conduits with `paginate`.