### PR TITLE
Override mechanism to apply additional operation specific request configuration

### DIFF
--- a/amazonka-s3/gen/Network/AWS/S3/DeleteObjects.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/DeleteObjects.hs
@@ -97,7 +97,7 @@ dosDelete = lens _dosDelete (\ s a -> s{_dosDelete = a});
 instance AWSRequest DeleteObjects where
         type Sv DeleteObjects = S3
         type Rs DeleteObjects = DeleteObjectsResponse
-        request = postXML
+        request = contentMD5 . postXML
         response
           = receiveXML
               (\ s h x ->

--- a/amazonka-s3/gen/Network/AWS/S3/PutBucketCORS.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/PutBucketCORS.hs
@@ -81,7 +81,7 @@ pbcBucket = lens _pbcBucket (\ s a -> s{_pbcBucket = a});
 instance AWSRequest PutBucketCORS where
         type Sv PutBucketCORS = S3
         type Rs PutBucketCORS = PutBucketCORSResponse
-        request = putXML
+        request = contentMD5 . putXML
         response = receiveNull PutBucketCORSResponse'
 
 instance ToElement PutBucketCORS where

--- a/amazonka-s3/gen/Network/AWS/S3/PutBucketLifecycle.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/PutBucketLifecycle.hs
@@ -83,7 +83,7 @@ instance AWSRequest PutBucketLifecycle where
         type Sv PutBucketLifecycle = S3
         type Rs PutBucketLifecycle =
              PutBucketLifecycleResponse
-        request = putXML
+        request = contentMD5 . putXML
         response = receiveNull PutBucketLifecycleResponse'
 
 instance ToElement PutBucketLifecycle where

--- a/amazonka-s3/gen/Network/AWS/S3/PutBucketPolicy.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/PutBucketPolicy.hs
@@ -82,7 +82,7 @@ pbpPolicy = lens _pbpPolicy (\ s a -> s{_pbpPolicy = a});
 instance AWSRequest PutBucketPolicy where
         type Sv PutBucketPolicy = S3
         type Rs PutBucketPolicy = PutBucketPolicyResponse
-        request = putXML
+        request = contentMD5 . putXML
         response = receiveNull PutBucketPolicyResponse'
 
 instance ToElement PutBucketPolicy where

--- a/amazonka-s3/gen/Network/AWS/S3/PutBucketTagging.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/PutBucketTagging.hs
@@ -81,7 +81,7 @@ pbtTagging = lens _pbtTagging (\ s a -> s{_pbtTagging = a});
 instance AWSRequest PutBucketTagging where
         type Sv PutBucketTagging = S3
         type Rs PutBucketTagging = PutBucketTaggingResponse
-        request = putXML
+        request = contentMD5 . putXML
         response = receiveNull PutBucketTaggingResponse'
 
 instance ToElement PutBucketTagging where

--- a/core/src/Network/AWS/Sign/V4.hs
+++ b/core/src/Network/AWS/Sign/V4.hs
@@ -94,7 +94,7 @@ instance AWSSigner V4 where
 
         date   = toBS (Time t :: AWSTime)
         tok    = (hAMZToken,) . toBS <$> _authToken a
-        hashed = rq ^. rqBody . to bodyHash
+        hashed = rq ^. rqBody . to bodySHA256
 
 authorisation :: Meta V4 -> ByteString
 authorisation Meta{..} = BS.concat

--- a/core/src/Network/AWS/Types.hs
+++ b/core/src/Network/AWS/Types.hs
@@ -283,22 +283,22 @@ type Response a = Either Error (Status, Rs a)
 
 -- | An unsigned request.
 data Request a = Request
-    { _rqMethod  :: !StdMethod
-    , _rqPath    :: ByteString
-    , _rqQuery   :: QueryString
-    , _rqHeaders :: [Header]
-    , _rqBody    :: RqBody
+    { _rqMethod    :: !StdMethod
+    , _rqPath      :: ByteString
+    , _rqQuery     :: QueryString
+    , _rqHeaders   :: [Header]
+    , _rqBody      :: RqBody
     }
 
 instance ToBuilder (Request a) where
     build Request{..} = buildLines
         [ "[Raw Request] {"
-        , "  method  = "  <> build _rqMethod
-        , "  path    = "  <> build _rqPath
-        , "  query   = "  <> build _rqQuery
-        , "  headers = "  <> build _rqHeaders
-        , "  body    = {"
-        , "    hash    = "  <> build (bodyHash    _rqBody)
+        , "  method    = "  <> build _rqMethod
+        , "  path      = "  <> build _rqPath
+        , "  query     = "  <> build _rqQuery
+        , "  headers   = "  <> build _rqHeaders
+        , "  body      = {"
+        , "    hash    = "  <> build (bodySHA256  _rqBody)
         , "    payload =\n" <> build (bodyRequest _rqBody)
         , "  }"
         , "}"

--- a/gen/config/s3.json
+++ b/gen/config/s3.json
@@ -2,6 +2,13 @@
     "referenceUrl": "http://docs.aws.amazon.com/AmazonS3/latest/API/Welcome.html",
     "operationUrl": "http://docs.aws.amazon.com/AmazonS3/latest/API/",
     "libraryName": "amazonka-s3",
+    "operationPlugins": {
+        "DeleteObjects": ["contentMD5"],
+        "PutBucketCORS": ["contentMD5"],
+        "PutBucketLifecycle": ["contentMD5"],
+        "PutBucketPolicy": ["contentMD5"],
+        "PutBucketTagging": ["contentMD5"]
+    },
     "typeModules": [
         "Network.AWS.S3.Internal"
     ],

--- a/gen/src/Gen/AST.hs
+++ b/gen/src/Gen/AST.hs
@@ -88,7 +88,7 @@ renderShapes cfg svc = do
     let prune = Map.filter $ \s -> not (isOrphan s) || s ^. infoException
 
     -- Convert shape ASTs into a rendered Haskell AST declaration,
-    xs <- traverse (operationData svc) x
+    xs <- traverse (operationData cfg svc) x
     ys <- kvTraverseMaybe (const (shapeData svc)) (prune y)
     zs <- Map.traverseWithKey (waiterData svc x) (svc ^. waiters)
 

--- a/gen/src/Gen/AST/Data.hs
+++ b/gen/src/Gen/AST/Data.hs
@@ -49,10 +49,11 @@ import           Language.Haskell.Exts.Pretty
 import           Language.Haskell.Exts.Syntax hiding (Int, List, Lit, Var)
 
 operationData :: HasMetadata a Identity
-              => a
+              => Config
+              -> a
               -> Operation Identity Ref (Pager Id)
               -> Either Error (Operation Identity SData (Pager Id))
-operationData m o = do
+operationData cfg m o = do
     (xa, x)  <- struct (xr ^. refAnn)
     (ya, y)  <- struct (yr ^. refAnn)
 
@@ -61,7 +62,7 @@ operationData m o = do
 
     is       <- requestInsts m h xr xs
 
-    cls      <- pp Print $ requestD m h (xr, is) (yr, ys)
+    cls      <- pp Print $ requestD cfg m h (xr, is) (yr, ys)
 
     mpage    <- pagerFields m o >>= traverse (pp Print . pagerD xn)
 

--- a/gen/src/Gen/Types.hs
+++ b/gen/src/Gen/Types.hs
@@ -136,6 +136,7 @@ data Config = Config
     , _referenceUrl     :: Text
     , _operationUrl     :: Text
     , _operationModules :: [NS]
+    , _operationPlugins :: Map Id [Text]
     , _typeModules      :: [NS]
     , _typeOverrides    :: Map Id Override
     , _ignoredWaiters   :: Set Id
@@ -149,6 +150,7 @@ instance FromJSON Config where
         <*> o .:  "referenceUrl"
         <*> o .:  "operationUrl"
         <*> o .:? "operationModules" .!= mempty
+        <*> o .:? "operationPlugins" .!= mempty
         <*> o .:? "typeModules"      .!= mempty
         <*> o .:? "typeOverrides"    .!= mempty
         <*> o .:? "ignoredWaiters"   .!= mempty


### PR DESCRIPTION
Allows the conditional insertion of `Content-MD5` headers via an `operationPlugins` override which allows specification via the `gen/config/<service_name>.json` of a list of functions which will be applied to a request on a per operation basis, before signature calculation is done.

The intent is similar to how some of the other SDKs works. 

See: [Ruby SDK MD5](https://github.com/aws/aws-sdk-ruby/blob/17508581a6887fb170e608242165b1ee18ccd9a9/aws-sdk-core/lib/aws-sdk-core/plugins/s3_md5s.rb#L15)

Fixes #115.