### PR TITLE
Correct encoding of ObjectKey path segments and additional combinators

### DIFF
--- a/amazonka-autoscaling/amazonka-autoscaling.cabal
+++ b/amazonka-autoscaling/amazonka-autoscaling.cabal
@@ -110,7 +110,7 @@ test-suite amazonka-autoscaling-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-autoscaling == 1.0.0
         , base
         , bytestring

--- a/amazonka-autoscaling/gen/Network/AWS/AutoScaling/Types/Sum.hs
+++ b/amazonka-autoscaling/gen/Network/AWS/AutoScaling/Types/Sum.hs
@@ -69,9 +69,11 @@ instance ToText LifecycleState where
         TerminatingProceed -> "terminating:proceed"
         TerminatingWait -> "terminating:wait"
 
-instance Hashable LifecycleState
-instance ToQuery  LifecycleState
-instance ToHeader LifecycleState
+instance Hashable     LifecycleState
+instance ToByteString LifecycleState
+instance ToPath       LifecycleState
+instance ToQuery      LifecycleState
+instance ToHeader     LifecycleState
 
 instance FromXML LifecycleState where
     parseXML = parseXMLText "LifecycleState"
@@ -120,9 +122,11 @@ instance ToText ScalingActivityStatusCode where
         WaitingForSpotInstanceId -> "waitingforspotinstanceid"
         WaitingForSpotInstanceRequestId -> "waitingforspotinstancerequestid"
 
-instance Hashable ScalingActivityStatusCode
-instance ToQuery  ScalingActivityStatusCode
-instance ToHeader ScalingActivityStatusCode
+instance Hashable     ScalingActivityStatusCode
+instance ToByteString ScalingActivityStatusCode
+instance ToPath       ScalingActivityStatusCode
+instance ToQuery      ScalingActivityStatusCode
+instance ToHeader     ScalingActivityStatusCode
 
 instance FromXML ScalingActivityStatusCode where
     parseXML = parseXMLText "ScalingActivityStatusCode"

--- a/amazonka-cloudformation/amazonka-cloudformation.cabal
+++ b/amazonka-cloudformation/amazonka-cloudformation.cabal
@@ -95,7 +95,7 @@ test-suite amazonka-cloudformation-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-cloudformation == 1.0.0
         , base
         , bytestring

--- a/amazonka-cloudformation/gen/Network/AWS/CloudFormation/Types/Sum.hs
+++ b/amazonka-cloudformation/gen/Network/AWS/CloudFormation/Types/Sum.hs
@@ -33,9 +33,11 @@ instance ToText Capability where
     toText = \case
         CapabilityIAM -> "capability_iam"
 
-instance Hashable Capability
-instance ToQuery  Capability
-instance ToHeader Capability
+instance Hashable     Capability
+instance ToByteString Capability
+instance ToPath       Capability
+instance ToQuery      Capability
+instance ToHeader     Capability
 
 instance FromXML Capability where
     parseXML = parseXMLText "Capability"
@@ -60,9 +62,11 @@ instance ToText OnFailure where
         DoNothing -> "do_nothing"
         Rollback -> "rollback"
 
-instance Hashable OnFailure
-instance ToQuery  OnFailure
-instance ToHeader OnFailure
+instance Hashable     OnFailure
+instance ToByteString OnFailure
+instance ToPath       OnFailure
+instance ToQuery      OnFailure
+instance ToHeader     OnFailure
 
 data ResourceSignalStatus
     = Success
@@ -81,9 +85,11 @@ instance ToText ResourceSignalStatus where
         Failure -> "failure"
         Success -> "success"
 
-instance Hashable ResourceSignalStatus
-instance ToQuery  ResourceSignalStatus
-instance ToHeader ResourceSignalStatus
+instance Hashable     ResourceSignalStatus
+instance ToByteString ResourceSignalStatus
+instance ToPath       ResourceSignalStatus
+instance ToQuery      ResourceSignalStatus
+instance ToHeader     ResourceSignalStatus
 
 data ResourceStatus
     = CreateFailed
@@ -126,9 +132,11 @@ instance ToText ResourceStatus where
         UpdateFailed -> "update_failed"
         UpdateInProgress -> "update_in_progress"
 
-instance Hashable ResourceStatus
-instance ToQuery  ResourceStatus
-instance ToHeader ResourceStatus
+instance Hashable     ResourceStatus
+instance ToByteString ResourceStatus
+instance ToPath       ResourceStatus
+instance ToQuery      ResourceStatus
+instance ToHeader     ResourceStatus
 
 instance FromXML ResourceStatus where
     parseXML = parseXMLText "ResourceStatus"
@@ -192,9 +200,11 @@ instance ToText StackStatus where
         SSUpdateRollbackFailed -> "update_rollback_failed"
         SSUpdateRollbackInProgress -> "update_rollback_in_progress"
 
-instance Hashable StackStatus
-instance ToQuery  StackStatus
-instance ToHeader StackStatus
+instance Hashable     StackStatus
+instance ToByteString StackStatus
+instance ToPath       StackStatus
+instance ToQuery      StackStatus
+instance ToHeader     StackStatus
 
 instance FromXML StackStatus where
     parseXML = parseXMLText "StackStatus"

--- a/amazonka-cloudfront/amazonka-cloudfront.cabal
+++ b/amazonka-cloudfront/amazonka-cloudfront.cabal
@@ -88,7 +88,7 @@ test-suite amazonka-cloudfront-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-cloudfront == 1.0.0
         , base
         , bytestring

--- a/amazonka-cloudfront/gen/Network/AWS/CloudFront/CreateInvalidation.hs
+++ b/amazonka-cloudfront/gen/Network/AWS/CloudFront/CreateInvalidation.hs
@@ -101,7 +101,7 @@ instance ToPath CreateInvalidation where
         toPath CreateInvalidation'{..}
           = mconcat
               ["/2015-04-17/distribution/",
-               toText _ciDistributionId, "/invalidation"]
+               toPath _ciDistributionId, "/invalidation"]
 
 instance ToQuery CreateInvalidation where
         toQuery = const mempty

--- a/amazonka-cloudfront/gen/Network/AWS/CloudFront/DeleteCloudFrontOriginAccessIdentity.hs
+++ b/amazonka-cloudfront/gen/Network/AWS/CloudFront/DeleteCloudFrontOriginAccessIdentity.hs
@@ -93,7 +93,7 @@ instance ToPath DeleteCloudFrontOriginAccessIdentity
         toPath DeleteCloudFrontOriginAccessIdentity'{..}
           = mconcat
               ["/2015-04-17/origin-access-identity/cloudfront/",
-               toText _dcfoaiId]
+               toPath _dcfoaiId]
 
 instance ToQuery DeleteCloudFrontOriginAccessIdentity
          where

--- a/amazonka-cloudfront/gen/Network/AWS/CloudFront/DeleteDistribution.hs
+++ b/amazonka-cloudfront/gen/Network/AWS/CloudFront/DeleteDistribution.hs
@@ -85,7 +85,7 @@ instance ToHeaders DeleteDistribution where
 
 instance ToPath DeleteDistribution where
         toPath DeleteDistribution'{..}
-          = mconcat ["/2015-04-17/distribution/", toText _ddId]
+          = mconcat ["/2015-04-17/distribution/", toPath _ddId]
 
 instance ToQuery DeleteDistribution where
         toQuery = const mempty

--- a/amazonka-cloudfront/gen/Network/AWS/CloudFront/DeleteStreamingDistribution.hs
+++ b/amazonka-cloudfront/gen/Network/AWS/CloudFront/DeleteStreamingDistribution.hs
@@ -88,7 +88,7 @@ instance ToPath DeleteStreamingDistribution where
         toPath DeleteStreamingDistribution'{..}
           = mconcat
               ["/2015-04-17/streaming-distribution/",
-               toText _dsdId]
+               toPath _dsdId]
 
 instance ToQuery DeleteStreamingDistribution where
         toQuery = const mempty

--- a/amazonka-cloudfront/gen/Network/AWS/CloudFront/GetCloudFrontOriginAccessIdentity.hs
+++ b/amazonka-cloudfront/gen/Network/AWS/CloudFront/GetCloudFrontOriginAccessIdentity.hs
@@ -89,7 +89,7 @@ instance ToPath GetCloudFrontOriginAccessIdentity
         toPath GetCloudFrontOriginAccessIdentity'{..}
           = mconcat
               ["/2015-04-17/origin-access-identity/cloudfront/",
-               toText _gcfoaiId]
+               toPath _gcfoaiId]
 
 instance ToQuery GetCloudFrontOriginAccessIdentity
          where

--- a/amazonka-cloudfront/gen/Network/AWS/CloudFront/GetCloudFrontOriginAccessIdentityConfig.hs
+++ b/amazonka-cloudfront/gen/Network/AWS/CloudFront/GetCloudFrontOriginAccessIdentityConfig.hs
@@ -89,7 +89,7 @@ instance ToPath
         toPath GetCloudFrontOriginAccessIdentityConfig'{..}
           = mconcat
               ["/2015-04-17/origin-access-identity/cloudfront/",
-               toText _gcfoaicId, "/config"]
+               toPath _gcfoaicId, "/config"]
 
 instance ToQuery
          GetCloudFrontOriginAccessIdentityConfig where

--- a/amazonka-cloudfront/gen/Network/AWS/CloudFront/GetDistribution.hs
+++ b/amazonka-cloudfront/gen/Network/AWS/CloudFront/GetDistribution.hs
@@ -82,7 +82,7 @@ instance ToHeaders GetDistribution where
 
 instance ToPath GetDistribution where
         toPath GetDistribution'{..}
-          = mconcat ["/2015-04-17/distribution/", toText _gdId]
+          = mconcat ["/2015-04-17/distribution/", toPath _gdId]
 
 instance ToQuery GetDistribution where
         toQuery = const mempty

--- a/amazonka-cloudfront/gen/Network/AWS/CloudFront/GetDistributionConfig.hs
+++ b/amazonka-cloudfront/gen/Network/AWS/CloudFront/GetDistributionConfig.hs
@@ -84,7 +84,7 @@ instance ToHeaders GetDistributionConfig where
 instance ToPath GetDistributionConfig where
         toPath GetDistributionConfig'{..}
           = mconcat
-              ["/2015-04-17/distribution/", toText _gdcId,
+              ["/2015-04-17/distribution/", toPath _gdcId,
                "/config"]
 
 instance ToQuery GetDistributionConfig where

--- a/amazonka-cloudfront/gen/Network/AWS/CloudFront/GetInvalidation.hs
+++ b/amazonka-cloudfront/gen/Network/AWS/CloudFront/GetInvalidation.hs
@@ -91,8 +91,8 @@ instance ToPath GetInvalidation where
         toPath GetInvalidation'{..}
           = mconcat
               ["/2015-04-17/distribution/",
-               toText _giDistributionId, "/invalidation/",
-               toText _giId]
+               toPath _giDistributionId, "/invalidation/",
+               toPath _giId]
 
 instance ToQuery GetInvalidation where
         toQuery = const mempty

--- a/amazonka-cloudfront/gen/Network/AWS/CloudFront/GetStreamingDistribution.hs
+++ b/amazonka-cloudfront/gen/Network/AWS/CloudFront/GetStreamingDistribution.hs
@@ -85,7 +85,7 @@ instance ToPath GetStreamingDistribution where
         toPath GetStreamingDistribution'{..}
           = mconcat
               ["/2015-04-17/streaming-distribution/",
-               toText _gsdId]
+               toPath _gsdId]
 
 instance ToQuery GetStreamingDistribution where
         toQuery = const mempty

--- a/amazonka-cloudfront/gen/Network/AWS/CloudFront/GetStreamingDistributionConfig.hs
+++ b/amazonka-cloudfront/gen/Network/AWS/CloudFront/GetStreamingDistributionConfig.hs
@@ -87,7 +87,7 @@ instance ToPath GetStreamingDistributionConfig where
         toPath GetStreamingDistributionConfig'{..}
           = mconcat
               ["/2015-04-17/streaming-distribution/",
-               toText _gsdcId, "/config"]
+               toPath _gsdcId, "/config"]
 
 instance ToQuery GetStreamingDistributionConfig where
         toQuery = const mempty

--- a/amazonka-cloudfront/gen/Network/AWS/CloudFront/ListInvalidations.hs
+++ b/amazonka-cloudfront/gen/Network/AWS/CloudFront/ListInvalidations.hs
@@ -107,7 +107,7 @@ instance ToPath ListInvalidations where
         toPath ListInvalidations'{..}
           = mconcat
               ["/2015-04-17/distribution/",
-               toText _liDistributionId, "/invalidation"]
+               toPath _liDistributionId, "/invalidation"]
 
 instance ToQuery ListInvalidations where
         toQuery ListInvalidations'{..}

--- a/amazonka-cloudfront/gen/Network/AWS/CloudFront/Types/Sum.hs
+++ b/amazonka-cloudfront/gen/Network/AWS/CloudFront/Types/Sum.hs
@@ -39,9 +39,11 @@ instance ToText GeoRestrictionType where
         None -> "none"
         Whitelist -> "whitelist"
 
-instance Hashable GeoRestrictionType
-instance ToQuery  GeoRestrictionType
-instance ToHeader GeoRestrictionType
+instance Hashable     GeoRestrictionType
+instance ToByteString GeoRestrictionType
+instance ToPath       GeoRestrictionType
+instance ToQuery      GeoRestrictionType
+instance ToHeader     GeoRestrictionType
 
 instance FromXML GeoRestrictionType where
     parseXML = parseXMLText "GeoRestrictionType"
@@ -69,9 +71,11 @@ instance ToText ItemSelection where
         ISNone -> "none"
         ISWhitelist -> "whitelist"
 
-instance Hashable ItemSelection
-instance ToQuery  ItemSelection
-instance ToHeader ItemSelection
+instance Hashable     ItemSelection
+instance ToByteString ItemSelection
+instance ToPath       ItemSelection
+instance ToQuery      ItemSelection
+instance ToHeader     ItemSelection
 
 instance FromXML ItemSelection where
     parseXML = parseXMLText "ItemSelection"
@@ -111,9 +115,11 @@ instance ToText Method where
         Post -> "post"
         Put -> "put"
 
-instance Hashable Method
-instance ToQuery  Method
-instance ToHeader Method
+instance Hashable     Method
+instance ToByteString Method
+instance ToPath       Method
+instance ToQuery      Method
+instance ToHeader     Method
 
 instance FromXML Method where
     parseXML = parseXMLText "Method"
@@ -138,9 +144,11 @@ instance ToText MinimumProtocolVersion where
         SSLV3 -> "sslv3"
         TLSV1 -> "tlsv1"
 
-instance Hashable MinimumProtocolVersion
-instance ToQuery  MinimumProtocolVersion
-instance ToHeader MinimumProtocolVersion
+instance Hashable     MinimumProtocolVersion
+instance ToByteString MinimumProtocolVersion
+instance ToPath       MinimumProtocolVersion
+instance ToQuery      MinimumProtocolVersion
+instance ToHeader     MinimumProtocolVersion
 
 instance FromXML MinimumProtocolVersion where
     parseXML = parseXMLText "MinimumProtocolVersion"
@@ -165,9 +173,11 @@ instance ToText OriginProtocolPolicy where
         HTTPOnly -> "http-only"
         MatchViewer -> "match-viewer"
 
-instance Hashable OriginProtocolPolicy
-instance ToQuery  OriginProtocolPolicy
-instance ToHeader OriginProtocolPolicy
+instance Hashable     OriginProtocolPolicy
+instance ToByteString OriginProtocolPolicy
+instance ToPath       OriginProtocolPolicy
+instance ToQuery      OriginProtocolPolicy
+instance ToHeader     OriginProtocolPolicy
 
 instance FromXML OriginProtocolPolicy where
     parseXML = parseXMLText "OriginProtocolPolicy"
@@ -195,9 +205,11 @@ instance ToText PriceClass where
         PriceClass200 -> "priceclass_200"
         PriceClassAll -> "priceclass_all"
 
-instance Hashable PriceClass
-instance ToQuery  PriceClass
-instance ToHeader PriceClass
+instance Hashable     PriceClass
+instance ToByteString PriceClass
+instance ToPath       PriceClass
+instance ToQuery      PriceClass
+instance ToHeader     PriceClass
 
 instance FromXML PriceClass where
     parseXML = parseXMLText "PriceClass"
@@ -222,9 +234,11 @@ instance ToText SSLSupportMethod where
         SNIOnly -> "sni-only"
         VIP -> "vip"
 
-instance Hashable SSLSupportMethod
-instance ToQuery  SSLSupportMethod
-instance ToHeader SSLSupportMethod
+instance Hashable     SSLSupportMethod
+instance ToByteString SSLSupportMethod
+instance ToPath       SSLSupportMethod
+instance ToQuery      SSLSupportMethod
+instance ToHeader     SSLSupportMethod
 
 instance FromXML SSLSupportMethod where
     parseXML = parseXMLText "SSLSupportMethod"
@@ -252,9 +266,11 @@ instance ToText ViewerProtocolPolicy where
         HTTPSOnly -> "https-only"
         RedirectToHTTPS -> "redirect-to-https"
 
-instance Hashable ViewerProtocolPolicy
-instance ToQuery  ViewerProtocolPolicy
-instance ToHeader ViewerProtocolPolicy
+instance Hashable     ViewerProtocolPolicy
+instance ToByteString ViewerProtocolPolicy
+instance ToPath       ViewerProtocolPolicy
+instance ToQuery      ViewerProtocolPolicy
+instance ToHeader     ViewerProtocolPolicy
 
 instance FromXML ViewerProtocolPolicy where
     parseXML = parseXMLText "ViewerProtocolPolicy"

--- a/amazonka-cloudfront/gen/Network/AWS/CloudFront/UpdateCloudFrontOriginAccessIdentity.hs
+++ b/amazonka-cloudfront/gen/Network/AWS/CloudFront/UpdateCloudFrontOriginAccessIdentity.hs
@@ -117,7 +117,7 @@ instance ToPath UpdateCloudFrontOriginAccessIdentity
         toPath UpdateCloudFrontOriginAccessIdentity'{..}
           = mconcat
               ["/2015-04-17/origin-access-identity/cloudfront/",
-               toText _ucfoaiId, "/config"]
+               toPath _ucfoaiId, "/config"]
 
 instance ToQuery UpdateCloudFrontOriginAccessIdentity
          where

--- a/amazonka-cloudfront/gen/Network/AWS/CloudFront/UpdateDistribution.hs
+++ b/amazonka-cloudfront/gen/Network/AWS/CloudFront/UpdateDistribution.hs
@@ -111,7 +111,7 @@ instance ToHeaders UpdateDistribution where
 instance ToPath UpdateDistribution where
         toPath UpdateDistribution'{..}
           = mconcat
-              ["/2015-04-17/distribution/", toText _udId,
+              ["/2015-04-17/distribution/", toPath _udId,
                "/config"]
 
 instance ToQuery UpdateDistribution where

--- a/amazonka-cloudfront/gen/Network/AWS/CloudFront/UpdateStreamingDistribution.hs
+++ b/amazonka-cloudfront/gen/Network/AWS/CloudFront/UpdateStreamingDistribution.hs
@@ -112,7 +112,7 @@ instance ToPath UpdateStreamingDistribution where
         toPath UpdateStreamingDistribution'{..}
           = mconcat
               ["/2015-04-17/streaming-distribution/",
-               toText _usdId, "/config"]
+               toPath _usdId, "/config"]
 
 instance ToQuery UpdateStreamingDistribution where
         toQuery = const mempty

--- a/amazonka-cloudhsm/amazonka-cloudhsm.cabal
+++ b/amazonka-cloudhsm/amazonka-cloudhsm.cabal
@@ -74,7 +74,7 @@ test-suite amazonka-cloudhsm-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-cloudhsm == 1.0.0
         , base
         , bytestring

--- a/amazonka-cloudhsm/gen/Network/AWS/CloudHSM/Types/Sum.hs
+++ b/amazonka-cloudhsm/gen/Network/AWS/CloudHSM/Types/Sum.hs
@@ -36,9 +36,11 @@ instance ToText ClientVersion where
         V5_1 -> "5.1"
         V5_3 -> "5.3"
 
-instance Hashable ClientVersion
-instance ToQuery  ClientVersion
-instance ToHeader ClientVersion
+instance Hashable     ClientVersion
+instance ToByteString ClientVersion
+instance ToPath       ClientVersion
+instance ToQuery      ClientVersion
+instance ToHeader     ClientVersion
 
 instance ToJSON ClientVersion where
     toJSON = toJSONText
@@ -63,9 +65,11 @@ instance ToText CloudHSMObjectState where
         Ready -> "ready"
         Updating -> "updating"
 
-instance Hashable CloudHSMObjectState
-instance ToQuery  CloudHSMObjectState
-instance ToHeader CloudHSMObjectState
+instance Hashable     CloudHSMObjectState
+instance ToByteString CloudHSMObjectState
+instance ToPath       CloudHSMObjectState
+instance ToQuery      CloudHSMObjectState
+instance ToHeader     CloudHSMObjectState
 
 instance FromJSON CloudHSMObjectState where
     parseJSON = parseJSONText "CloudHSMObjectState"
@@ -102,9 +106,11 @@ instance ToText HSMStatus where
         HSTerminating -> "terminating"
         HSUpdating -> "updating"
 
-instance Hashable HSMStatus
-instance ToQuery  HSMStatus
-instance ToHeader HSMStatus
+instance Hashable     HSMStatus
+instance ToByteString HSMStatus
+instance ToPath       HSMStatus
+instance ToQuery      HSMStatus
+instance ToHeader     HSMStatus
 
 instance FromJSON HSMStatus where
     parseJSON = parseJSONText "HSMStatus"
@@ -123,9 +129,11 @@ instance ToText SubscriptionType where
     toText = \case
         Production -> "production"
 
-instance Hashable SubscriptionType
-instance ToQuery  SubscriptionType
-instance ToHeader SubscriptionType
+instance Hashable     SubscriptionType
+instance ToByteString SubscriptionType
+instance ToPath       SubscriptionType
+instance ToQuery      SubscriptionType
+instance ToHeader     SubscriptionType
 
 instance ToJSON SubscriptionType where
     toJSON = toJSONText

--- a/amazonka-cloudsearch-domains/amazonka-cloudsearch-domains.cabal
+++ b/amazonka-cloudsearch-domains/amazonka-cloudsearch-domains.cabal
@@ -71,7 +71,7 @@ test-suite amazonka-cloudsearch-domains-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-cloudsearch-domains == 1.0.0
         , base
         , bytestring

--- a/amazonka-cloudsearch-domains/gen/Network/AWS/CloudSearchDomains/Types/Sum.hs
+++ b/amazonka-cloudsearch-domains/gen/Network/AWS/CloudSearchDomains/Types/Sum.hs
@@ -36,9 +36,11 @@ instance ToText ContentType where
         ApplicationJSON -> "application/json"
         ApplicationXML -> "application/xml"
 
-instance Hashable ContentType
-instance ToQuery  ContentType
-instance ToHeader ContentType
+instance Hashable     ContentType
+instance ToByteString ContentType
+instance ToPath       ContentType
+instance ToQuery      ContentType
+instance ToHeader     ContentType
 
 instance ToJSON ContentType where
     toJSON = toJSONText
@@ -66,9 +68,11 @@ instance ToText QueryParser where
         Simple -> "simple"
         Structured -> "structured"
 
-instance Hashable QueryParser
-instance ToQuery  QueryParser
-instance ToHeader QueryParser
+instance Hashable     QueryParser
+instance ToByteString QueryParser
+instance ToPath       QueryParser
+instance ToQuery      QueryParser
+instance ToHeader     QueryParser
 
 instance ToJSON QueryParser where
     toJSON = toJSONText

--- a/amazonka-cloudsearch/amazonka-cloudsearch.cabal
+++ b/amazonka-cloudsearch/amazonka-cloudsearch.cabal
@@ -93,7 +93,7 @@ test-suite amazonka-cloudsearch-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-cloudsearch == 1.0.0
         , base
         , bytestring

--- a/amazonka-cloudsearch/gen/Network/AWS/CloudSearch/Types/Sum.hs
+++ b/amazonka-cloudsearch/gen/Network/AWS/CloudSearch/Types/Sum.hs
@@ -42,9 +42,11 @@ instance ToText AlgorithmicStemming where
         ASMinimal -> "minimal"
         ASNone -> "none"
 
-instance Hashable AlgorithmicStemming
-instance ToQuery  AlgorithmicStemming
-instance ToHeader AlgorithmicStemming
+instance Hashable     AlgorithmicStemming
+instance ToByteString AlgorithmicStemming
+instance ToPath       AlgorithmicStemming
+instance ToQuery      AlgorithmicStemming
+instance ToHeader     AlgorithmicStemming
 
 instance FromXML AlgorithmicStemming where
     parseXML = parseXMLText "AlgorithmicStemming"
@@ -167,9 +169,11 @@ instance ToText AnalysisSchemeLanguage where
         ZhHans -> "zh-hans"
         ZhHant -> "zh-hant"
 
-instance Hashable AnalysisSchemeLanguage
-instance ToQuery  AnalysisSchemeLanguage
-instance ToHeader AnalysisSchemeLanguage
+instance Hashable     AnalysisSchemeLanguage
+instance ToByteString AnalysisSchemeLanguage
+instance ToPath       AnalysisSchemeLanguage
+instance ToQuery      AnalysisSchemeLanguage
+instance ToHeader     AnalysisSchemeLanguage
 
 instance FromXML AnalysisSchemeLanguage where
     parseXML = parseXMLText "AnalysisSchemeLanguage"
@@ -222,9 +226,11 @@ instance ToText IndexFieldType where
         Text -> "text"
         TextArray -> "text-array"
 
-instance Hashable IndexFieldType
-instance ToQuery  IndexFieldType
-instance ToHeader IndexFieldType
+instance Hashable     IndexFieldType
+instance ToByteString IndexFieldType
+instance ToPath       IndexFieldType
+instance ToQuery      IndexFieldType
+instance ToHeader     IndexFieldType
 
 instance FromXML IndexFieldType where
     parseXML = parseXMLText "IndexFieldType"
@@ -264,9 +270,11 @@ instance ToText OptionState where
         Processing -> "processing"
         RequiresIndexDocuments -> "requiresindexdocuments"
 
-instance Hashable OptionState
-instance ToQuery  OptionState
-instance ToHeader OptionState
+instance Hashable     OptionState
+instance ToByteString OptionState
+instance ToPath       OptionState
+instance ToQuery      OptionState
+instance ToHeader     OptionState
 
 instance FromXML OptionState where
     parseXML = parseXMLText "OptionState"
@@ -308,9 +316,11 @@ instance ToText PartitionInstanceType where
         Search_M3_Medium -> "search.m3.medium"
         Search_M3_XLarge -> "search.m3.xlarge"
 
-instance Hashable PartitionInstanceType
-instance ToQuery  PartitionInstanceType
-instance ToHeader PartitionInstanceType
+instance Hashable     PartitionInstanceType
+instance ToByteString PartitionInstanceType
+instance ToPath       PartitionInstanceType
+instance ToQuery      PartitionInstanceType
+instance ToHeader     PartitionInstanceType
 
 instance FromXML PartitionInstanceType where
     parseXML = parseXMLText "PartitionInstanceType"
@@ -335,9 +345,11 @@ instance ToText SuggesterFuzzyMatching where
         Low -> "low"
         None -> "none"
 
-instance Hashable SuggesterFuzzyMatching
-instance ToQuery  SuggesterFuzzyMatching
-instance ToHeader SuggesterFuzzyMatching
+instance Hashable     SuggesterFuzzyMatching
+instance ToByteString SuggesterFuzzyMatching
+instance ToPath       SuggesterFuzzyMatching
+instance ToQuery      SuggesterFuzzyMatching
+instance ToHeader     SuggesterFuzzyMatching
 
 instance FromXML SuggesterFuzzyMatching where
     parseXML = parseXMLText "SuggesterFuzzyMatching"

--- a/amazonka-cloudtrail/amazonka-cloudtrail.cabal
+++ b/amazonka-cloudtrail/amazonka-cloudtrail.cabal
@@ -87,7 +87,7 @@ test-suite amazonka-cloudtrail-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-cloudtrail == 1.0.0
         , base
         , bytestring

--- a/amazonka-cloudtrail/gen/Network/AWS/CloudTrail/Types/Sum.hs
+++ b/amazonka-cloudtrail/gen/Network/AWS/CloudTrail/Types/Sum.hs
@@ -45,9 +45,11 @@ instance ToText LookupAttributeKey where
         ResourceType -> "resourcetype"
         Username -> "username"
 
-instance Hashable LookupAttributeKey
-instance ToQuery  LookupAttributeKey
-instance ToHeader LookupAttributeKey
+instance Hashable     LookupAttributeKey
+instance ToByteString LookupAttributeKey
+instance ToPath       LookupAttributeKey
+instance ToQuery      LookupAttributeKey
+instance ToHeader     LookupAttributeKey
 
 instance ToJSON LookupAttributeKey where
     toJSON = toJSONText

--- a/amazonka-cloudwatch-logs/amazonka-cloudwatch-logs.cabal
+++ b/amazonka-cloudwatch-logs/amazonka-cloudwatch-logs.cabal
@@ -115,7 +115,7 @@ test-suite amazonka-cloudwatch-logs-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-cloudwatch-logs == 1.0.0
         , base
         , bytestring

--- a/amazonka-cloudwatch-logs/gen/Network/AWS/CloudWatchLogs/Types/Sum.hs
+++ b/amazonka-cloudwatch-logs/gen/Network/AWS/CloudWatchLogs/Types/Sum.hs
@@ -36,9 +36,11 @@ instance ToText OrderBy where
         LastEventTime -> "lasteventtime"
         LogStreamName -> "logstreamname"
 
-instance Hashable OrderBy
-instance ToQuery  OrderBy
-instance ToHeader OrderBy
+instance Hashable     OrderBy
+instance ToByteString OrderBy
+instance ToPath       OrderBy
+instance ToQuery      OrderBy
+instance ToHeader     OrderBy
 
 instance ToJSON OrderBy where
     toJSON = toJSONText

--- a/amazonka-cloudwatch/amazonka-cloudwatch.cabal
+++ b/amazonka-cloudwatch/amazonka-cloudwatch.cabal
@@ -117,7 +117,7 @@ test-suite amazonka-cloudwatch-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-cloudwatch == 1.0.0
         , base
         , bytestring

--- a/amazonka-cloudwatch/gen/Network/AWS/CloudWatch/Types/Sum.hs
+++ b/amazonka-cloudwatch/gen/Network/AWS/CloudWatch/Types/Sum.hs
@@ -42,9 +42,11 @@ instance ToText ComparisonOperator where
         LessThanOrEqualToThreshold -> "lessthanorequaltothreshold"
         LessThanThreshold -> "lessthanthreshold"
 
-instance Hashable ComparisonOperator
-instance ToQuery  ComparisonOperator
-instance ToHeader ComparisonOperator
+instance Hashable     ComparisonOperator
+instance ToByteString ComparisonOperator
+instance ToPath       ComparisonOperator
+instance ToQuery      ComparisonOperator
+instance ToHeader     ComparisonOperator
 
 instance FromXML ComparisonOperator where
     parseXML = parseXMLText "ComparisonOperator"
@@ -69,9 +71,11 @@ instance ToText HistoryItemType where
         ConfigurationUpdate -> "configurationupdate"
         StateUpdate -> "stateupdate"
 
-instance Hashable HistoryItemType
-instance ToQuery  HistoryItemType
-instance ToHeader HistoryItemType
+instance Hashable     HistoryItemType
+instance ToByteString HistoryItemType
+instance ToPath       HistoryItemType
+instance ToQuery      HistoryItemType
+instance ToHeader     HistoryItemType
 
 instance FromXML HistoryItemType where
     parseXML = parseXMLText "HistoryItemType"
@@ -168,9 +172,11 @@ instance ToText StandardUnit where
         Terabytes -> "terabytes"
         TerabytesSecond -> "terabytes/second"
 
-instance Hashable StandardUnit
-instance ToQuery  StandardUnit
-instance ToHeader StandardUnit
+instance Hashable     StandardUnit
+instance ToByteString StandardUnit
+instance ToPath       StandardUnit
+instance ToQuery      StandardUnit
+instance ToHeader     StandardUnit
 
 instance FromXML StandardUnit where
     parseXML = parseXMLText "StandardUnit"
@@ -195,9 +201,11 @@ instance ToText StateValue where
         InsufficientData -> "insufficient_data"
         OK -> "ok"
 
-instance Hashable StateValue
-instance ToQuery  StateValue
-instance ToHeader StateValue
+instance Hashable     StateValue
+instance ToByteString StateValue
+instance ToPath       StateValue
+instance ToQuery      StateValue
+instance ToHeader     StateValue
 
 instance FromXML StateValue where
     parseXML = parseXMLText "StateValue"
@@ -228,9 +236,11 @@ instance ToText Statistic where
         SampleCount -> "samplecount"
         Sum -> "sum"
 
-instance Hashable Statistic
-instance ToQuery  Statistic
-instance ToHeader Statistic
+instance Hashable     Statistic
+instance ToByteString Statistic
+instance ToPath       Statistic
+instance ToQuery      Statistic
+instance ToHeader     Statistic
 
 instance FromXML Statistic where
     parseXML = parseXMLText "Statistic"

--- a/amazonka-codecommit/amazonka-codecommit.cabal
+++ b/amazonka-codecommit/amazonka-codecommit.cabal
@@ -80,7 +80,7 @@ test-suite amazonka-codecommit-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-codecommit == 1.0.0
         , base
         , bytestring

--- a/amazonka-codecommit/gen/Network/AWS/CodeCommit/Types/Sum.hs
+++ b/amazonka-codecommit/gen/Network/AWS/CodeCommit/Types/Sum.hs
@@ -36,9 +36,11 @@ instance ToText OrderEnum where
         Ascending -> "ascending"
         Descending -> "descending"
 
-instance Hashable OrderEnum
-instance ToQuery  OrderEnum
-instance ToHeader OrderEnum
+instance Hashable     OrderEnum
+instance ToByteString OrderEnum
+instance ToPath       OrderEnum
+instance ToQuery      OrderEnum
+instance ToHeader     OrderEnum
 
 instance ToJSON OrderEnum where
     toJSON = toJSONText
@@ -60,9 +62,11 @@ instance ToText SortByEnum where
         LastModifiedDate -> "lastmodifieddate"
         RepositoryName -> "repositoryname"
 
-instance Hashable SortByEnum
-instance ToQuery  SortByEnum
-instance ToHeader SortByEnum
+instance Hashable     SortByEnum
+instance ToByteString SortByEnum
+instance ToPath       SortByEnum
+instance ToQuery      SortByEnum
+instance ToHeader     SortByEnum
 
 instance ToJSON SortByEnum where
     toJSON = toJSONText

--- a/amazonka-codedeploy/amazonka-codedeploy.cabal
+++ b/amazonka-codedeploy/amazonka-codedeploy.cabal
@@ -148,7 +148,7 @@ test-suite amazonka-codedeploy-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-codedeploy == 1.0.0
         , base
         , bytestring

--- a/amazonka-codedeploy/gen/Network/AWS/CodeDeploy/Types/Sum.hs
+++ b/amazonka-codedeploy/gen/Network/AWS/CodeDeploy/Types/Sum.hs
@@ -39,9 +39,11 @@ instance ToText ApplicationRevisionSortBy where
         LastUsedTime -> "lastusedtime"
         RegisterTime -> "registertime"
 
-instance Hashable ApplicationRevisionSortBy
-instance ToQuery  ApplicationRevisionSortBy
-instance ToHeader ApplicationRevisionSortBy
+instance Hashable     ApplicationRevisionSortBy
+instance ToByteString ApplicationRevisionSortBy
+instance ToPath       ApplicationRevisionSortBy
+instance ToQuery      ApplicationRevisionSortBy
+instance ToHeader     ApplicationRevisionSortBy
 
 instance ToJSON ApplicationRevisionSortBy where
     toJSON = toJSONText
@@ -66,9 +68,11 @@ instance ToText BundleType where
         TGZ -> "tgz"
         Zip -> "zip"
 
-instance Hashable BundleType
-instance ToQuery  BundleType
-instance ToHeader BundleType
+instance Hashable     BundleType
+instance ToByteString BundleType
+instance ToPath       BundleType
+instance ToQuery      BundleType
+instance ToHeader     BundleType
 
 instance ToJSON BundleType where
     toJSON = toJSONText
@@ -126,9 +130,11 @@ instance ToText DeployErrorCode where
         Throttled -> "throttled"
         Timeout -> "timeout"
 
-instance Hashable DeployErrorCode
-instance ToQuery  DeployErrorCode
-instance ToHeader DeployErrorCode
+instance Hashable     DeployErrorCode
+instance ToByteString DeployErrorCode
+instance ToPath       DeployErrorCode
+instance ToQuery      DeployErrorCode
+instance ToHeader     DeployErrorCode
 
 instance FromJSON DeployErrorCode where
     parseJSON = parseJSONText "DeployErrorCode"
@@ -150,9 +156,11 @@ instance ToText DeploymentCreator where
         Autoscaling -> "autoscaling"
         User -> "user"
 
-instance Hashable DeploymentCreator
-instance ToQuery  DeploymentCreator
-instance ToHeader DeploymentCreator
+instance Hashable     DeploymentCreator
+instance ToByteString DeploymentCreator
+instance ToPath       DeploymentCreator
+instance ToQuery      DeploymentCreator
+instance ToHeader     DeploymentCreator
 
 instance FromJSON DeploymentCreator where
     parseJSON = parseJSONText "DeploymentCreator"
@@ -186,9 +194,11 @@ instance ToText DeploymentStatus where
         Stopped -> "stopped"
         Succeeded -> "succeeded"
 
-instance Hashable DeploymentStatus
-instance ToQuery  DeploymentStatus
-instance ToHeader DeploymentStatus
+instance Hashable     DeploymentStatus
+instance ToByteString DeploymentStatus
+instance ToPath       DeploymentStatus
+instance ToQuery      DeploymentStatus
+instance ToHeader     DeploymentStatus
 
 instance ToJSON DeploymentStatus where
     toJSON = toJSONText
@@ -216,9 +226,11 @@ instance ToText EC2TagFilterType where
         KeyOnly -> "key_only"
         ValueOnly -> "value_only"
 
-instance Hashable EC2TagFilterType
-instance ToQuery  EC2TagFilterType
-instance ToHeader EC2TagFilterType
+instance Hashable     EC2TagFilterType
+instance ToByteString EC2TagFilterType
+instance ToPath       EC2TagFilterType
+instance ToQuery      EC2TagFilterType
+instance ToHeader     EC2TagFilterType
 
 instance ToJSON EC2TagFilterType where
     toJSON = toJSONText
@@ -255,9 +267,11 @@ instance ToText InstanceStatus where
         ISSucceeded -> "succeeded"
         ISUnknown -> "unknown"
 
-instance Hashable InstanceStatus
-instance ToQuery  InstanceStatus
-instance ToHeader InstanceStatus
+instance Hashable     InstanceStatus
+instance ToByteString InstanceStatus
+instance ToPath       InstanceStatus
+instance ToQuery      InstanceStatus
+instance ToHeader     InstanceStatus
 
 instance ToJSON InstanceStatus where
     toJSON = toJSONText
@@ -294,9 +308,11 @@ instance ToText LifecycleErrorCode where
         Success -> "success"
         UnknownError -> "unknownerror"
 
-instance Hashable LifecycleErrorCode
-instance ToQuery  LifecycleErrorCode
-instance ToHeader LifecycleErrorCode
+instance Hashable     LifecycleErrorCode
+instance ToByteString LifecycleErrorCode
+instance ToPath       LifecycleErrorCode
+instance ToQuery      LifecycleErrorCode
+instance ToHeader     LifecycleErrorCode
 
 instance FromJSON LifecycleErrorCode where
     parseJSON = parseJSONText "LifecycleErrorCode"
@@ -330,9 +346,11 @@ instance ToText LifecycleEventStatus where
         LESSucceeded -> "succeeded"
         LESUnknown -> "unknown"
 
-instance Hashable LifecycleEventStatus
-instance ToQuery  LifecycleEventStatus
-instance ToHeader LifecycleEventStatus
+instance Hashable     LifecycleEventStatus
+instance ToByteString LifecycleEventStatus
+instance ToPath       LifecycleEventStatus
+instance ToQuery      LifecycleEventStatus
+instance ToHeader     LifecycleEventStatus
 
 instance FromJSON LifecycleEventStatus where
     parseJSON = parseJSONText "LifecycleEventStatus"
@@ -357,9 +375,11 @@ instance ToText ListStateFilterAction where
         Ignore -> "ignore"
         Include -> "include"
 
-instance Hashable ListStateFilterAction
-instance ToQuery  ListStateFilterAction
-instance ToHeader ListStateFilterAction
+instance Hashable     ListStateFilterAction
+instance ToByteString ListStateFilterAction
+instance ToPath       ListStateFilterAction
+instance ToQuery      ListStateFilterAction
+instance ToHeader     ListStateFilterAction
 
 instance ToJSON ListStateFilterAction where
     toJSON = toJSONText
@@ -381,9 +401,11 @@ instance ToText MinimumHealthyHostsType where
         FleetPercent -> "fleet_percent"
         HostCount -> "host_count"
 
-instance Hashable MinimumHealthyHostsType
-instance ToQuery  MinimumHealthyHostsType
-instance ToHeader MinimumHealthyHostsType
+instance Hashable     MinimumHealthyHostsType
+instance ToByteString MinimumHealthyHostsType
+instance ToPath       MinimumHealthyHostsType
+instance ToQuery      MinimumHealthyHostsType
+instance ToHeader     MinimumHealthyHostsType
 
 instance ToJSON MinimumHealthyHostsType where
     toJSON = toJSONText
@@ -408,9 +430,11 @@ instance ToText RegistrationStatus where
         Deregistered -> "deregistered"
         Registered -> "registered"
 
-instance Hashable RegistrationStatus
-instance ToQuery  RegistrationStatus
-instance ToHeader RegistrationStatus
+instance Hashable     RegistrationStatus
+instance ToByteString RegistrationStatus
+instance ToPath       RegistrationStatus
+instance ToQuery      RegistrationStatus
+instance ToHeader     RegistrationStatus
 
 instance ToJSON RegistrationStatus where
     toJSON = toJSONText
@@ -432,9 +456,11 @@ instance ToText RevisionLocationType where
         GitHub -> "github"
         S3 -> "s3"
 
-instance Hashable RevisionLocationType
-instance ToQuery  RevisionLocationType
-instance ToHeader RevisionLocationType
+instance Hashable     RevisionLocationType
+instance ToByteString RevisionLocationType
+instance ToPath       RevisionLocationType
+instance ToQuery      RevisionLocationType
+instance ToHeader     RevisionLocationType
 
 instance ToJSON RevisionLocationType where
     toJSON = toJSONText
@@ -459,9 +485,11 @@ instance ToText SortOrder where
         Ascending -> "ascending"
         Descending -> "descending"
 
-instance Hashable SortOrder
-instance ToQuery  SortOrder
-instance ToHeader SortOrder
+instance Hashable     SortOrder
+instance ToByteString SortOrder
+instance ToPath       SortOrder
+instance ToQuery      SortOrder
+instance ToHeader     SortOrder
 
 instance ToJSON SortOrder where
     toJSON = toJSONText
@@ -483,9 +511,11 @@ instance ToText StopStatus where
         SSPending -> "pending"
         SSSucceeded -> "succeeded"
 
-instance Hashable StopStatus
-instance ToQuery  StopStatus
-instance ToHeader StopStatus
+instance Hashable     StopStatus
+instance ToByteString StopStatus
+instance ToPath       StopStatus
+instance ToQuery      StopStatus
+instance ToHeader     StopStatus
 
 instance FromJSON StopStatus where
     parseJSON = parseJSONText "StopStatus"
@@ -510,9 +540,11 @@ instance ToText TagFilterType where
         TFTKeyOnly -> "key_only"
         TFTValueOnly -> "value_only"
 
-instance Hashable TagFilterType
-instance ToQuery  TagFilterType
-instance ToHeader TagFilterType
+instance Hashable     TagFilterType
+instance ToByteString TagFilterType
+instance ToPath       TagFilterType
+instance ToQuery      TagFilterType
+instance ToHeader     TagFilterType
 
 instance ToJSON TagFilterType where
     toJSON = toJSONText

--- a/amazonka-codepipeline/amazonka-codepipeline.cabal
+++ b/amazonka-codepipeline/amazonka-codepipeline.cabal
@@ -170,7 +170,7 @@ test-suite amazonka-codepipeline-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-codepipeline == 1.0.0
         , base
         , bytestring

--- a/amazonka-codepipeline/gen/Network/AWS/CodePipeline/Types/Sum.hs
+++ b/amazonka-codepipeline/gen/Network/AWS/CodePipeline/Types/Sum.hs
@@ -45,9 +45,11 @@ instance ToText ActionCategory where
         Source -> "source"
         Test -> "test"
 
-instance Hashable ActionCategory
-instance ToQuery  ActionCategory
-instance ToHeader ActionCategory
+instance Hashable     ActionCategory
+instance ToByteString ActionCategory
+instance ToPath       ActionCategory
+instance ToQuery      ActionCategory
+instance ToHeader     ActionCategory
 
 instance ToJSON ActionCategory where
     toJSON = toJSONText
@@ -75,9 +77,11 @@ instance ToText ActionConfigurationPropertyType where
         Number -> "number"
         String -> "string"
 
-instance Hashable ActionConfigurationPropertyType
-instance ToQuery  ActionConfigurationPropertyType
-instance ToHeader ActionConfigurationPropertyType
+instance Hashable     ActionConfigurationPropertyType
+instance ToByteString ActionConfigurationPropertyType
+instance ToPath       ActionConfigurationPropertyType
+instance ToQuery      ActionConfigurationPropertyType
+instance ToHeader     ActionConfigurationPropertyType
 
 instance ToJSON ActionConfigurationPropertyType where
     toJSON = toJSONText
@@ -105,9 +109,11 @@ instance ToText ActionExecutionStatus where
         InProgress -> "inprogress"
         Succeeded -> "succeeded"
 
-instance Hashable ActionExecutionStatus
-instance ToQuery  ActionExecutionStatus
-instance ToHeader ActionExecutionStatus
+instance Hashable     ActionExecutionStatus
+instance ToByteString ActionExecutionStatus
+instance ToPath       ActionExecutionStatus
+instance ToQuery      ActionExecutionStatus
+instance ToHeader     ActionExecutionStatus
 
 instance FromJSON ActionExecutionStatus where
     parseJSON = parseJSONText "ActionExecutionStatus"
@@ -132,9 +138,11 @@ instance ToText ActionOwner where
         Custom -> "custom"
         ThirdParty -> "thirdparty"
 
-instance Hashable ActionOwner
-instance ToQuery  ActionOwner
-instance ToHeader ActionOwner
+instance Hashable     ActionOwner
+instance ToByteString ActionOwner
+instance ToPath       ActionOwner
+instance ToQuery      ActionOwner
+instance ToHeader     ActionOwner
 
 instance ToJSON ActionOwner where
     toJSON = toJSONText
@@ -156,9 +164,11 @@ instance ToText ArtifactLocationType where
     toText = \case
         ALTS3 -> "s3"
 
-instance Hashable ArtifactLocationType
-instance ToQuery  ArtifactLocationType
-instance ToHeader ArtifactLocationType
+instance Hashable     ArtifactLocationType
+instance ToByteString ArtifactLocationType
+instance ToPath       ArtifactLocationType
+instance ToQuery      ArtifactLocationType
+instance ToHeader     ArtifactLocationType
 
 instance FromJSON ArtifactLocationType where
     parseJSON = parseJSONText "ArtifactLocationType"
@@ -177,9 +187,11 @@ instance ToText ArtifactStoreType where
     toText = \case
         S3 -> "s3"
 
-instance Hashable ArtifactStoreType
-instance ToQuery  ArtifactStoreType
-instance ToHeader ArtifactStoreType
+instance Hashable     ArtifactStoreType
+instance ToByteString ArtifactStoreType
+instance ToPath       ArtifactStoreType
+instance ToQuery      ArtifactStoreType
+instance ToHeader     ArtifactStoreType
 
 instance ToJSON ArtifactStoreType where
     toJSON = toJSONText
@@ -201,9 +213,11 @@ instance ToText BlockerType where
     toText = \case
         Schedule -> "schedule"
 
-instance Hashable BlockerType
-instance ToQuery  BlockerType
-instance ToHeader BlockerType
+instance Hashable     BlockerType
+instance ToByteString BlockerType
+instance ToPath       BlockerType
+instance ToQuery      BlockerType
+instance ToHeader     BlockerType
 
 instance ToJSON BlockerType where
     toJSON = toJSONText
@@ -240,9 +254,11 @@ instance ToText FailureType where
         RevisionUnavailable -> "revisionunavailable"
         SystemUnavailable -> "systemunavailable"
 
-instance Hashable FailureType
-instance ToQuery  FailureType
-instance ToHeader FailureType
+instance Hashable     FailureType
+instance ToByteString FailureType
+instance ToPath       FailureType
+instance ToQuery      FailureType
+instance ToHeader     FailureType
 
 instance ToJSON FailureType where
     toJSON = toJSONText
@@ -279,9 +295,11 @@ instance ToText JobStatus where
         JSSucceeded -> "succeeded"
         JSTimedOut -> "timedout"
 
-instance Hashable JobStatus
-instance ToQuery  JobStatus
-instance ToHeader JobStatus
+instance Hashable     JobStatus
+instance ToByteString JobStatus
+instance ToPath       JobStatus
+instance ToQuery      JobStatus
+instance ToHeader     JobStatus
 
 instance FromJSON JobStatus where
     parseJSON = parseJSONText "JobStatus"
@@ -303,9 +321,11 @@ instance ToText StageTransitionType where
         Inbound -> "inbound"
         Outbound -> "outbound"
 
-instance Hashable StageTransitionType
-instance ToQuery  StageTransitionType
-instance ToHeader StageTransitionType
+instance Hashable     StageTransitionType
+instance ToByteString StageTransitionType
+instance ToPath       StageTransitionType
+instance ToQuery      StageTransitionType
+instance ToHeader     StageTransitionType
 
 instance ToJSON StageTransitionType where
     toJSON = toJSONText

--- a/amazonka-cognito-identity/amazonka-cognito-identity.cabal
+++ b/amazonka-cognito-identity/amazonka-cognito-identity.cabal
@@ -111,7 +111,7 @@ test-suite amazonka-cognito-identity-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-cognito-identity == 1.0.0
         , base
         , bytestring

--- a/amazonka-cognito-identity/gen/Network/AWS/CognitoIdentity/Types/Sum.hs
+++ b/amazonka-cognito-identity/gen/Network/AWS/CognitoIdentity/Types/Sum.hs
@@ -36,9 +36,11 @@ instance ToText CognitoErrorCode where
         AccessDenied -> "accessdenied"
         InternalServerError -> "internalservererror"
 
-instance Hashable CognitoErrorCode
-instance ToQuery  CognitoErrorCode
-instance ToHeader CognitoErrorCode
+instance Hashable     CognitoErrorCode
+instance ToByteString CognitoErrorCode
+instance ToPath       CognitoErrorCode
+instance ToQuery      CognitoErrorCode
+instance ToHeader     CognitoErrorCode
 
 instance FromJSON CognitoErrorCode where
     parseJSON = parseJSONText "CognitoErrorCode"

--- a/amazonka-cognito-sync/amazonka-cognito-sync.cabal
+++ b/amazonka-cognito-sync/amazonka-cognito-sync.cabal
@@ -97,7 +97,7 @@ test-suite amazonka-cognito-sync-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-cognito-sync == 1.0.0
         , base
         , bytestring

--- a/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/BulkPublish.hs
+++ b/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/BulkPublish.hs
@@ -98,7 +98,7 @@ instance ToJSON BulkPublish where
 instance ToPath BulkPublish where
         toPath BulkPublish'{..}
           = mconcat
-              ["/identitypools/", toText _bpIdentityPoolId,
+              ["/identitypools/", toPath _bpIdentityPoolId,
                "/bulkpublish"]
 
 instance ToQuery BulkPublish where

--- a/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/DeleteDataset.hs
+++ b/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/DeleteDataset.hs
@@ -114,9 +114,9 @@ instance ToHeaders DeleteDataset where
 instance ToPath DeleteDataset where
         toPath DeleteDataset'{..}
           = mconcat
-              ["/identitypools/", toText _delIdentityPoolId,
-               "/identities/", toText _delIdentityId, "/datasets/",
-               toText _delDatasetName]
+              ["/identitypools/", toPath _delIdentityPoolId,
+               "/identities/", toPath _delIdentityId, "/datasets/",
+               toPath _delDatasetName]
 
 instance ToQuery DeleteDataset where
         toQuery = const mempty

--- a/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/DescribeDataset.hs
+++ b/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/DescribeDataset.hs
@@ -116,9 +116,9 @@ instance ToHeaders DescribeDataset where
 instance ToPath DescribeDataset where
         toPath DescribeDataset'{..}
           = mconcat
-              ["/identitypools/", toText _ddIdentityPoolId,
-               "/identities/", toText _ddIdentityId, "/datasets/",
-               toText _ddDatasetName]
+              ["/identitypools/", toPath _ddIdentityPoolId,
+               "/identities/", toPath _ddIdentityId, "/datasets/",
+               toPath _ddDatasetName]
 
 instance ToQuery DescribeDataset where
         toQuery = const mempty

--- a/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/DescribeIdentityPoolUsage.hs
+++ b/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/DescribeIdentityPoolUsage.hs
@@ -93,7 +93,7 @@ instance ToHeaders DescribeIdentityPoolUsage where
 instance ToPath DescribeIdentityPoolUsage where
         toPath DescribeIdentityPoolUsage'{..}
           = mconcat
-              ["/identitypools/", toText _dipuIdentityPoolId]
+              ["/identitypools/", toPath _dipuIdentityPoolId]
 
 instance ToQuery DescribeIdentityPoolUsage where
         toQuery = const mempty

--- a/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/DescribeIdentityUsage.hs
+++ b/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/DescribeIdentityUsage.hs
@@ -103,8 +103,8 @@ instance ToHeaders DescribeIdentityUsage where
 instance ToPath DescribeIdentityUsage where
         toPath DescribeIdentityUsage'{..}
           = mconcat
-              ["/identitypools/", toText _diuIdentityPoolId,
-               "/identities/", toText _diuIdentityId]
+              ["/identitypools/", toPath _diuIdentityPoolId,
+               "/identities/", toPath _diuIdentityId]
 
 instance ToQuery DescribeIdentityUsage where
         toQuery = const mempty

--- a/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/GetBulkPublishDetails.hs
+++ b/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/GetBulkPublishDetails.hs
@@ -104,7 +104,7 @@ instance ToJSON GetBulkPublishDetails where
 instance ToPath GetBulkPublishDetails where
         toPath GetBulkPublishDetails'{..}
           = mconcat
-              ["/identitypools/", toText _gbpdIdentityPoolId,
+              ["/identitypools/", toPath _gbpdIdentityPoolId,
                "/getBulkPublishDetails"]
 
 instance ToQuery GetBulkPublishDetails where

--- a/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/GetCognitoEvents.hs
+++ b/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/GetCognitoEvents.hs
@@ -90,7 +90,7 @@ instance ToHeaders GetCognitoEvents where
 instance ToPath GetCognitoEvents where
         toPath GetCognitoEvents'{..}
           = mconcat
-              ["/identitypools/", toText _gceIdentityPoolId,
+              ["/identitypools/", toPath _gceIdentityPoolId,
                "/events"]
 
 instance ToQuery GetCognitoEvents where

--- a/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/GetIdentityPoolConfiguration.hs
+++ b/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/GetIdentityPoolConfiguration.hs
@@ -97,7 +97,7 @@ instance ToHeaders GetIdentityPoolConfiguration where
 instance ToPath GetIdentityPoolConfiguration where
         toPath GetIdentityPoolConfiguration'{..}
           = mconcat
-              ["/identitypools/", toText _gipcIdentityPoolId,
+              ["/identitypools/", toPath _gipcIdentityPoolId,
                "/configuration"]
 
 instance ToQuery GetIdentityPoolConfiguration where

--- a/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/ListDatasets.hs
+++ b/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/ListDatasets.hs
@@ -126,8 +126,8 @@ instance ToHeaders ListDatasets where
 instance ToPath ListDatasets where
         toPath ListDatasets'{..}
           = mconcat
-              ["/identitypools/", toText _ldIdentityPoolId,
-               "/identities/", toText _ldIdentityId, "/datasets"]
+              ["/identitypools/", toPath _ldIdentityPoolId,
+               "/identities/", toPath _ldIdentityId, "/datasets"]
 
 instance ToQuery ListDatasets where
         toQuery ListDatasets'{..}

--- a/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/ListRecords.hs
+++ b/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/ListRecords.hs
@@ -168,9 +168,9 @@ instance ToHeaders ListRecords where
 instance ToPath ListRecords where
         toPath ListRecords'{..}
           = mconcat
-              ["/identitypools/", toText _lrIdentityPoolId,
-               "/identities/", toText _lrIdentityId, "/datasets/",
-               toText _lrDatasetName, "/records"]
+              ["/identitypools/", toPath _lrIdentityPoolId,
+               "/identities/", toPath _lrIdentityId, "/datasets/",
+               toPath _lrDatasetName, "/records"]
 
 instance ToQuery ListRecords where
         toQuery ListRecords'{..}

--- a/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/RegisterDevice.hs
+++ b/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/RegisterDevice.hs
@@ -122,8 +122,8 @@ instance ToJSON RegisterDevice where
 instance ToPath RegisterDevice where
         toPath RegisterDevice'{..}
           = mconcat
-              ["/identitypools/", toText _rdIdentityPoolId,
-               "/identity/", toText _rdIdentityId, "/device"]
+              ["/identitypools/", toPath _rdIdentityPoolId,
+               "/identity/", toPath _rdIdentityId, "/device"]
 
 instance ToQuery RegisterDevice where
         toQuery = const mempty

--- a/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/SetCognitoEvents.hs
+++ b/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/SetCognitoEvents.hs
@@ -100,7 +100,7 @@ instance ToJSON SetCognitoEvents where
 instance ToPath SetCognitoEvents where
         toPath SetCognitoEvents'{..}
           = mconcat
-              ["/identitypools/", toText _sceIdentityPoolId,
+              ["/identitypools/", toPath _sceIdentityPoolId,
                "/events"]
 
 instance ToQuery SetCognitoEvents where

--- a/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/SetIdentityPoolConfiguration.hs
+++ b/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/SetIdentityPoolConfiguration.hs
@@ -121,7 +121,7 @@ instance ToJSON SetIdentityPoolConfiguration where
 instance ToPath SetIdentityPoolConfiguration where
         toPath SetIdentityPoolConfiguration'{..}
           = mconcat
-              ["/identitypools/", toText _sipcIdentityPoolId,
+              ["/identitypools/", toPath _sipcIdentityPoolId,
                "/configuration"]
 
 instance ToQuery SetIdentityPoolConfiguration where

--- a/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/SubscribeToDataset.hs
+++ b/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/SubscribeToDataset.hs
@@ -120,10 +120,10 @@ instance ToJSON SubscribeToDataset where
 instance ToPath SubscribeToDataset where
         toPath SubscribeToDataset'{..}
           = mconcat
-              ["/identitypools/", toText _stdIdentityPoolId,
-               "/identities/", toText _stdIdentityId, "/datasets/",
-               toText _stdDatasetName, "/subscriptions/",
-               toText _stdDeviceId]
+              ["/identitypools/", toPath _stdIdentityPoolId,
+               "/identities/", toPath _stdIdentityId, "/datasets/",
+               toPath _stdDatasetName, "/subscriptions/",
+               toPath _stdDeviceId]
 
 instance ToQuery SubscribeToDataset where
         toQuery = const mempty

--- a/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/Types/Sum.hs
+++ b/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/Types/Sum.hs
@@ -42,9 +42,11 @@ instance ToText BulkPublishStatus where
         NotStarted -> "not_started"
         Succeeded -> "succeeded"
 
-instance Hashable BulkPublishStatus
-instance ToQuery  BulkPublishStatus
-instance ToHeader BulkPublishStatus
+instance Hashable     BulkPublishStatus
+instance ToByteString BulkPublishStatus
+instance ToPath       BulkPublishStatus
+instance ToQuery      BulkPublishStatus
+instance ToHeader     BulkPublishStatus
 
 instance FromJSON BulkPublishStatus where
     parseJSON = parseJSONText "BulkPublishStatus"
@@ -66,9 +68,11 @@ instance ToText Operation where
         Remove -> "remove"
         Replace -> "replace"
 
-instance Hashable Operation
-instance ToQuery  Operation
-instance ToHeader Operation
+instance Hashable     Operation
+instance ToByteString Operation
+instance ToPath       Operation
+instance ToQuery      Operation
+instance ToHeader     Operation
 
 instance ToJSON Operation where
     toJSON = toJSONText
@@ -96,9 +100,11 @@ instance ToText Platform where
         APNSSandbox -> "apns_sandbox"
         GCM -> "gcm"
 
-instance Hashable Platform
-instance ToQuery  Platform
-instance ToHeader Platform
+instance Hashable     Platform
+instance ToByteString Platform
+instance ToPath       Platform
+instance ToQuery      Platform
+instance ToHeader     Platform
 
 instance ToJSON Platform where
     toJSON = toJSONText
@@ -120,9 +126,11 @@ instance ToText StreamingStatus where
         Disabled -> "disabled"
         Enabled -> "enabled"
 
-instance Hashable StreamingStatus
-instance ToQuery  StreamingStatus
-instance ToHeader StreamingStatus
+instance Hashable     StreamingStatus
+instance ToByteString StreamingStatus
+instance ToPath       StreamingStatus
+instance ToQuery      StreamingStatus
+instance ToHeader     StreamingStatus
 
 instance ToJSON StreamingStatus where
     toJSON = toJSONText

--- a/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/UnsubscribeFromDataset.hs
+++ b/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/UnsubscribeFromDataset.hs
@@ -118,10 +118,10 @@ instance ToHeaders UnsubscribeFromDataset where
 instance ToPath UnsubscribeFromDataset where
         toPath UnsubscribeFromDataset'{..}
           = mconcat
-              ["/identitypools/", toText _ufdIdentityPoolId,
-               "/identities/", toText _ufdIdentityId, "/datasets/",
-               toText _ufdDatasetName, "/subscriptions/",
-               toText _ufdDeviceId]
+              ["/identitypools/", toPath _ufdIdentityPoolId,
+               "/identities/", toPath _ufdIdentityId, "/datasets/",
+               toPath _ufdDatasetName, "/subscriptions/",
+               toPath _ufdDeviceId]
 
 instance ToQuery UnsubscribeFromDataset where
         toQuery = const mempty

--- a/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/UpdateRecords.hs
+++ b/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/UpdateRecords.hs
@@ -172,9 +172,9 @@ instance ToJSON UpdateRecords where
 instance ToPath UpdateRecords where
         toPath UpdateRecords'{..}
           = mconcat
-              ["/identitypools/", toText _urIdentityPoolId,
-               "/identities/", toText _urIdentityId, "/datasets/",
-               toText _urDatasetName]
+              ["/identitypools/", toPath _urIdentityPoolId,
+               "/identities/", toPath _urIdentityId, "/datasets/",
+               toPath _urDatasetName]
 
 instance ToQuery UpdateRecords where
         toQuery = const mempty

--- a/amazonka-config/amazonka-config.cabal
+++ b/amazonka-config/amazonka-config.cabal
@@ -96,7 +96,7 @@ test-suite amazonka-config-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-config == 1.0.0
         , base
         , bytestring

--- a/amazonka-config/gen/Network/AWS/Config/Types/Sum.hs
+++ b/amazonka-config/gen/Network/AWS/Config/Types/Sum.hs
@@ -36,9 +36,11 @@ instance ToText ChronologicalOrder where
         Forward -> "forward"
         Reverse -> "reverse"
 
-instance Hashable ChronologicalOrder
-instance ToQuery  ChronologicalOrder
-instance ToHeader ChronologicalOrder
+instance Hashable     ChronologicalOrder
+instance ToByteString ChronologicalOrder
+instance ToPath       ChronologicalOrder
+instance ToQuery      ChronologicalOrder
+instance ToHeader     ChronologicalOrder
 
 instance ToJSON ChronologicalOrder where
     toJSON = toJSONText
@@ -66,9 +68,11 @@ instance ToText ConfigurationItemStatus where
         Failed -> "failed"
         OK -> "ok"
 
-instance Hashable ConfigurationItemStatus
-instance ToQuery  ConfigurationItemStatus
-instance ToHeader ConfigurationItemStatus
+instance Hashable     ConfigurationItemStatus
+instance ToByteString ConfigurationItemStatus
+instance ToPath       ConfigurationItemStatus
+instance ToQuery      ConfigurationItemStatus
+instance ToHeader     ConfigurationItemStatus
 
 instance FromJSON ConfigurationItemStatus where
     parseJSON = parseJSONText "ConfigurationItemStatus"
@@ -93,9 +97,11 @@ instance ToText DeliveryStatus where
         NotApplicable -> "not_applicable"
         Success -> "success"
 
-instance Hashable DeliveryStatus
-instance ToQuery  DeliveryStatus
-instance ToHeader DeliveryStatus
+instance Hashable     DeliveryStatus
+instance ToByteString DeliveryStatus
+instance ToPath       DeliveryStatus
+instance ToQuery      DeliveryStatus
+instance ToHeader     DeliveryStatus
 
 instance FromJSON DeliveryStatus where
     parseJSON = parseJSONText "DeliveryStatus"
@@ -120,9 +126,11 @@ instance ToText RecorderStatus where
         RSPending -> "pending"
         RSSuccess -> "success"
 
-instance Hashable RecorderStatus
-instance ToQuery  RecorderStatus
-instance ToHeader RecorderStatus
+instance Hashable     RecorderStatus
+instance ToByteString RecorderStatus
+instance ToPath       RecorderStatus
+instance ToQuery      RecorderStatus
+instance ToHeader     RecorderStatus
 
 instance FromJSON RecorderStatus where
     parseJSON = parseJSONText "RecorderStatus"
@@ -180,9 +188,11 @@ instance ToText ResourceType where
         AWSEC2VPNGateway -> "aws::ec2::vpngateway"
         AWSEC2Volume -> "aws::ec2::volume"
 
-instance Hashable ResourceType
-instance ToQuery  ResourceType
-instance ToHeader ResourceType
+instance Hashable     ResourceType
+instance ToByteString ResourceType
+instance ToPath       ResourceType
+instance ToQuery      ResourceType
+instance ToHeader     ResourceType
 
 instance ToJSON ResourceType where
     toJSON = toJSONText

--- a/amazonka-datapipeline/amazonka-datapipeline.cabal
+++ b/amazonka-datapipeline/amazonka-datapipeline.cabal
@@ -98,7 +98,7 @@ test-suite amazonka-datapipeline-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-datapipeline == 1.0.0
         , base
         , bytestring

--- a/amazonka-datapipeline/gen/Network/AWS/DataPipeline/Types/Sum.hs
+++ b/amazonka-datapipeline/gen/Network/AWS/DataPipeline/Types/Sum.hs
@@ -45,9 +45,11 @@ instance ToText OperatorType where
         OperatorLE -> "le"
         OperatorRefEQ -> "ref_eq"
 
-instance Hashable OperatorType
-instance ToQuery  OperatorType
-instance ToHeader OperatorType
+instance Hashable     OperatorType
+instance ToByteString OperatorType
+instance ToPath       OperatorType
+instance ToQuery      OperatorType
+instance ToHeader     OperatorType
 
 instance ToJSON OperatorType where
     toJSON = toJSONText
@@ -72,9 +74,11 @@ instance ToText TaskStatus where
         False' -> "false"
         Finished -> "finished"
 
-instance Hashable TaskStatus
-instance ToQuery  TaskStatus
-instance ToHeader TaskStatus
+instance Hashable     TaskStatus
+instance ToByteString TaskStatus
+instance ToPath       TaskStatus
+instance ToQuery      TaskStatus
+instance ToHeader     TaskStatus
 
 instance ToJSON TaskStatus where
     toJSON = toJSONText

--- a/amazonka-devicefarm/amazonka-devicefarm.cabal
+++ b/amazonka-devicefarm/amazonka-devicefarm.cabal
@@ -83,7 +83,7 @@ test-suite amazonka-devicefarm-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-devicefarm == 1.0.0
         , base
         , bytestring

--- a/amazonka-devicefarm/gen/Network/AWS/DeviceFarm/Types/Sum.hs
+++ b/amazonka-devicefarm/gen/Network/AWS/DeviceFarm/Types/Sum.hs
@@ -39,9 +39,11 @@ instance ToText ArtifactCategory where
         ACLog -> "log"
         ACScreenshot -> "screenshot"
 
-instance Hashable ArtifactCategory
-instance ToQuery  ArtifactCategory
-instance ToHeader ArtifactCategory
+instance Hashable     ArtifactCategory
+instance ToByteString ArtifactCategory
+instance ToPath       ArtifactCategory
+instance ToQuery      ArtifactCategory
+instance ToHeader     ArtifactCategory
 
 instance ToJSON ArtifactCategory where
     toJSON = toJSONText
@@ -105,9 +107,11 @@ instance ToText ArtifactType where
         ServiceLog -> "service_log"
         Unknown -> "unknown"
 
-instance Hashable ArtifactType
-instance ToQuery  ArtifactType
-instance ToHeader ArtifactType
+instance Hashable     ArtifactType
+instance ToByteString ArtifactType
+instance ToPath       ArtifactType
+instance ToQuery      ArtifactType
+instance ToHeader     ArtifactType
 
 instance FromJSON ArtifactType where
     parseJSON = parseJSONText "ArtifactType"
@@ -135,9 +139,11 @@ instance ToText DeviceAttribute where
         Manufacturer -> "manufacturer"
         Platform -> "platform"
 
-instance Hashable DeviceAttribute
-instance ToQuery  DeviceAttribute
-instance ToHeader DeviceAttribute
+instance Hashable     DeviceAttribute
+instance ToByteString DeviceAttribute
+instance ToPath       DeviceAttribute
+instance ToQuery      DeviceAttribute
+instance ToHeader     DeviceAttribute
 
 instance ToJSON DeviceAttribute where
     toJSON = toJSONText
@@ -162,9 +168,11 @@ instance ToText DeviceFormFactor where
         Phone -> "phone"
         Tablet -> "tablet"
 
-instance Hashable DeviceFormFactor
-instance ToQuery  DeviceFormFactor
-instance ToHeader DeviceFormFactor
+instance Hashable     DeviceFormFactor
+instance ToByteString DeviceFormFactor
+instance ToPath       DeviceFormFactor
+instance ToQuery      DeviceFormFactor
+instance ToHeader     DeviceFormFactor
 
 instance FromJSON DeviceFormFactor where
     parseJSON = parseJSONText "DeviceFormFactor"
@@ -183,9 +191,11 @@ instance ToText DevicePlatform where
     toText = \case
         Android -> "android"
 
-instance Hashable DevicePlatform
-instance ToQuery  DevicePlatform
-instance ToHeader DevicePlatform
+instance Hashable     DevicePlatform
+instance ToByteString DevicePlatform
+instance ToPath       DevicePlatform
+instance ToQuery      DevicePlatform
+instance ToHeader     DevicePlatform
 
 instance FromJSON DevicePlatform where
     parseJSON = parseJSONText "DevicePlatform"
@@ -207,9 +217,11 @@ instance ToText DevicePoolType where
         Curated -> "curated"
         Private -> "private"
 
-instance Hashable DevicePoolType
-instance ToQuery  DevicePoolType
-instance ToHeader DevicePoolType
+instance Hashable     DevicePoolType
+instance ToByteString DevicePoolType
+instance ToPath       DevicePoolType
+instance ToQuery      DevicePoolType
+instance ToHeader     DevicePoolType
 
 instance ToJSON DevicePoolType where
     toJSON = toJSONText
@@ -249,9 +261,11 @@ instance ToText ExecutionResult where
         ERStopped -> "stopped"
         ERWarned -> "warned"
 
-instance Hashable ExecutionResult
-instance ToQuery  ExecutionResult
-instance ToHeader ExecutionResult
+instance Hashable     ExecutionResult
+instance ToByteString ExecutionResult
+instance ToPath       ExecutionResult
+instance ToQuery      ExecutionResult
+instance ToHeader     ExecutionResult
 
 instance FromJSON ExecutionResult where
     parseJSON = parseJSONText "ExecutionResult"
@@ -282,9 +296,11 @@ instance ToText ExecutionStatus where
         Running -> "running"
         Scheduling -> "scheduling"
 
-instance Hashable ExecutionStatus
-instance ToQuery  ExecutionStatus
-instance ToHeader ExecutionStatus
+instance Hashable     ExecutionStatus
+instance ToByteString ExecutionStatus
+instance ToPath       ExecutionStatus
+instance ToQuery      ExecutionStatus
+instance ToHeader     ExecutionStatus
 
 instance FromJSON ExecutionStatus where
     parseJSON = parseJSONText "ExecutionStatus"
@@ -315,9 +331,11 @@ instance ToText RuleOperator where
         LessThan -> "less_than"
         NotIn -> "not_in"
 
-instance Hashable RuleOperator
-instance ToQuery  RuleOperator
-instance ToHeader RuleOperator
+instance Hashable     RuleOperator
+instance ToByteString RuleOperator
+instance ToPath       RuleOperator
+instance ToQuery      RuleOperator
+instance ToHeader     RuleOperator
 
 instance ToJSON RuleOperator where
     toJSON = toJSONText
@@ -387,9 +405,11 @@ instance ToText SampleType where
         Threads -> "threads"
         TxRate -> "tx_rate"
 
-instance Hashable SampleType
-instance ToQuery  SampleType
-instance ToHeader SampleType
+instance Hashable     SampleType
+instance ToByteString SampleType
+instance ToPath       SampleType
+instance ToQuery      SampleType
+instance ToHeader     SampleType
 
 instance FromJSON SampleType where
     parseJSON = parseJSONText "SampleType"
@@ -426,9 +446,11 @@ instance ToText TestType where
         Instrumentation -> "instrumentation"
         Uiautomator -> "uiautomator"
 
-instance Hashable TestType
-instance ToQuery  TestType
-instance ToHeader TestType
+instance Hashable     TestType
+instance ToByteString TestType
+instance ToPath       TestType
+instance ToQuery      TestType
+instance ToHeader     TestType
 
 instance ToJSON TestType where
     toJSON = toJSONText
@@ -459,9 +481,11 @@ instance ToText UploadStatus where
         USProcessing -> "processing"
         USSucceeded -> "succeeded"
 
-instance Hashable UploadStatus
-instance ToQuery  UploadStatus
-instance ToHeader UploadStatus
+instance Hashable     UploadStatus
+instance ToByteString UploadStatus
+instance ToPath       UploadStatus
+instance ToQuery      UploadStatus
+instance ToHeader     UploadStatus
 
 instance FromJSON UploadStatus where
     parseJSON = parseJSONText "UploadStatus"
@@ -498,9 +522,11 @@ instance ToText UploadType where
         InstrumentationTestPackage -> "instrumentation_test_package"
         UiautomatorTestPackage -> "uiautomator_test_package"
 
-instance Hashable UploadType
-instance ToQuery  UploadType
-instance ToHeader UploadType
+instance Hashable     UploadType
+instance ToByteString UploadType
+instance ToPath       UploadType
+instance ToQuery      UploadType
+instance ToHeader     UploadType
 
 instance ToJSON UploadType where
     toJSON = toJSONText

--- a/amazonka-directconnect/amazonka-directconnect.cabal
+++ b/amazonka-directconnect/amazonka-directconnect.cabal
@@ -96,7 +96,7 @@ test-suite amazonka-directconnect-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-directconnect == 1.0.0
         , base
         , bytestring

--- a/amazonka-directconnect/gen/Network/AWS/DirectConnect/Types/Sum.hs
+++ b/amazonka-directconnect/gen/Network/AWS/DirectConnect/Types/Sum.hs
@@ -71,9 +71,11 @@ instance ToText ConnectionState where
         CSRejected -> "rejected"
         CSRequested -> "requested"
 
-instance Hashable ConnectionState
-instance ToQuery  ConnectionState
-instance ToHeader ConnectionState
+instance Hashable     ConnectionState
+instance ToByteString ConnectionState
+instance ToPath       ConnectionState
+instance ToQuery      ConnectionState
+instance ToHeader     ConnectionState
 
 instance FromJSON ConnectionState where
     parseJSON = parseJSONText "ConnectionState"
@@ -118,9 +120,11 @@ instance ToText InterconnectState where
         ISPending -> "pending"
         ISRequested -> "requested"
 
-instance Hashable InterconnectState
-instance ToQuery  InterconnectState
-instance ToHeader InterconnectState
+instance Hashable     InterconnectState
+instance ToByteString InterconnectState
+instance ToPath       InterconnectState
+instance ToQuery      InterconnectState
+instance ToHeader     InterconnectState
 
 instance FromJSON InterconnectState where
     parseJSON = parseJSONText "InterconnectState"
@@ -179,9 +183,11 @@ instance ToText VirtualInterfaceState where
         Rejected -> "rejected"
         Verifying -> "verifying"
 
-instance Hashable VirtualInterfaceState
-instance ToQuery  VirtualInterfaceState
-instance ToHeader VirtualInterfaceState
+instance Hashable     VirtualInterfaceState
+instance ToByteString VirtualInterfaceState
+instance ToPath       VirtualInterfaceState
+instance ToQuery      VirtualInterfaceState
+instance ToHeader     VirtualInterfaceState
 
 instance FromJSON VirtualInterfaceState where
     parseJSON = parseJSONText "VirtualInterfaceState"

--- a/amazonka-ds/amazonka-ds.cabal
+++ b/amazonka-ds/amazonka-ds.cabal
@@ -78,7 +78,7 @@ test-suite amazonka-ds-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-ds == 1.0.0
         , base
         , bytestring

--- a/amazonka-ds/gen/Network/AWS/DirectoryService/Types/Sum.hs
+++ b/amazonka-ds/gen/Network/AWS/DirectoryService/Types/Sum.hs
@@ -36,9 +36,11 @@ instance ToText DirectorySize where
         Large -> "large"
         Small -> "small"
 
-instance Hashable DirectorySize
-instance ToQuery  DirectorySize
-instance ToHeader DirectorySize
+instance Hashable     DirectorySize
+instance ToByteString DirectorySize
+instance ToPath       DirectorySize
+instance ToQuery      DirectorySize
+instance ToHeader     DirectorySize
 
 instance ToJSON DirectorySize where
     toJSON = toJSONText
@@ -90,9 +92,11 @@ instance ToText DirectoryStage where
         DSRestoreFailed -> "restorefailed"
         DSRestoring -> "restoring"
 
-instance Hashable DirectoryStage
-instance ToQuery  DirectoryStage
-instance ToHeader DirectoryStage
+instance Hashable     DirectoryStage
+instance ToByteString DirectoryStage
+instance ToPath       DirectoryStage
+instance ToQuery      DirectoryStage
+instance ToHeader     DirectoryStage
 
 instance FromJSON DirectoryStage where
     parseJSON = parseJSONText "DirectoryStage"
@@ -114,9 +118,11 @@ instance ToText DirectoryType where
         ADConnector -> "adconnector"
         SimpleAD -> "simplead"
 
-instance Hashable DirectoryType
-instance ToQuery  DirectoryType
-instance ToHeader DirectoryType
+instance Hashable     DirectoryType
+instance ToByteString DirectoryType
+instance ToPath       DirectoryType
+instance ToQuery      DirectoryType
+instance ToHeader     DirectoryType
 
 instance FromJSON DirectoryType where
     parseJSON = parseJSONText "DirectoryType"
@@ -144,9 +150,11 @@ instance ToText RadiusAuthenticationProtocol where
         MsCHAPV2 -> "ms-chapv2"
         Pap -> "pap"
 
-instance Hashable RadiusAuthenticationProtocol
-instance ToQuery  RadiusAuthenticationProtocol
-instance ToHeader RadiusAuthenticationProtocol
+instance Hashable     RadiusAuthenticationProtocol
+instance ToByteString RadiusAuthenticationProtocol
+instance ToPath       RadiusAuthenticationProtocol
+instance ToQuery      RadiusAuthenticationProtocol
+instance ToHeader     RadiusAuthenticationProtocol
 
 instance ToJSON RadiusAuthenticationProtocol where
     toJSON = toJSONText
@@ -174,9 +182,11 @@ instance ToText RadiusStatus where
         Creating -> "creating"
         Failed -> "failed"
 
-instance Hashable RadiusStatus
-instance ToQuery  RadiusStatus
-instance ToHeader RadiusStatus
+instance Hashable     RadiusStatus
+instance ToByteString RadiusStatus
+instance ToPath       RadiusStatus
+instance ToQuery      RadiusStatus
+instance ToHeader     RadiusStatus
 
 instance FromJSON RadiusStatus where
     parseJSON = parseJSONText "RadiusStatus"
@@ -201,9 +211,11 @@ instance ToText SnapshotStatus where
         SSCreating -> "creating"
         SSFailed -> "failed"
 
-instance Hashable SnapshotStatus
-instance ToQuery  SnapshotStatus
-instance ToHeader SnapshotStatus
+instance Hashable     SnapshotStatus
+instance ToByteString SnapshotStatus
+instance ToPath       SnapshotStatus
+instance ToQuery      SnapshotStatus
+instance ToHeader     SnapshotStatus
 
 instance FromJSON SnapshotStatus where
     parseJSON = parseJSONText "SnapshotStatus"
@@ -225,9 +237,11 @@ instance ToText SnapshotType where
         Auto -> "auto"
         Manual -> "manual"
 
-instance Hashable SnapshotType
-instance ToQuery  SnapshotType
-instance ToHeader SnapshotType
+instance Hashable     SnapshotType
+instance ToByteString SnapshotType
+instance ToPath       SnapshotType
+instance ToQuery      SnapshotType
+instance ToHeader     SnapshotType
 
 instance FromJSON SnapshotType where
     parseJSON = parseJSONText "SnapshotType"

--- a/amazonka-dynamodb-streams/amazonka-dynamodb-streams.cabal
+++ b/amazonka-dynamodb-streams/amazonka-dynamodb-streams.cabal
@@ -88,7 +88,7 @@ test-suite amazonka-dynamodb-streams-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-dynamodb-streams == 1.0.0
         , base
         , bytestring

--- a/amazonka-dynamodb-streams/gen/Network/AWS/DynamoDBStreams/Types/Sum.hs
+++ b/amazonka-dynamodb-streams/gen/Network/AWS/DynamoDBStreams/Types/Sum.hs
@@ -36,9 +36,11 @@ instance ToText KeyType where
         Hash -> "hash"
         Range -> "range"
 
-instance Hashable KeyType
-instance ToQuery  KeyType
-instance ToHeader KeyType
+instance Hashable     KeyType
+instance ToByteString KeyType
+instance ToPath       KeyType
+instance ToQuery      KeyType
+instance ToHeader     KeyType
 
 instance FromJSON KeyType where
     parseJSON = parseJSONText "KeyType"
@@ -63,9 +65,11 @@ instance ToText OperationType where
         Modify -> "modify"
         Remove -> "remove"
 
-instance Hashable OperationType
-instance ToQuery  OperationType
-instance ToHeader OperationType
+instance Hashable     OperationType
+instance ToByteString OperationType
+instance ToPath       OperationType
+instance ToQuery      OperationType
+instance ToHeader     OperationType
 
 instance FromJSON OperationType where
     parseJSON = parseJSONText "OperationType"
@@ -93,9 +97,11 @@ instance ToText ShardIteratorType where
         Latest -> "latest"
         TrimHorizon -> "trim_horizon"
 
-instance Hashable ShardIteratorType
-instance ToQuery  ShardIteratorType
-instance ToHeader ShardIteratorType
+instance Hashable     ShardIteratorType
+instance ToByteString ShardIteratorType
+instance ToPath       ShardIteratorType
+instance ToQuery      ShardIteratorType
+instance ToHeader     ShardIteratorType
 
 instance ToJSON ShardIteratorType where
     toJSON = toJSONText
@@ -123,9 +129,11 @@ instance ToText StreamStatus where
         Enabled -> "enabled"
         Enabling -> "enabling"
 
-instance Hashable StreamStatus
-instance ToQuery  StreamStatus
-instance ToHeader StreamStatus
+instance Hashable     StreamStatus
+instance ToByteString StreamStatus
+instance ToPath       StreamStatus
+instance ToQuery      StreamStatus
+instance ToHeader     StreamStatus
 
 instance FromJSON StreamStatus where
     parseJSON = parseJSONText "StreamStatus"
@@ -153,9 +161,11 @@ instance ToText StreamViewType where
         NewImage -> "new_image"
         OldImage -> "old_image"
 
-instance Hashable StreamViewType
-instance ToQuery  StreamViewType
-instance ToHeader StreamViewType
+instance Hashable     StreamViewType
+instance ToByteString StreamViewType
+instance ToPath       StreamViewType
+instance ToQuery      StreamViewType
+instance ToHeader     StreamViewType
 
 instance FromJSON StreamViewType where
     parseJSON = parseJSONText "StreamViewType"

--- a/amazonka-dynamodb/amazonka-dynamodb.cabal
+++ b/amazonka-dynamodb/amazonka-dynamodb.cabal
@@ -184,7 +184,7 @@ test-suite amazonka-dynamodb-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-dynamodb == 1.0.0
         , base
         , bytestring

--- a/amazonka-dynamodb/gen/Network/AWS/DynamoDB/Types/Sum.hs
+++ b/amazonka-dynamodb/gen/Network/AWS/DynamoDB/Types/Sum.hs
@@ -39,9 +39,11 @@ instance ToText AttributeAction where
         Delete -> "delete"
         Put -> "put"
 
-instance Hashable AttributeAction
-instance ToQuery  AttributeAction
-instance ToHeader AttributeAction
+instance Hashable     AttributeAction
+instance ToByteString AttributeAction
+instance ToPath       AttributeAction
+instance ToQuery      AttributeAction
+instance ToHeader     AttributeAction
 
 instance ToJSON AttributeAction where
     toJSON = toJSONText
@@ -96,9 +98,11 @@ instance ToText ComparisonOperator where
         NotNull -> "not_null"
         Null -> "null"
 
-instance Hashable ComparisonOperator
-instance ToQuery  ComparisonOperator
-instance ToHeader ComparisonOperator
+instance Hashable     ComparisonOperator
+instance ToByteString ComparisonOperator
+instance ToPath       ComparisonOperator
+instance ToQuery      ComparisonOperator
+instance ToHeader     ComparisonOperator
 
 instance ToJSON ComparisonOperator where
     toJSON = toJSONText
@@ -120,9 +124,11 @@ instance ToText ConditionalOperator where
         And -> "and"
         OR -> "or"
 
-instance Hashable ConditionalOperator
-instance ToQuery  ConditionalOperator
-instance ToHeader ConditionalOperator
+instance Hashable     ConditionalOperator
+instance ToByteString ConditionalOperator
+instance ToPath       ConditionalOperator
+instance ToQuery      ConditionalOperator
+instance ToHeader     ConditionalOperator
 
 instance ToJSON ConditionalOperator where
     toJSON = toJSONText
@@ -150,9 +156,11 @@ instance ToText IndexStatus where
         ISDeleting -> "deleting"
         ISUpdating -> "updating"
 
-instance Hashable IndexStatus
-instance ToQuery  IndexStatus
-instance ToHeader IndexStatus
+instance Hashable     IndexStatus
+instance ToByteString IndexStatus
+instance ToPath       IndexStatus
+instance ToQuery      IndexStatus
+instance ToHeader     IndexStatus
 
 instance FromJSON IndexStatus where
     parseJSON = parseJSONText "IndexStatus"
@@ -174,9 +182,11 @@ instance ToText KeyType where
         Hash -> "hash"
         Range -> "range"
 
-instance Hashable KeyType
-instance ToQuery  KeyType
-instance ToHeader KeyType
+instance Hashable     KeyType
+instance ToByteString KeyType
+instance ToPath       KeyType
+instance ToQuery      KeyType
+instance ToHeader     KeyType
 
 instance ToJSON KeyType where
     toJSON = toJSONText
@@ -204,9 +214,11 @@ instance ToText ProjectionType where
         Include -> "include"
         KeysOnly -> "keys_only"
 
-instance Hashable ProjectionType
-instance ToQuery  ProjectionType
-instance ToHeader ProjectionType
+instance Hashable     ProjectionType
+instance ToByteString ProjectionType
+instance ToPath       ProjectionType
+instance ToQuery      ProjectionType
+instance ToHeader     ProjectionType
 
 instance ToJSON ProjectionType where
     toJSON = toJSONText
@@ -250,9 +262,11 @@ instance ToText ReturnConsumedCapacity where
         RCCNone -> "none"
         RCCTotal -> "total"
 
-instance Hashable ReturnConsumedCapacity
-instance ToQuery  ReturnConsumedCapacity
-instance ToHeader ReturnConsumedCapacity
+instance Hashable     ReturnConsumedCapacity
+instance ToByteString ReturnConsumedCapacity
+instance ToPath       ReturnConsumedCapacity
+instance ToQuery      ReturnConsumedCapacity
+instance ToHeader     ReturnConsumedCapacity
 
 instance ToJSON ReturnConsumedCapacity where
     toJSON = toJSONText
@@ -274,9 +288,11 @@ instance ToText ReturnItemCollectionMetrics where
         RICMNone -> "none"
         RICMSize -> "size"
 
-instance Hashable ReturnItemCollectionMetrics
-instance ToQuery  ReturnItemCollectionMetrics
-instance ToHeader ReturnItemCollectionMetrics
+instance Hashable     ReturnItemCollectionMetrics
+instance ToByteString ReturnItemCollectionMetrics
+instance ToPath       ReturnItemCollectionMetrics
+instance ToQuery      ReturnItemCollectionMetrics
+instance ToHeader     ReturnItemCollectionMetrics
 
 instance ToJSON ReturnItemCollectionMetrics where
     toJSON = toJSONText
@@ -307,9 +323,11 @@ instance ToText ReturnValue where
         UpdatedNew -> "updated_new"
         UpdatedOld -> "updated_old"
 
-instance Hashable ReturnValue
-instance ToQuery  ReturnValue
-instance ToHeader ReturnValue
+instance Hashable     ReturnValue
+instance ToByteString ReturnValue
+instance ToPath       ReturnValue
+instance ToQuery      ReturnValue
+instance ToHeader     ReturnValue
 
 instance ToJSON ReturnValue where
     toJSON = toJSONText
@@ -334,9 +352,11 @@ instance ToText ScalarAttributeType where
         N -> "n"
         S -> "s"
 
-instance Hashable ScalarAttributeType
-instance ToQuery  ScalarAttributeType
-instance ToHeader ScalarAttributeType
+instance Hashable     ScalarAttributeType
+instance ToByteString ScalarAttributeType
+instance ToPath       ScalarAttributeType
+instance ToQuery      ScalarAttributeType
+instance ToHeader     ScalarAttributeType
 
 instance ToJSON ScalarAttributeType where
     toJSON = toJSONText
@@ -367,9 +387,11 @@ instance ToText Select where
         Count -> "count"
         SpecificAttributes -> "specific_attributes"
 
-instance Hashable Select
-instance ToQuery  Select
-instance ToHeader Select
+instance Hashable     Select
+instance ToByteString Select
+instance ToPath       Select
+instance ToQuery      Select
+instance ToHeader     Select
 
 instance ToJSON Select where
     toJSON = toJSONText
@@ -397,9 +419,11 @@ instance ToText StreamViewType where
         SVTNewImage -> "new_image"
         SVTOldImage -> "old_image"
 
-instance Hashable StreamViewType
-instance ToQuery  StreamViewType
-instance ToHeader StreamViewType
+instance Hashable     StreamViewType
+instance ToByteString StreamViewType
+instance ToPath       StreamViewType
+instance ToQuery      StreamViewType
+instance ToHeader     StreamViewType
 
 instance ToJSON StreamViewType where
     toJSON = toJSONText
@@ -430,9 +454,11 @@ instance ToText TableStatus where
         Deleting -> "deleting"
         Updating -> "updating"
 
-instance Hashable TableStatus
-instance ToQuery  TableStatus
-instance ToHeader TableStatus
+instance Hashable     TableStatus
+instance ToByteString TableStatus
+instance ToPath       TableStatus
+instance ToQuery      TableStatus
+instance ToHeader     TableStatus
 
 instance FromJSON TableStatus where
     parseJSON = parseJSONText "TableStatus"

--- a/amazonka-ec2/amazonka-ec2.cabal
+++ b/amazonka-ec2/amazonka-ec2.cabal
@@ -244,7 +244,7 @@ test-suite amazonka-ec2-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-ec2 == 1.0.0
         , base
         , bytestring

--- a/amazonka-ec2/gen/Network/AWS/EC2/Types/Sum.hs
+++ b/amazonka-ec2/gen/Network/AWS/EC2/Types/Sum.hs
@@ -36,9 +36,11 @@ instance ToText AccountAttributeName where
         DefaultVPC -> "default-vpc"
         SupportedPlatforms -> "supported-platforms"
 
-instance Hashable AccountAttributeName
-instance ToQuery  AccountAttributeName
-instance ToHeader AccountAttributeName
+instance Hashable     AccountAttributeName
+instance ToByteString AccountAttributeName
+instance ToPath       AccountAttributeName
+instance ToQuery      AccountAttributeName
+instance ToHeader     AccountAttributeName
 
 data AddressStatus
     = MoveInProgress
@@ -60,9 +62,11 @@ instance ToText AddressStatus where
         InVPC -> "invpc"
         MoveInProgress -> "moveinprogress"
 
-instance Hashable AddressStatus
-instance ToQuery  AddressStatus
-instance ToHeader AddressStatus
+instance Hashable     AddressStatus
+instance ToByteString AddressStatus
+instance ToPath       AddressStatus
+instance ToQuery      AddressStatus
+instance ToHeader     AddressStatus
 
 instance FromXML AddressStatus where
     parseXML = parseXMLText "AddressStatus"
@@ -84,9 +88,11 @@ instance ToText ArchitectureValues where
         I386 -> "i386"
         X86_64 -> "x86_64"
 
-instance Hashable ArchitectureValues
-instance ToQuery  ArchitectureValues
-instance ToHeader ArchitectureValues
+instance Hashable     ArchitectureValues
+instance ToByteString ArchitectureValues
+instance ToPath       ArchitectureValues
+instance ToQuery      ArchitectureValues
+instance ToHeader     ArchitectureValues
 
 instance FromXML ArchitectureValues where
     parseXML = parseXMLText "ArchitectureValues"
@@ -114,9 +120,11 @@ instance ToText AttachmentStatus where
         Detached -> "detached"
         Detaching -> "detaching"
 
-instance Hashable AttachmentStatus
-instance ToQuery  AttachmentStatus
-instance ToHeader AttachmentStatus
+instance Hashable     AttachmentStatus
+instance ToByteString AttachmentStatus
+instance ToPath       AttachmentStatus
+instance ToQuery      AttachmentStatus
+instance ToHeader     AttachmentStatus
 
 instance FromXML AttachmentStatus where
     parseXML = parseXMLText "AttachmentStatus"
@@ -135,9 +143,11 @@ instance ToText AvailabilityZoneState where
     toText = \case
         AZSAvailable -> "available"
 
-instance Hashable AvailabilityZoneState
-instance ToQuery  AvailabilityZoneState
-instance ToHeader AvailabilityZoneState
+instance Hashable     AvailabilityZoneState
+instance ToByteString AvailabilityZoneState
+instance ToPath       AvailabilityZoneState
+instance ToQuery      AvailabilityZoneState
+instance ToHeader     AvailabilityZoneState
 
 instance FromXML AvailabilityZoneState where
     parseXML = parseXMLText "AvailabilityZoneState"
@@ -171,9 +181,11 @@ instance ToText BatchState where
         BSFailed -> "failed"
         BSSubmitted -> "submitted"
 
-instance Hashable BatchState
-instance ToQuery  BatchState
-instance ToHeader BatchState
+instance Hashable     BatchState
+instance ToByteString BatchState
+instance ToPath       BatchState
+instance ToQuery      BatchState
+instance ToHeader     BatchState
 
 instance FromXML BatchState where
     parseXML = parseXMLText "BatchState"
@@ -210,9 +222,11 @@ instance ToText BundleTaskState where
         BTSStoring -> "storing"
         BTSWaitingForShutdown -> "waiting-for-shutdown"
 
-instance Hashable BundleTaskState
-instance ToQuery  BundleTaskState
-instance ToHeader BundleTaskState
+instance Hashable     BundleTaskState
+instance ToByteString BundleTaskState
+instance ToPath       BundleTaskState
+instance ToQuery      BundleTaskState
+instance ToHeader     BundleTaskState
 
 instance FromXML BundleTaskState where
     parseXML = parseXMLText "BundleTaskState"
@@ -240,9 +254,11 @@ instance ToText CancelBatchErrorCode where
         FleetRequestNotInCancellableState -> "fleetrequestnotincancellablestate"
         UnexpectedError -> "unexpectederror"
 
-instance Hashable CancelBatchErrorCode
-instance ToQuery  CancelBatchErrorCode
-instance ToHeader CancelBatchErrorCode
+instance Hashable     CancelBatchErrorCode
+instance ToByteString CancelBatchErrorCode
+instance ToPath       CancelBatchErrorCode
+instance ToQuery      CancelBatchErrorCode
+instance ToHeader     CancelBatchErrorCode
 
 instance FromXML CancelBatchErrorCode where
     parseXML = parseXMLText "CancelBatchErrorCode"
@@ -273,9 +289,11 @@ instance ToText CancelSpotInstanceRequestState where
         CSIRSCompleted -> "completed"
         CSIRSOpen -> "open"
 
-instance Hashable CancelSpotInstanceRequestState
-instance ToQuery  CancelSpotInstanceRequestState
-instance ToHeader CancelSpotInstanceRequestState
+instance Hashable     CancelSpotInstanceRequestState
+instance ToByteString CancelSpotInstanceRequestState
+instance ToPath       CancelSpotInstanceRequestState
+instance ToQuery      CancelSpotInstanceRequestState
+instance ToHeader     CancelSpotInstanceRequestState
 
 instance FromXML CancelSpotInstanceRequestState where
     parseXML = parseXMLText "CancelSpotInstanceRequestState"
@@ -294,9 +312,11 @@ instance ToText ContainerFormat where
     toText = \case
         Ova -> "ova"
 
-instance Hashable ContainerFormat
-instance ToQuery  ContainerFormat
-instance ToHeader ContainerFormat
+instance Hashable     ContainerFormat
+instance ToByteString ContainerFormat
+instance ToPath       ContainerFormat
+instance ToQuery      ContainerFormat
+instance ToHeader     ContainerFormat
 
 instance FromXML ContainerFormat where
     parseXML = parseXMLText "ContainerFormat"
@@ -324,9 +344,11 @@ instance ToText ConversionTaskState where
         CTSCancelling -> "cancelling"
         CTSCompleted -> "completed"
 
-instance Hashable ConversionTaskState
-instance ToQuery  ConversionTaskState
-instance ToHeader ConversionTaskState
+instance Hashable     ConversionTaskState
+instance ToByteString ConversionTaskState
+instance ToPath       ConversionTaskState
+instance ToQuery      ConversionTaskState
+instance ToHeader     ConversionTaskState
 
 instance FromXML ConversionTaskState where
     parseXML = parseXMLText "ConversionTaskState"
@@ -345,9 +367,11 @@ instance ToText CurrencyCodeValues where
     toText = \case
         Usd -> "usd"
 
-instance Hashable CurrencyCodeValues
-instance ToQuery  CurrencyCodeValues
-instance ToHeader CurrencyCodeValues
+instance Hashable     CurrencyCodeValues
+instance ToByteString CurrencyCodeValues
+instance ToPath       CurrencyCodeValues
+instance ToQuery      CurrencyCodeValues
+instance ToHeader     CurrencyCodeValues
 
 instance FromXML CurrencyCodeValues where
     parseXML = parseXMLText "CurrencyCodeValues"
@@ -369,9 +393,11 @@ instance ToText DatafeedSubscriptionState where
         DSSActive -> "active"
         DSSInactive -> "inactive"
 
-instance Hashable DatafeedSubscriptionState
-instance ToQuery  DatafeedSubscriptionState
-instance ToHeader DatafeedSubscriptionState
+instance Hashable     DatafeedSubscriptionState
+instance ToByteString DatafeedSubscriptionState
+instance ToPath       DatafeedSubscriptionState
+instance ToQuery      DatafeedSubscriptionState
+instance ToHeader     DatafeedSubscriptionState
 
 instance FromXML DatafeedSubscriptionState where
     parseXML = parseXMLText "DatafeedSubscriptionState"
@@ -393,9 +419,11 @@ instance ToText DeviceType where
         EBS -> "ebs"
         InstanceStore -> "instance-store"
 
-instance Hashable DeviceType
-instance ToQuery  DeviceType
-instance ToHeader DeviceType
+instance Hashable     DeviceType
+instance ToByteString DeviceType
+instance ToPath       DeviceType
+instance ToQuery      DeviceType
+instance ToHeader     DeviceType
 
 instance FromXML DeviceType where
     parseXML = parseXMLText "DeviceType"
@@ -420,9 +448,11 @@ instance ToText DiskImageFormat where
         VHD -> "vhd"
         VMDK -> "vmdk"
 
-instance Hashable DiskImageFormat
-instance ToQuery  DiskImageFormat
-instance ToHeader DiskImageFormat
+instance Hashable     DiskImageFormat
+instance ToByteString DiskImageFormat
+instance ToPath       DiskImageFormat
+instance ToQuery      DiskImageFormat
+instance ToHeader     DiskImageFormat
 
 instance FromXML DiskImageFormat where
     parseXML = parseXMLText "DiskImageFormat"
@@ -444,9 +474,11 @@ instance ToText DomainType where
         DTStandard -> "standard"
         DTVPC -> "vpc"
 
-instance Hashable DomainType
-instance ToQuery  DomainType
-instance ToHeader DomainType
+instance Hashable     DomainType
+instance ToByteString DomainType
+instance ToPath       DomainType
+instance ToQuery      DomainType
+instance ToHeader     DomainType
 
 instance FromXML DomainType where
     parseXML = parseXMLText "DomainType"
@@ -477,9 +509,11 @@ instance ToText EventCode where
         SystemMaintenance -> "system-maintenance"
         SystemReboot -> "system-reboot"
 
-instance Hashable EventCode
-instance ToQuery  EventCode
-instance ToHeader EventCode
+instance Hashable     EventCode
+instance ToByteString EventCode
+instance ToPath       EventCode
+instance ToQuery      EventCode
+instance ToHeader     EventCode
 
 instance FromXML EventCode where
     parseXML = parseXMLText "EventCode"
@@ -504,9 +538,11 @@ instance ToText EventType where
         FleetRequestChange -> "fleetrequestchange"
         InstanceChange -> "instancechange"
 
-instance Hashable EventType
-instance ToQuery  EventType
-instance ToHeader EventType
+instance Hashable     EventType
+instance ToByteString EventType
+instance ToPath       EventType
+instance ToQuery      EventType
+instance ToHeader     EventType
 
 instance FromXML EventType where
     parseXML = parseXMLText "EventType"
@@ -531,9 +567,11 @@ instance ToText ExportEnvironment where
         Microsoft -> "microsoft"
         VMware -> "vmware"
 
-instance Hashable ExportEnvironment
-instance ToQuery  ExportEnvironment
-instance ToHeader ExportEnvironment
+instance Hashable     ExportEnvironment
+instance ToByteString ExportEnvironment
+instance ToPath       ExportEnvironment
+instance ToQuery      ExportEnvironment
+instance ToHeader     ExportEnvironment
 
 instance FromXML ExportEnvironment where
     parseXML = parseXMLText "ExportEnvironment"
@@ -561,9 +599,11 @@ instance ToText ExportTaskState where
         ETSCancelling -> "cancelling"
         ETSCompleted -> "completed"
 
-instance Hashable ExportTaskState
-instance ToQuery  ExportTaskState
-instance ToHeader ExportTaskState
+instance Hashable     ExportTaskState
+instance ToByteString ExportTaskState
+instance ToPath       ExportTaskState
+instance ToQuery      ExportTaskState
+instance ToHeader     ExportTaskState
 
 instance FromXML ExportTaskState where
     parseXML = parseXMLText "ExportTaskState"
@@ -588,9 +628,11 @@ instance ToText FlowLogsResourceType where
         FLRTSubnet -> "subnet"
         FLRTVPC -> "vpc"
 
-instance Hashable FlowLogsResourceType
-instance ToQuery  FlowLogsResourceType
-instance ToHeader FlowLogsResourceType
+instance Hashable     FlowLogsResourceType
+instance ToByteString FlowLogsResourceType
+instance ToPath       FlowLogsResourceType
+instance ToQuery      FlowLogsResourceType
+instance ToHeader     FlowLogsResourceType
 
 data GatewayType =
     IPsec_1
@@ -606,9 +648,11 @@ instance ToText GatewayType where
     toText = \case
         IPsec_1 -> "ipsec.1"
 
-instance Hashable GatewayType
-instance ToQuery  GatewayType
-instance ToHeader GatewayType
+instance Hashable     GatewayType
+instance ToByteString GatewayType
+instance ToPath       GatewayType
+instance ToQuery      GatewayType
+instance ToHeader     GatewayType
 
 instance FromXML GatewayType where
     parseXML = parseXMLText "GatewayType"
@@ -630,9 +674,11 @@ instance ToText HypervisorType where
         Ovm -> "ovm"
         Xen -> "xen"
 
-instance Hashable HypervisorType
-instance ToQuery  HypervisorType
-instance ToHeader HypervisorType
+instance Hashable     HypervisorType
+instance ToByteString HypervisorType
+instance ToPath       HypervisorType
+instance ToQuery      HypervisorType
+instance ToHeader     HypervisorType
 
 instance FromXML HypervisorType where
     parseXML = parseXMLText "HypervisorType"
@@ -669,9 +715,11 @@ instance ToText ImageAttributeName where
         RAMDisk -> "ramdisk"
         SRIOVNetSupport -> "sriovnetsupport"
 
-instance Hashable ImageAttributeName
-instance ToQuery  ImageAttributeName
-instance ToHeader ImageAttributeName
+instance Hashable     ImageAttributeName
+instance ToByteString ImageAttributeName
+instance ToPath       ImageAttributeName
+instance ToQuery      ImageAttributeName
+instance ToHeader     ImageAttributeName
 
 data ImageState
     = ISAvailable
@@ -705,9 +753,11 @@ instance ToText ImageState where
         ISPending -> "pending"
         ISTransient -> "transient"
 
-instance Hashable ImageState
-instance ToQuery  ImageState
-instance ToHeader ImageState
+instance Hashable     ImageState
+instance ToByteString ImageState
+instance ToPath       ImageState
+instance ToQuery      ImageState
+instance ToHeader     ImageState
 
 instance FromXML ImageState where
     parseXML = parseXMLText "ImageState"
@@ -732,9 +782,11 @@ instance ToText ImageTypeValues where
         ITVMachine -> "machine"
         ITVRAMDisk -> "ramdisk"
 
-instance Hashable ImageTypeValues
-instance ToQuery  ImageTypeValues
-instance ToHeader ImageTypeValues
+instance Hashable     ImageTypeValues
+instance ToByteString ImageTypeValues
+instance ToPath       ImageTypeValues
+instance ToQuery      ImageTypeValues
+instance ToHeader     ImageTypeValues
 
 instance FromXML ImageTypeValues where
     parseXML = parseXMLText "ImageTypeValues"
@@ -789,9 +841,11 @@ instance ToText InstanceAttributeName where
         IANSourceDestCheck -> "sourcedestcheck"
         IANUserData -> "userdata"
 
-instance Hashable InstanceAttributeName
-instance ToQuery  InstanceAttributeName
-instance ToHeader InstanceAttributeName
+instance Hashable     InstanceAttributeName
+instance ToByteString InstanceAttributeName
+instance ToPath       InstanceAttributeName
+instance ToQuery      InstanceAttributeName
+instance ToHeader     InstanceAttributeName
 
 data InstanceLifecycleType =
     Spot
@@ -807,9 +861,11 @@ instance ToText InstanceLifecycleType where
     toText = \case
         Spot -> "spot"
 
-instance Hashable InstanceLifecycleType
-instance ToQuery  InstanceLifecycleType
-instance ToHeader InstanceLifecycleType
+instance Hashable     InstanceLifecycleType
+instance ToByteString InstanceLifecycleType
+instance ToPath       InstanceLifecycleType
+instance ToQuery      InstanceLifecycleType
+instance ToHeader     InstanceLifecycleType
 
 instance FromXML InstanceLifecycleType where
     parseXML = parseXMLText "InstanceLifecycleType"
@@ -843,9 +899,11 @@ instance ToText InstanceStateName where
         ISNStopping -> "stopping"
         ISNTerminated -> "terminated"
 
-instance Hashable InstanceStateName
-instance ToQuery  InstanceStateName
-instance ToHeader InstanceStateName
+instance Hashable     InstanceStateName
+instance ToByteString InstanceStateName
+instance ToPath       InstanceStateName
+instance ToQuery      InstanceStateName
+instance ToHeader     InstanceStateName
 
 instance FromXML InstanceStateName where
     parseXML = parseXMLText "InstanceStateName"
@@ -1020,9 +1078,11 @@ instance ToText InstanceType where
         T2_Micro -> "t2.micro"
         T2_Small -> "t2.small"
 
-instance Hashable InstanceType
-instance ToQuery  InstanceType
-instance ToHeader InstanceType
+instance Hashable     InstanceType
+instance ToByteString InstanceType
+instance ToPath       InstanceType
+instance ToQuery      InstanceType
+instance ToHeader     InstanceType
 
 instance FromXML InstanceType where
     parseXML = parseXMLText "InstanceType"
@@ -1050,9 +1110,11 @@ instance ToText ListingState where
         LPending -> "pending"
         LSold -> "sold"
 
-instance Hashable ListingState
-instance ToQuery  ListingState
-instance ToHeader ListingState
+instance Hashable     ListingState
+instance ToByteString ListingState
+instance ToPath       ListingState
+instance ToQuery      ListingState
+instance ToHeader     ListingState
 
 instance FromXML ListingState where
     parseXML = parseXMLText "ListingState"
@@ -1080,9 +1142,11 @@ instance ToText ListingStatus where
         LSClosed -> "closed"
         LSPending -> "pending"
 
-instance Hashable ListingStatus
-instance ToQuery  ListingStatus
-instance ToHeader ListingStatus
+instance Hashable     ListingStatus
+instance ToByteString ListingStatus
+instance ToPath       ListingStatus
+instance ToQuery      ListingStatus
+instance ToHeader     ListingStatus
 
 instance FromXML ListingStatus where
     parseXML = parseXMLText "ListingStatus"
@@ -1110,9 +1174,11 @@ instance ToText MonitoringState where
         MSEnabled -> "enabled"
         MSPending -> "pending"
 
-instance Hashable MonitoringState
-instance ToQuery  MonitoringState
-instance ToHeader MonitoringState
+instance Hashable     MonitoringState
+instance ToByteString MonitoringState
+instance ToPath       MonitoringState
+instance ToQuery      MonitoringState
+instance ToHeader     MonitoringState
 
 instance FromXML MonitoringState where
     parseXML = parseXMLText "MonitoringState"
@@ -1134,9 +1200,11 @@ instance ToText MoveStatus where
         MovingToVPC -> "movingtovpc"
         RestoringToClassic -> "restoringtoclassic"
 
-instance Hashable MoveStatus
-instance ToQuery  MoveStatus
-instance ToHeader MoveStatus
+instance Hashable     MoveStatus
+instance ToByteString MoveStatus
+instance ToPath       MoveStatus
+instance ToQuery      MoveStatus
+instance ToHeader     MoveStatus
 
 instance FromXML MoveStatus where
     parseXML = parseXMLText "MoveStatus"
@@ -1164,9 +1232,11 @@ instance ToText NetworkInterfaceAttribute where
         NIAGroupSet -> "groupset"
         NIASourceDestCheck -> "sourcedestcheck"
 
-instance Hashable NetworkInterfaceAttribute
-instance ToQuery  NetworkInterfaceAttribute
-instance ToHeader NetworkInterfaceAttribute
+instance Hashable     NetworkInterfaceAttribute
+instance ToByteString NetworkInterfaceAttribute
+instance ToPath       NetworkInterfaceAttribute
+instance ToQuery      NetworkInterfaceAttribute
+instance ToHeader     NetworkInterfaceAttribute
 
 data NetworkInterfaceStatus
     = NISInUse
@@ -1191,9 +1261,11 @@ instance ToText NetworkInterfaceStatus where
         NISDetaching -> "detaching"
         NISInUse -> "in-use"
 
-instance Hashable NetworkInterfaceStatus
-instance ToQuery  NetworkInterfaceStatus
-instance ToHeader NetworkInterfaceStatus
+instance Hashable     NetworkInterfaceStatus
+instance ToByteString NetworkInterfaceStatus
+instance ToPath       NetworkInterfaceStatus
+instance ToQuery      NetworkInterfaceStatus
+instance ToHeader     NetworkInterfaceStatus
 
 instance FromXML NetworkInterfaceStatus where
     parseXML = parseXMLText "NetworkInterfaceStatus"
@@ -1227,9 +1299,11 @@ instance ToText OfferingTypeValues where
         NoUpfront -> "no upfront"
         PartialUpfront -> "partial upfront"
 
-instance Hashable OfferingTypeValues
-instance ToQuery  OfferingTypeValues
-instance ToHeader OfferingTypeValues
+instance Hashable     OfferingTypeValues
+instance ToByteString OfferingTypeValues
+instance ToPath       OfferingTypeValues
+instance ToQuery      OfferingTypeValues
+instance ToHeader     OfferingTypeValues
 
 instance FromXML OfferingTypeValues where
     parseXML = parseXMLText "OfferingTypeValues"
@@ -1248,9 +1322,11 @@ instance ToText PermissionGroup where
     toText = \case
         PGAll -> "all"
 
-instance Hashable PermissionGroup
-instance ToQuery  PermissionGroup
-instance ToHeader PermissionGroup
+instance Hashable     PermissionGroup
+instance ToByteString PermissionGroup
+instance ToPath       PermissionGroup
+instance ToQuery      PermissionGroup
+instance ToHeader     PermissionGroup
 
 instance FromXML PermissionGroup where
     parseXML = parseXMLText "PermissionGroup"
@@ -1278,9 +1354,11 @@ instance ToText PlacementGroupState where
         PGSDeleting -> "deleting"
         PGSPending -> "pending"
 
-instance Hashable PlacementGroupState
-instance ToQuery  PlacementGroupState
-instance ToHeader PlacementGroupState
+instance Hashable     PlacementGroupState
+instance ToByteString PlacementGroupState
+instance ToPath       PlacementGroupState
+instance ToQuery      PlacementGroupState
+instance ToHeader     PlacementGroupState
 
 instance FromXML PlacementGroupState where
     parseXML = parseXMLText "PlacementGroupState"
@@ -1299,9 +1377,11 @@ instance ToText PlacementStrategy where
     toText = \case
         Cluster -> "cluster"
 
-instance Hashable PlacementStrategy
-instance ToQuery  PlacementStrategy
-instance ToHeader PlacementStrategy
+instance Hashable     PlacementStrategy
+instance ToByteString PlacementStrategy
+instance ToPath       PlacementStrategy
+instance ToQuery      PlacementStrategy
+instance ToHeader     PlacementStrategy
 
 instance FromXML PlacementStrategy where
     parseXML = parseXMLText "PlacementStrategy"
@@ -1320,9 +1400,11 @@ instance ToText PlatformValues where
     toText = \case
         PVWindows -> "windows"
 
-instance Hashable PlatformValues
-instance ToQuery  PlatformValues
-instance ToHeader PlatformValues
+instance Hashable     PlatformValues
+instance ToByteString PlatformValues
+instance ToPath       PlatformValues
+instance ToQuery      PlatformValues
+instance ToHeader     PlatformValues
 
 instance FromXML PlatformValues where
     parseXML = parseXMLText "PlatformValues"
@@ -1344,9 +1426,11 @@ instance ToText ProductCodeValues where
         Devpay -> "devpay"
         Marketplace -> "marketplace"
 
-instance Hashable ProductCodeValues
-instance ToQuery  ProductCodeValues
-instance ToHeader ProductCodeValues
+instance Hashable     ProductCodeValues
+instance ToByteString ProductCodeValues
+instance ToPath       ProductCodeValues
+instance ToQuery      ProductCodeValues
+instance ToHeader     ProductCodeValues
 
 instance FromXML ProductCodeValues where
     parseXML = parseXMLText "ProductCodeValues"
@@ -1374,9 +1458,11 @@ instance ToText RIProductDescription where
         Windows -> "windows"
         WindowsAmazonVPC -> "windows (amazon vpc)"
 
-instance Hashable RIProductDescription
-instance ToQuery  RIProductDescription
-instance ToHeader RIProductDescription
+instance Hashable     RIProductDescription
+instance ToByteString RIProductDescription
+instance ToPath       RIProductDescription
+instance ToQuery      RIProductDescription
+instance ToHeader     RIProductDescription
 
 instance FromXML RIProductDescription where
     parseXML = parseXMLText "RIProductDescription"
@@ -1395,9 +1481,11 @@ instance ToText RecurringChargeFrequency where
     toText = \case
         Hourly -> "hourly"
 
-instance Hashable RecurringChargeFrequency
-instance ToQuery  RecurringChargeFrequency
-instance ToHeader RecurringChargeFrequency
+instance Hashable     RecurringChargeFrequency
+instance ToByteString RecurringChargeFrequency
+instance ToPath       RecurringChargeFrequency
+instance ToQuery      RecurringChargeFrequency
+instance ToHeader     RecurringChargeFrequency
 
 instance FromXML RecurringChargeFrequency where
     parseXML = parseXMLText "RecurringChargeFrequency"
@@ -1440,9 +1528,11 @@ instance ToText ReportInstanceReasonCodes where
         PerformanceOther -> "performance-other"
         Unresponsive -> "unresponsive"
 
-instance Hashable ReportInstanceReasonCodes
-instance ToQuery  ReportInstanceReasonCodes
-instance ToHeader ReportInstanceReasonCodes
+instance Hashable     ReportInstanceReasonCodes
+instance ToByteString ReportInstanceReasonCodes
+instance ToPath       ReportInstanceReasonCodes
+instance ToQuery      ReportInstanceReasonCodes
+instance ToHeader     ReportInstanceReasonCodes
 
 data ReportStatusType
     = OK
@@ -1461,9 +1551,11 @@ instance ToText ReportStatusType where
         Impaired -> "impaired"
         OK -> "ok"
 
-instance Hashable ReportStatusType
-instance ToQuery  ReportStatusType
-instance ToHeader ReportStatusType
+instance Hashable     ReportStatusType
+instance ToByteString ReportStatusType
+instance ToPath       ReportStatusType
+instance ToQuery      ReportStatusType
+instance ToHeader     ReportStatusType
 
 data ReservedInstanceState
     = PaymentPending
@@ -1488,9 +1580,11 @@ instance ToText ReservedInstanceState where
         PaymentPending -> "payment-pending"
         Retired -> "retired"
 
-instance Hashable ReservedInstanceState
-instance ToQuery  ReservedInstanceState
-instance ToHeader ReservedInstanceState
+instance Hashable     ReservedInstanceState
+instance ToByteString ReservedInstanceState
+instance ToPath       ReservedInstanceState
+instance ToQuery      ReservedInstanceState
+instance ToHeader     ReservedInstanceState
 
 instance FromXML ReservedInstanceState where
     parseXML = parseXMLText "ReservedInstanceState"
@@ -1509,9 +1603,11 @@ instance ToText ResetImageAttributeName where
     toText = \case
         RIANLaunchPermission -> "launchpermission"
 
-instance Hashable ResetImageAttributeName
-instance ToQuery  ResetImageAttributeName
-instance ToHeader ResetImageAttributeName
+instance Hashable     ResetImageAttributeName
+instance ToByteString ResetImageAttributeName
+instance ToPath       ResetImageAttributeName
+instance ToQuery      ResetImageAttributeName
+instance ToHeader     ResetImageAttributeName
 
 data ResourceType
     = Snapshot
@@ -1575,9 +1671,11 @@ instance ToText ResourceType where
         VPNGateway -> "vpn-gateway"
         Volume -> "volume"
 
-instance Hashable ResourceType
-instance ToQuery  ResourceType
-instance ToHeader ResourceType
+instance Hashable     ResourceType
+instance ToByteString ResourceType
+instance ToPath       ResourceType
+instance ToQuery      ResourceType
+instance ToHeader     ResourceType
 
 instance FromXML ResourceType where
     parseXML = parseXMLText "ResourceType"
@@ -1602,9 +1700,11 @@ instance ToText RouteOrigin where
         CreateRouteTable -> "createroutetable"
         EnableVGWRoutePropagation -> "enablevgwroutepropagation"
 
-instance Hashable RouteOrigin
-instance ToQuery  RouteOrigin
-instance ToHeader RouteOrigin
+instance Hashable     RouteOrigin
+instance ToByteString RouteOrigin
+instance ToPath       RouteOrigin
+instance ToQuery      RouteOrigin
+instance ToHeader     RouteOrigin
 
 instance FromXML RouteOrigin where
     parseXML = parseXMLText "RouteOrigin"
@@ -1626,9 +1726,11 @@ instance ToText RouteState where
         RSActive -> "active"
         RSBlackhole -> "blackhole"
 
-instance Hashable RouteState
-instance ToQuery  RouteState
-instance ToHeader RouteState
+instance Hashable     RouteState
+instance ToByteString RouteState
+instance ToPath       RouteState
+instance ToQuery      RouteState
+instance ToHeader     RouteState
 
 instance FromXML RouteState where
     parseXML = parseXMLText "RouteState"
@@ -1650,9 +1752,11 @@ instance ToText RuleAction where
         Allow -> "allow"
         Deny -> "deny"
 
-instance Hashable RuleAction
-instance ToQuery  RuleAction
-instance ToHeader RuleAction
+instance Hashable     RuleAction
+instance ToByteString RuleAction
+instance ToPath       RuleAction
+instance ToQuery      RuleAction
+instance ToHeader     RuleAction
 
 instance FromXML RuleAction where
     parseXML = parseXMLText "RuleAction"
@@ -1674,9 +1778,11 @@ instance ToText ShutdownBehavior where
         Stop -> "stop"
         Terminate -> "terminate"
 
-instance Hashable ShutdownBehavior
-instance ToQuery  ShutdownBehavior
-instance ToHeader ShutdownBehavior
+instance Hashable     ShutdownBehavior
+instance ToByteString ShutdownBehavior
+instance ToPath       ShutdownBehavior
+instance ToQuery      ShutdownBehavior
+instance ToHeader     ShutdownBehavior
 
 data SnapshotAttributeName
     = SANProductCodes
@@ -1695,9 +1801,11 @@ instance ToText SnapshotAttributeName where
         SANCreateVolumePermission -> "createvolumepermission"
         SANProductCodes -> "productcodes"
 
-instance Hashable SnapshotAttributeName
-instance ToQuery  SnapshotAttributeName
-instance ToHeader SnapshotAttributeName
+instance Hashable     SnapshotAttributeName
+instance ToByteString SnapshotAttributeName
+instance ToPath       SnapshotAttributeName
+instance ToQuery      SnapshotAttributeName
+instance ToHeader     SnapshotAttributeName
 
 data SnapshotState
     = SSCompleted
@@ -1719,9 +1827,11 @@ instance ToText SnapshotState where
         SSError' -> "error"
         SSPending -> "pending"
 
-instance Hashable SnapshotState
-instance ToQuery  SnapshotState
-instance ToHeader SnapshotState
+instance Hashable     SnapshotState
+instance ToByteString SnapshotState
+instance ToPath       SnapshotState
+instance ToQuery      SnapshotState
+instance ToHeader     SnapshotState
 
 instance FromXML SnapshotState where
     parseXML = parseXMLText "SnapshotState"
@@ -1752,9 +1862,11 @@ instance ToText SpotInstanceState where
         SISFailed -> "failed"
         SISOpen -> "open"
 
-instance Hashable SpotInstanceState
-instance ToQuery  SpotInstanceState
-instance ToHeader SpotInstanceState
+instance Hashable     SpotInstanceState
+instance ToByteString SpotInstanceState
+instance ToPath       SpotInstanceState
+instance ToQuery      SpotInstanceState
+instance ToHeader     SpotInstanceState
 
 instance FromXML SpotInstanceState where
     parseXML = parseXMLText "SpotInstanceState"
@@ -1776,9 +1888,11 @@ instance ToText SpotInstanceType where
         OneTime -> "one-time"
         Persistent -> "persistent"
 
-instance Hashable SpotInstanceType
-instance ToQuery  SpotInstanceType
-instance ToHeader SpotInstanceType
+instance Hashable     SpotInstanceType
+instance ToByteString SpotInstanceType
+instance ToPath       SpotInstanceType
+instance ToQuery      SpotInstanceType
+instance ToHeader     SpotInstanceType
 
 instance FromXML SpotInstanceType where
     parseXML = parseXMLText "SpotInstanceType"
@@ -1806,9 +1920,11 @@ instance ToText State where
         Deleting -> "deleting"
         Pending -> "pending"
 
-instance Hashable State
-instance ToQuery  State
-instance ToHeader State
+instance Hashable     State
+instance ToByteString State
+instance ToPath       State
+instance ToQuery      State
+instance ToHeader     State
 
 instance FromXML State where
     parseXML = parseXMLText "State"
@@ -1827,9 +1943,11 @@ instance ToText StatusName where
     toText = \case
         Reachability -> "reachability"
 
-instance Hashable StatusName
-instance ToQuery  StatusName
-instance ToHeader StatusName
+instance Hashable     StatusName
+instance ToByteString StatusName
+instance ToPath       StatusName
+instance ToQuery      StatusName
+instance ToHeader     StatusName
 
 instance FromXML StatusName where
     parseXML = parseXMLText "StatusName"
@@ -1857,9 +1975,11 @@ instance ToText StatusType where
         InsufficientData -> "insufficient-data"
         Passed -> "passed"
 
-instance Hashable StatusType
-instance ToQuery  StatusType
-instance ToHeader StatusType
+instance Hashable     StatusType
+instance ToByteString StatusType
+instance ToPath       StatusType
+instance ToQuery      StatusType
+instance ToHeader     StatusType
 
 instance FromXML StatusType where
     parseXML = parseXMLText "StatusType"
@@ -1881,9 +2001,11 @@ instance ToText SubnetState where
         SAvailable -> "available"
         SPending -> "pending"
 
-instance Hashable SubnetState
-instance ToQuery  SubnetState
-instance ToHeader SubnetState
+instance Hashable     SubnetState
+instance ToByteString SubnetState
+instance ToPath       SubnetState
+instance ToQuery      SubnetState
+instance ToHeader     SubnetState
 
 instance FromXML SubnetState where
     parseXML = parseXMLText "SubnetState"
@@ -1914,9 +2036,11 @@ instance ToText SummaryStatus where
         SSNotApplicable -> "not-applicable"
         SSOK -> "ok"
 
-instance Hashable SummaryStatus
-instance ToQuery  SummaryStatus
-instance ToHeader SummaryStatus
+instance Hashable     SummaryStatus
+instance ToByteString SummaryStatus
+instance ToPath       SummaryStatus
+instance ToQuery      SummaryStatus
+instance ToHeader     SummaryStatus
 
 instance FromXML SummaryStatus where
     parseXML = parseXMLText "SummaryStatus"
@@ -1938,9 +2062,11 @@ instance ToText TelemetryStatus where
         Down -> "down"
         UP -> "up"
 
-instance Hashable TelemetryStatus
-instance ToQuery  TelemetryStatus
-instance ToHeader TelemetryStatus
+instance Hashable     TelemetryStatus
+instance ToByteString TelemetryStatus
+instance ToPath       TelemetryStatus
+instance ToQuery      TelemetryStatus
+instance ToHeader     TelemetryStatus
 
 instance FromXML TelemetryStatus where
     parseXML = parseXMLText "TelemetryStatus"
@@ -1962,9 +2088,11 @@ instance ToText Tenancy where
         Dedicated -> "dedicated"
         Default -> "default"
 
-instance Hashable Tenancy
-instance ToQuery  Tenancy
-instance ToHeader Tenancy
+instance Hashable     Tenancy
+instance ToByteString Tenancy
+instance ToPath       Tenancy
+instance ToQuery      Tenancy
+instance ToHeader     Tenancy
 
 instance FromXML Tenancy where
     parseXML = parseXMLText "Tenancy"
@@ -1989,9 +2117,11 @@ instance ToText TrafficType where
         All -> "all"
         Reject -> "reject"
 
-instance Hashable TrafficType
-instance ToQuery  TrafficType
-instance ToHeader TrafficType
+instance Hashable     TrafficType
+instance ToByteString TrafficType
+instance ToPath       TrafficType
+instance ToQuery      TrafficType
+instance ToHeader     TrafficType
 
 instance FromXML TrafficType where
     parseXML = parseXMLText "TrafficType"
@@ -2013,9 +2143,11 @@ instance ToText VPCAttributeName where
         EnableDNSHostnames -> "enablednshostnames"
         EnableDNSSupport -> "enablednssupport"
 
-instance Hashable VPCAttributeName
-instance ToQuery  VPCAttributeName
-instance ToHeader VPCAttributeName
+instance Hashable     VPCAttributeName
+instance ToByteString VPCAttributeName
+instance ToPath       VPCAttributeName
+instance ToQuery      VPCAttributeName
+instance ToHeader     VPCAttributeName
 
 data VPCPeeringConnectionStateReasonCode
     = VPCSRCFailed
@@ -2055,9 +2187,11 @@ instance ToText VPCPeeringConnectionStateReasonCode where
         VPCSRCProvisioning -> "provisioning"
         VPCSRCRejected -> "rejected"
 
-instance Hashable VPCPeeringConnectionStateReasonCode
-instance ToQuery  VPCPeeringConnectionStateReasonCode
-instance ToHeader VPCPeeringConnectionStateReasonCode
+instance Hashable     VPCPeeringConnectionStateReasonCode
+instance ToByteString VPCPeeringConnectionStateReasonCode
+instance ToPath       VPCPeeringConnectionStateReasonCode
+instance ToQuery      VPCPeeringConnectionStateReasonCode
+instance ToHeader     VPCPeeringConnectionStateReasonCode
 
 instance FromXML VPCPeeringConnectionStateReasonCode where
     parseXML = parseXMLText "VPCPeeringConnectionStateReasonCode"
@@ -2079,9 +2213,11 @@ instance ToText VPCState where
         VPCSAvailable -> "available"
         VPCSPending -> "pending"
 
-instance Hashable VPCState
-instance ToQuery  VPCState
-instance ToHeader VPCState
+instance Hashable     VPCState
+instance ToByteString VPCState
+instance ToPath       VPCState
+instance ToQuery      VPCState
+instance ToHeader     VPCState
 
 instance FromXML VPCState where
     parseXML = parseXMLText "VPCState"
@@ -2109,9 +2245,11 @@ instance ToText VPNState where
         VSDeleting -> "deleting"
         VSPending -> "pending"
 
-instance Hashable VPNState
-instance ToQuery  VPNState
-instance ToHeader VPNState
+instance Hashable     VPNState
+instance ToByteString VPNState
+instance ToPath       VPNState
+instance ToQuery      VPNState
+instance ToHeader     VPNState
 
 instance FromXML VPNState where
     parseXML = parseXMLText "VPNState"
@@ -2130,9 +2268,11 @@ instance ToText VPNStaticRouteSource where
     toText = \case
         Static -> "static"
 
-instance Hashable VPNStaticRouteSource
-instance ToQuery  VPNStaticRouteSource
-instance ToHeader VPNStaticRouteSource
+instance Hashable     VPNStaticRouteSource
+instance ToByteString VPNStaticRouteSource
+instance ToPath       VPNStaticRouteSource
+instance ToQuery      VPNStaticRouteSource
+instance ToHeader     VPNStaticRouteSource
 
 instance FromXML VPNStaticRouteSource where
     parseXML = parseXMLText "VPNStaticRouteSource"
@@ -2154,9 +2294,11 @@ instance ToText VirtualizationType where
         HVM -> "hvm"
         Paravirtual -> "paravirtual"
 
-instance Hashable VirtualizationType
-instance ToQuery  VirtualizationType
-instance ToHeader VirtualizationType
+instance Hashable     VirtualizationType
+instance ToByteString VirtualizationType
+instance ToPath       VirtualizationType
+instance ToQuery      VirtualizationType
+instance ToHeader     VirtualizationType
 
 instance FromXML VirtualizationType where
     parseXML = parseXMLText "VirtualizationType"
@@ -2184,9 +2326,11 @@ instance ToText VolumeAttachmentState where
         VASDetached -> "detached"
         VASDetaching -> "detaching"
 
-instance Hashable VolumeAttachmentState
-instance ToQuery  VolumeAttachmentState
-instance ToHeader VolumeAttachmentState
+instance Hashable     VolumeAttachmentState
+instance ToByteString VolumeAttachmentState
+instance ToPath       VolumeAttachmentState
+instance ToQuery      VolumeAttachmentState
+instance ToHeader     VolumeAttachmentState
 
 instance FromXML VolumeAttachmentState where
     parseXML = parseXMLText "VolumeAttachmentState"
@@ -2208,9 +2352,11 @@ instance ToText VolumeAttributeName where
         VANAutoEnableIO -> "autoenableio"
         VANProductCodes -> "productcodes"
 
-instance Hashable VolumeAttributeName
-instance ToQuery  VolumeAttributeName
-instance ToHeader VolumeAttributeName
+instance Hashable     VolumeAttributeName
+instance ToByteString VolumeAttributeName
+instance ToPath       VolumeAttributeName
+instance ToQuery      VolumeAttributeName
+instance ToHeader     VolumeAttributeName
 
 data VolumeState
     = VCreating
@@ -2241,9 +2387,11 @@ instance ToText VolumeState where
         VError' -> "error"
         VInUse -> "in-use"
 
-instance Hashable VolumeState
-instance ToQuery  VolumeState
-instance ToHeader VolumeState
+instance Hashable     VolumeState
+instance ToByteString VolumeState
+instance ToPath       VolumeState
+instance ToQuery      VolumeState
+instance ToHeader     VolumeState
 
 instance FromXML VolumeState where
     parseXML = parseXMLText "VolumeState"
@@ -2268,9 +2416,11 @@ instance ToText VolumeStatusInfoStatus where
         VSISInsufficientData -> "insufficient-data"
         VSISOK -> "ok"
 
-instance Hashable VolumeStatusInfoStatus
-instance ToQuery  VolumeStatusInfoStatus
-instance ToHeader VolumeStatusInfoStatus
+instance Hashable     VolumeStatusInfoStatus
+instance ToByteString VolumeStatusInfoStatus
+instance ToPath       VolumeStatusInfoStatus
+instance ToQuery      VolumeStatusInfoStatus
+instance ToHeader     VolumeStatusInfoStatus
 
 instance FromXML VolumeStatusInfoStatus where
     parseXML = parseXMLText "VolumeStatusInfoStatus"
@@ -2292,9 +2442,11 @@ instance ToText VolumeStatusName where
         IOEnabled -> "io-enabled"
         IOPerformance -> "io-performance"
 
-instance Hashable VolumeStatusName
-instance ToQuery  VolumeStatusName
-instance ToHeader VolumeStatusName
+instance Hashable     VolumeStatusName
+instance ToByteString VolumeStatusName
+instance ToPath       VolumeStatusName
+instance ToQuery      VolumeStatusName
+instance ToHeader     VolumeStatusName
 
 instance FromXML VolumeStatusName where
     parseXML = parseXMLText "VolumeStatusName"
@@ -2319,9 +2471,11 @@ instance ToText VolumeType where
         IO1 -> "io1"
         Standard -> "standard"
 
-instance Hashable VolumeType
-instance ToQuery  VolumeType
-instance ToHeader VolumeType
+instance Hashable     VolumeType
+instance ToByteString VolumeType
+instance ToPath       VolumeType
+instance ToQuery      VolumeType
+instance ToHeader     VolumeType
 
 instance FromXML VolumeType where
     parseXML = parseXMLText "VolumeType"

--- a/amazonka-ecs/amazonka-ecs.cabal
+++ b/amazonka-ecs/amazonka-ecs.cabal
@@ -97,7 +97,7 @@ test-suite amazonka-ecs-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-ecs == 1.0.0
         , base
         , bytestring

--- a/amazonka-ecs/gen/Network/AWS/ECS/Types/Sum.hs
+++ b/amazonka-ecs/gen/Network/AWS/ECS/Types/Sum.hs
@@ -48,9 +48,11 @@ instance ToText AgentUpdateStatus where
         AUSUpdated -> "updated"
         AUSUpdating -> "updating"
 
-instance Hashable AgentUpdateStatus
-instance ToQuery  AgentUpdateStatus
-instance ToHeader AgentUpdateStatus
+instance Hashable     AgentUpdateStatus
+instance ToByteString AgentUpdateStatus
+instance ToPath       AgentUpdateStatus
+instance ToQuery      AgentUpdateStatus
+instance ToHeader     AgentUpdateStatus
 
 instance FromJSON AgentUpdateStatus where
     parseJSON = parseJSONText "AgentUpdateStatus"
@@ -75,9 +77,11 @@ instance ToText DesiredStatus where
         Running -> "running"
         Stopped -> "stopped"
 
-instance Hashable DesiredStatus
-instance ToQuery  DesiredStatus
-instance ToHeader DesiredStatus
+instance Hashable     DesiredStatus
+instance ToByteString DesiredStatus
+instance ToPath       DesiredStatus
+instance ToQuery      DesiredStatus
+instance ToHeader     DesiredStatus
 
 instance ToJSON DesiredStatus where
     toJSON = toJSONText
@@ -99,9 +103,11 @@ instance ToText SortOrder where
         Asc -> "asc"
         Desc -> "desc"
 
-instance Hashable SortOrder
-instance ToQuery  SortOrder
-instance ToHeader SortOrder
+instance Hashable     SortOrder
+instance ToByteString SortOrder
+instance ToPath       SortOrder
+instance ToQuery      SortOrder
+instance ToHeader     SortOrder
 
 instance ToJSON SortOrder where
     toJSON = toJSONText
@@ -123,9 +129,11 @@ instance ToText TaskDefinitionStatus where
         Active -> "active"
         Inactive -> "inactive"
 
-instance Hashable TaskDefinitionStatus
-instance ToQuery  TaskDefinitionStatus
-instance ToHeader TaskDefinitionStatus
+instance Hashable     TaskDefinitionStatus
+instance ToByteString TaskDefinitionStatus
+instance ToPath       TaskDefinitionStatus
+instance ToQuery      TaskDefinitionStatus
+instance ToHeader     TaskDefinitionStatus
 
 instance ToJSON TaskDefinitionStatus where
     toJSON = toJSONText
@@ -150,9 +158,11 @@ instance ToText TransportProtocol where
         TCP -> "tcp"
         Udp -> "udp"
 
-instance Hashable TransportProtocol
-instance ToQuery  TransportProtocol
-instance ToHeader TransportProtocol
+instance Hashable     TransportProtocol
+instance ToByteString TransportProtocol
+instance ToPath       TransportProtocol
+instance ToQuery      TransportProtocol
+instance ToHeader     TransportProtocol
 
 instance ToJSON TransportProtocol where
     toJSON = toJSONText

--- a/amazonka-efs/amazonka-efs.cabal
+++ b/amazonka-efs/amazonka-efs.cabal
@@ -68,7 +68,7 @@ test-suite amazonka-efs-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-efs == 1.0.0
         , base
         , bytestring

--- a/amazonka-efs/gen/Network/AWS/EFS/CreateTags.hs
+++ b/amazonka-efs/gen/Network/AWS/EFS/CreateTags.hs
@@ -93,7 +93,7 @@ instance ToJSON CreateTags where
 instance ToPath CreateTags where
         toPath CreateTags'{..}
           = mconcat
-              ["/2015-02-01/create-tags/", toText _ctFileSystemId]
+              ["/2015-02-01/create-tags/", toPath _ctFileSystemId]
 
 instance ToQuery CreateTags where
         toQuery = const mempty

--- a/amazonka-efs/gen/Network/AWS/EFS/DeleteFileSystem.hs
+++ b/amazonka-efs/gen/Network/AWS/EFS/DeleteFileSystem.hs
@@ -89,7 +89,7 @@ instance ToPath DeleteFileSystem where
         toPath DeleteFileSystem'{..}
           = mconcat
               ["/2015-02-01/file-systems/",
-               toText _delFileSystemId]
+               toPath _delFileSystemId]
 
 instance ToQuery DeleteFileSystem where
         toQuery = const mempty

--- a/amazonka-efs/gen/Network/AWS/EFS/DeleteMountTarget.hs
+++ b/amazonka-efs/gen/Network/AWS/EFS/DeleteMountTarget.hs
@@ -98,7 +98,7 @@ instance ToPath DeleteMountTarget where
         toPath DeleteMountTarget'{..}
           = mconcat
               ["/2015-02-01/mount-targets/",
-               toText _dmtMountTargetId]
+               toPath _dmtMountTargetId]
 
 instance ToQuery DeleteMountTarget where
         toQuery = const mempty

--- a/amazonka-efs/gen/Network/AWS/EFS/DeleteTags.hs
+++ b/amazonka-efs/gen/Network/AWS/EFS/DeleteTags.hs
@@ -93,7 +93,7 @@ instance ToJSON DeleteTags where
 instance ToPath DeleteTags where
         toPath DeleteTags'{..}
           = mconcat
-              ["/2015-02-01/delete-tags/", toText _dFileSystemId]
+              ["/2015-02-01/delete-tags/", toPath _dFileSystemId]
 
 instance ToQuery DeleteTags where
         toQuery = const mempty

--- a/amazonka-efs/gen/Network/AWS/EFS/DescribeMountTargetSecurityGroups.hs
+++ b/amazonka-efs/gen/Network/AWS/EFS/DescribeMountTargetSecurityGroups.hs
@@ -95,7 +95,7 @@ instance ToPath DescribeMountTargetSecurityGroups
         toPath DescribeMountTargetSecurityGroups'{..}
           = mconcat
               ["/2015-02-01/mount-targets/",
-               toText _dmtsgMountTargetId, "/security-groups"]
+               toPath _dmtsgMountTargetId, "/security-groups"]
 
 instance ToQuery DescribeMountTargetSecurityGroups
          where

--- a/amazonka-efs/gen/Network/AWS/EFS/DescribeTags.hs
+++ b/amazonka-efs/gen/Network/AWS/EFS/DescribeTags.hs
@@ -110,7 +110,7 @@ instance ToHeaders DescribeTags where
 instance ToPath DescribeTags where
         toPath DescribeTags'{..}
           = mconcat
-              ["/2015-02-01/tags/", toText _dtFileSystemId, "/"]
+              ["/2015-02-01/tags/", toPath _dtFileSystemId, "/"]
 
 instance ToQuery DescribeTags where
         toQuery DescribeTags'{..}

--- a/amazonka-efs/gen/Network/AWS/EFS/ModifyMountTargetSecurityGroups.hs
+++ b/amazonka-efs/gen/Network/AWS/EFS/ModifyMountTargetSecurityGroups.hs
@@ -106,7 +106,7 @@ instance ToPath ModifyMountTargetSecurityGroups where
         toPath ModifyMountTargetSecurityGroups'{..}
           = mconcat
               ["/2015-02-01/mount-targets/",
-               toText _mmtsgMountTargetId, "/security-groups"]
+               toPath _mmtsgMountTargetId, "/security-groups"]
 
 instance ToQuery ModifyMountTargetSecurityGroups
          where

--- a/amazonka-efs/gen/Network/AWS/EFS/Types/Sum.hs
+++ b/amazonka-efs/gen/Network/AWS/EFS/Types/Sum.hs
@@ -42,9 +42,11 @@ instance ToText LifeCycleState where
         Deleted -> "deleted"
         Deleting -> "deleting"
 
-instance Hashable LifeCycleState
-instance ToQuery  LifeCycleState
-instance ToHeader LifeCycleState
+instance Hashable     LifeCycleState
+instance ToByteString LifeCycleState
+instance ToPath       LifeCycleState
+instance ToQuery      LifeCycleState
+instance ToHeader     LifeCycleState
 
 instance FromJSON LifeCycleState where
     parseJSON = parseJSONText "LifeCycleState"

--- a/amazonka-elasticache/amazonka-elasticache.cabal
+++ b/amazonka-elasticache/amazonka-elasticache.cabal
@@ -107,7 +107,7 @@ test-suite amazonka-elasticache-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-elasticache == 1.0.0
         , base
         , bytestring

--- a/amazonka-elasticache/gen/Network/AWS/ElastiCache/Types/Sum.hs
+++ b/amazonka-elasticache/gen/Network/AWS/ElastiCache/Types/Sum.hs
@@ -36,9 +36,11 @@ instance ToText AZMode where
         CrossAz -> "cross-az"
         SingleAz -> "single-az"
 
-instance Hashable AZMode
-instance ToQuery  AZMode
-instance ToHeader AZMode
+instance Hashable     AZMode
+instance ToByteString AZMode
+instance ToPath       AZMode
+instance ToQuery      AZMode
+instance ToHeader     AZMode
 
 data AutomaticFailoverStatus
     = AFSEnabling
@@ -63,9 +65,11 @@ instance ToText AutomaticFailoverStatus where
         AFSEnabled -> "enabled"
         AFSEnabling -> "enabling"
 
-instance Hashable AutomaticFailoverStatus
-instance ToQuery  AutomaticFailoverStatus
-instance ToHeader AutomaticFailoverStatus
+instance Hashable     AutomaticFailoverStatus
+instance ToByteString AutomaticFailoverStatus
+instance ToPath       AutomaticFailoverStatus
+instance ToQuery      AutomaticFailoverStatus
+instance ToHeader     AutomaticFailoverStatus
 
 instance FromXML AutomaticFailoverStatus where
     parseXML = parseXMLText "AutomaticFailoverStatus"
@@ -87,9 +91,11 @@ instance ToText PendingAutomaticFailoverStatus where
         Disabled -> "disabled"
         Enabled -> "enabled"
 
-instance Hashable PendingAutomaticFailoverStatus
-instance ToQuery  PendingAutomaticFailoverStatus
-instance ToHeader PendingAutomaticFailoverStatus
+instance Hashable     PendingAutomaticFailoverStatus
+instance ToByteString PendingAutomaticFailoverStatus
+instance ToPath       PendingAutomaticFailoverStatus
+instance ToQuery      PendingAutomaticFailoverStatus
+instance ToHeader     PendingAutomaticFailoverStatus
 
 instance FromXML PendingAutomaticFailoverStatus where
     parseXML = parseXMLText "PendingAutomaticFailoverStatus"
@@ -117,9 +123,11 @@ instance ToText SourceType where
         CacheSecurityGroup -> "cache-security-group"
         CacheSubnetGroup -> "cache-subnet-group"
 
-instance Hashable SourceType
-instance ToQuery  SourceType
-instance ToHeader SourceType
+instance Hashable     SourceType
+instance ToByteString SourceType
+instance ToPath       SourceType
+instance ToQuery      SourceType
+instance ToHeader     SourceType
 
 instance FromXML SourceType where
     parseXML = parseXMLText "SourceType"

--- a/amazonka-elasticbeanstalk/amazonka-elasticbeanstalk.cabal
+++ b/amazonka-elasticbeanstalk/amazonka-elasticbeanstalk.cabal
@@ -111,7 +111,7 @@ test-suite amazonka-elasticbeanstalk-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-elasticbeanstalk == 1.0.0
         , base
         , bytestring

--- a/amazonka-elasticbeanstalk/gen/Network/AWS/ElasticBeanstalk/Types/Sum.hs
+++ b/amazonka-elasticbeanstalk/gen/Network/AWS/ElasticBeanstalk/Types/Sum.hs
@@ -39,9 +39,11 @@ instance ToText ConfigurationDeploymentStatus where
         Failed -> "failed"
         Pending -> "pending"
 
-instance Hashable ConfigurationDeploymentStatus
-instance ToQuery  ConfigurationDeploymentStatus
-instance ToHeader ConfigurationDeploymentStatus
+instance Hashable     ConfigurationDeploymentStatus
+instance ToByteString ConfigurationDeploymentStatus
+instance ToPath       ConfigurationDeploymentStatus
+instance ToQuery      ConfigurationDeploymentStatus
+instance ToHeader     ConfigurationDeploymentStatus
 
 instance FromXML ConfigurationDeploymentStatus where
     parseXML = parseXMLText "ConfigurationDeploymentStatus"
@@ -63,9 +65,11 @@ instance ToText ConfigurationOptionValueType where
         List -> "list"
         Scalar -> "scalar"
 
-instance Hashable ConfigurationOptionValueType
-instance ToQuery  ConfigurationOptionValueType
-instance ToHeader ConfigurationOptionValueType
+instance Hashable     ConfigurationOptionValueType
+instance ToByteString ConfigurationOptionValueType
+instance ToPath       ConfigurationOptionValueType
+instance ToQuery      ConfigurationOptionValueType
+instance ToHeader     ConfigurationOptionValueType
 
 instance FromXML ConfigurationOptionValueType where
     parseXML = parseXMLText "ConfigurationOptionValueType"
@@ -93,9 +97,11 @@ instance ToText EnvironmentHealth where
         Red -> "red"
         Yellow -> "yellow"
 
-instance Hashable EnvironmentHealth
-instance ToQuery  EnvironmentHealth
-instance ToHeader EnvironmentHealth
+instance Hashable     EnvironmentHealth
+instance ToByteString EnvironmentHealth
+instance ToPath       EnvironmentHealth
+instance ToQuery      EnvironmentHealth
+instance ToHeader     EnvironmentHealth
 
 instance FromXML EnvironmentHealth where
     parseXML = parseXMLText "EnvironmentHealth"
@@ -117,9 +123,11 @@ instance ToText EnvironmentInfoType where
         Bundle -> "bundle"
         Tail -> "tail"
 
-instance Hashable EnvironmentInfoType
-instance ToQuery  EnvironmentInfoType
-instance ToHeader EnvironmentInfoType
+instance Hashable     EnvironmentInfoType
+instance ToByteString EnvironmentInfoType
+instance ToPath       EnvironmentInfoType
+instance ToQuery      EnvironmentInfoType
+instance ToHeader     EnvironmentInfoType
 
 instance FromXML EnvironmentInfoType where
     parseXML = parseXMLText "EnvironmentInfoType"
@@ -150,9 +158,11 @@ instance ToText EnvironmentStatus where
         Terminating -> "terminating"
         Updating -> "updating"
 
-instance Hashable EnvironmentStatus
-instance ToQuery  EnvironmentStatus
-instance ToHeader EnvironmentStatus
+instance Hashable     EnvironmentStatus
+instance ToByteString EnvironmentStatus
+instance ToPath       EnvironmentStatus
+instance ToQuery      EnvironmentStatus
+instance ToHeader     EnvironmentStatus
 
 instance FromXML EnvironmentStatus where
     parseXML = parseXMLText "EnvironmentStatus"
@@ -186,9 +196,11 @@ instance ToText EventSeverity where
         LevelTrace -> "trace"
         LevelWarn -> "warn"
 
-instance Hashable EventSeverity
-instance ToQuery  EventSeverity
-instance ToHeader EventSeverity
+instance Hashable     EventSeverity
+instance ToByteString EventSeverity
+instance ToPath       EventSeverity
+instance ToQuery      EventSeverity
+instance ToHeader     EventSeverity
 
 instance FromXML EventSeverity where
     parseXML = parseXMLText "EventSeverity"
@@ -210,9 +222,11 @@ instance ToText ValidationSeverity where
         Error' -> "error"
         Warning -> "warning"
 
-instance Hashable ValidationSeverity
-instance ToQuery  ValidationSeverity
-instance ToHeader ValidationSeverity
+instance Hashable     ValidationSeverity
+instance ToByteString ValidationSeverity
+instance ToPath       ValidationSeverity
+instance ToQuery      ValidationSeverity
+instance ToHeader     ValidationSeverity
 
 instance FromXML ValidationSeverity where
     parseXML = parseXMLText "ValidationSeverity"

--- a/amazonka-elastictranscoder/amazonka-elastictranscoder.cabal
+++ b/amazonka-elastictranscoder/amazonka-elastictranscoder.cabal
@@ -76,7 +76,7 @@ test-suite amazonka-elastictranscoder-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-elastictranscoder == 1.0.0
         , base
         , bytestring

--- a/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/CancelJob.hs
+++ b/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/CancelJob.hs
@@ -85,7 +85,7 @@ instance ToHeaders CancelJob where
 
 instance ToPath CancelJob where
         toPath CancelJob'{..}
-          = mconcat ["/2012-09-25/jobs/", toText _cjId]
+          = mconcat ["/2012-09-25/jobs/", toPath _cjId]
 
 instance ToQuery CancelJob where
         toQuery = const mempty

--- a/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/DeletePipeline.hs
+++ b/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/DeletePipeline.hs
@@ -82,7 +82,7 @@ instance ToHeaders DeletePipeline where
 
 instance ToPath DeletePipeline where
         toPath DeletePipeline'{..}
-          = mconcat ["/2012-09-25/pipelines/", toText _dId]
+          = mconcat ["/2012-09-25/pipelines/", toPath _dId]
 
 instance ToQuery DeletePipeline where
         toQuery = const mempty

--- a/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/DeletePreset.hs
+++ b/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/DeletePreset.hs
@@ -83,7 +83,7 @@ instance ToHeaders DeletePreset where
 
 instance ToPath DeletePreset where
         toPath DeletePreset'{..}
-          = mconcat ["/2012-09-25/presets/", toText _dpId]
+          = mconcat ["/2012-09-25/presets/", toPath _dpId]
 
 instance ToQuery DeletePreset where
         toQuery = const mempty

--- a/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/ListJobsByPipeline.hs
+++ b/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/ListJobsByPipeline.hs
@@ -121,7 +121,7 @@ instance ToPath ListJobsByPipeline where
         toPath ListJobsByPipeline'{..}
           = mconcat
               ["/2012-09-25/jobsByPipeline/",
-               toText _ljbpPipelineId]
+               toPath _ljbpPipelineId]
 
 instance ToQuery ListJobsByPipeline where
         toQuery ListJobsByPipeline'{..}

--- a/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/ListJobsByStatus.hs
+++ b/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/ListJobsByStatus.hs
@@ -118,7 +118,7 @@ instance ToHeaders ListJobsByStatus where
 instance ToPath ListJobsByStatus where
         toPath ListJobsByStatus'{..}
           = mconcat
-              ["/2012-09-25/jobsByStatus/", toText _ljbsStatus]
+              ["/2012-09-25/jobsByStatus/", toPath _ljbsStatus]
 
 instance ToQuery ListJobsByStatus where
         toQuery ListJobsByStatus'{..}

--- a/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/ReadJob.hs
+++ b/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/ReadJob.hs
@@ -81,7 +81,7 @@ instance ToHeaders ReadJob where
 
 instance ToPath ReadJob where
         toPath ReadJob'{..}
-          = mconcat ["/2012-09-25/jobs/", toText _rjId]
+          = mconcat ["/2012-09-25/jobs/", toPath _rjId]
 
 instance ToQuery ReadJob where
         toQuery = const mempty

--- a/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/ReadPipeline.hs
+++ b/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/ReadPipeline.hs
@@ -82,7 +82,7 @@ instance ToHeaders ReadPipeline where
 
 instance ToPath ReadPipeline where
         toPath ReadPipeline'{..}
-          = mconcat ["/2012-09-25/pipelines/", toText _rId]
+          = mconcat ["/2012-09-25/pipelines/", toPath _rId]
 
 instance ToQuery ReadPipeline where
         toQuery = const mempty

--- a/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/ReadPreset.hs
+++ b/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/ReadPreset.hs
@@ -81,7 +81,7 @@ instance ToHeaders ReadPreset where
 
 instance ToPath ReadPreset where
         toPath ReadPreset'{..}
-          = mconcat ["/2012-09-25/presets/", toText _rpId]
+          = mconcat ["/2012-09-25/presets/", toPath _rpId]
 
 instance ToQuery ReadPreset where
         toQuery = const mempty

--- a/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/UpdatePipeline.hs
+++ b/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/UpdatePipeline.hs
@@ -278,7 +278,7 @@ instance ToJSON UpdatePipeline where
 
 instance ToPath UpdatePipeline where
         toPath UpdatePipeline'{..}
-          = mconcat ["/2012-09-25/pipelines/", toText _upId]
+          = mconcat ["/2012-09-25/pipelines/", toPath _upId]
 
 instance ToQuery UpdatePipeline where
         toQuery = const mempty

--- a/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/UpdatePipelineNotifications.hs
+++ b/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/UpdatePipelineNotifications.hs
@@ -120,7 +120,7 @@ instance ToJSON UpdatePipelineNotifications where
 instance ToPath UpdatePipelineNotifications where
         toPath UpdatePipelineNotifications'{..}
           = mconcat
-              ["/2012-09-25/pipelines/", toText _upnId,
+              ["/2012-09-25/pipelines/", toPath _upnId,
                "/notifications"]
 
 instance ToQuery UpdatePipelineNotifications where

--- a/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/UpdatePipelineStatus.hs
+++ b/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/UpdatePipelineStatus.hs
@@ -105,7 +105,7 @@ instance ToJSON UpdatePipelineStatus where
 instance ToPath UpdatePipelineStatus where
         toPath UpdatePipelineStatus'{..}
           = mconcat
-              ["/2012-09-25/pipelines/", toText _upsId, "/status"]
+              ["/2012-09-25/pipelines/", toPath _upsId, "/status"]
 
 instance ToQuery UpdatePipelineStatus where
         toQuery = const mempty

--- a/amazonka-elb/amazonka-elb.cabal
+++ b/amazonka-elb/amazonka-elb.cabal
@@ -101,7 +101,7 @@ test-suite amazonka-elb-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-elb == 1.0.0
         , base
         , bytestring

--- a/amazonka-emr/amazonka-emr.cabal
+++ b/amazonka-emr/amazonka-emr.cabal
@@ -77,7 +77,7 @@ test-suite amazonka-emr-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-emr == 1.0.0
         , base
         , bytestring

--- a/amazonka-emr/gen/Network/AWS/EMR/Types/Sum.hs
+++ b/amazonka-emr/gen/Network/AWS/EMR/Types/Sum.hs
@@ -42,9 +42,11 @@ instance ToText ActionOnFailure where
         TerminateCluster -> "terminate_cluster"
         TerminateJobFlow -> "terminate_job_flow"
 
-instance Hashable ActionOnFailure
-instance ToQuery  ActionOnFailure
-instance ToHeader ActionOnFailure
+instance Hashable     ActionOnFailure
+instance ToByteString ActionOnFailure
+instance ToPath       ActionOnFailure
+instance ToQuery      ActionOnFailure
+instance ToHeader     ActionOnFailure
 
 instance ToJSON ActionOnFailure where
     toJSON = toJSONText
@@ -84,9 +86,11 @@ instance ToText ClusterState where
         Terminating -> "terminating"
         Waiting -> "waiting"
 
-instance Hashable ClusterState
-instance ToQuery  ClusterState
-instance ToHeader ClusterState
+instance Hashable     ClusterState
+instance ToByteString ClusterState
+instance ToPath       ClusterState
+instance ToQuery      ClusterState
+instance ToHeader     ClusterState
 
 instance ToJSON ClusterState where
     toJSON = toJSONText
@@ -126,9 +130,11 @@ instance ToText ClusterStateChangeReasonCode where
         UserRequest -> "user_request"
         ValidationError -> "validation_error"
 
-instance Hashable ClusterStateChangeReasonCode
-instance ToQuery  ClusterStateChangeReasonCode
-instance ToHeader ClusterStateChangeReasonCode
+instance Hashable     ClusterStateChangeReasonCode
+instance ToByteString ClusterStateChangeReasonCode
+instance ToPath       ClusterStateChangeReasonCode
+instance ToQuery      ClusterStateChangeReasonCode
+instance ToHeader     ClusterStateChangeReasonCode
 
 instance FromJSON ClusterStateChangeReasonCode where
     parseJSON = parseJSONText "ClusterStateChangeReasonCode"
@@ -174,9 +180,11 @@ instance ToText InstanceGroupState where
         IGSTerminated -> "terminated"
         IGSTerminating -> "terminating"
 
-instance Hashable InstanceGroupState
-instance ToQuery  InstanceGroupState
-instance ToHeader InstanceGroupState
+instance Hashable     InstanceGroupState
+instance ToByteString InstanceGroupState
+instance ToPath       InstanceGroupState
+instance ToQuery      InstanceGroupState
+instance ToHeader     InstanceGroupState
 
 instance FromJSON InstanceGroupState where
     parseJSON = parseJSONText "InstanceGroupState"
@@ -204,9 +212,11 @@ instance ToText InstanceGroupStateChangeReasonCode where
         IGSCRCInternalError -> "internal_error"
         IGSCRCValidationError -> "validation_error"
 
-instance Hashable InstanceGroupStateChangeReasonCode
-instance ToQuery  InstanceGroupStateChangeReasonCode
-instance ToHeader InstanceGroupStateChangeReasonCode
+instance Hashable     InstanceGroupStateChangeReasonCode
+instance ToByteString InstanceGroupStateChangeReasonCode
+instance ToPath       InstanceGroupStateChangeReasonCode
+instance ToQuery      InstanceGroupStateChangeReasonCode
+instance ToHeader     InstanceGroupStateChangeReasonCode
 
 instance FromJSON InstanceGroupStateChangeReasonCode where
     parseJSON = parseJSONText "InstanceGroupStateChangeReasonCode"
@@ -231,9 +241,11 @@ instance ToText InstanceGroupType where
         IGTMaster -> "master"
         IGTTask -> "task"
 
-instance Hashable InstanceGroupType
-instance ToQuery  InstanceGroupType
-instance ToHeader InstanceGroupType
+instance Hashable     InstanceGroupType
+instance ToByteString InstanceGroupType
+instance ToPath       InstanceGroupType
+instance ToQuery      InstanceGroupType
+instance ToHeader     InstanceGroupType
 
 instance ToJSON InstanceGroupType where
     toJSON = toJSONText
@@ -261,9 +273,11 @@ instance ToText InstanceRoleType where
         Master -> "master"
         Task -> "task"
 
-instance Hashable InstanceRoleType
-instance ToQuery  InstanceRoleType
-instance ToHeader InstanceRoleType
+instance Hashable     InstanceRoleType
+instance ToByteString InstanceRoleType
+instance ToPath       InstanceRoleType
+instance ToQuery      InstanceRoleType
+instance ToHeader     InstanceRoleType
 
 instance ToJSON InstanceRoleType where
     toJSON = toJSONText
@@ -294,9 +308,11 @@ instance ToText InstanceState where
         ISRunning -> "running"
         ISTerminated -> "terminated"
 
-instance Hashable InstanceState
-instance ToQuery  InstanceState
-instance ToHeader InstanceState
+instance Hashable     InstanceState
+instance ToByteString InstanceState
+instance ToPath       InstanceState
+instance ToQuery      InstanceState
+instance ToHeader     InstanceState
 
 instance FromJSON InstanceState where
     parseJSON = parseJSONText "InstanceState"
@@ -327,9 +343,11 @@ instance ToText InstanceStateChangeReasonCode where
         ISCRCInternalError -> "internal_error"
         ISCRCValidationError -> "validation_error"
 
-instance Hashable InstanceStateChangeReasonCode
-instance ToQuery  InstanceStateChangeReasonCode
-instance ToHeader InstanceStateChangeReasonCode
+instance Hashable     InstanceStateChangeReasonCode
+instance ToByteString InstanceStateChangeReasonCode
+instance ToPath       InstanceStateChangeReasonCode
+instance ToQuery      InstanceStateChangeReasonCode
+instance ToHeader     InstanceStateChangeReasonCode
 
 instance FromJSON InstanceStateChangeReasonCode where
     parseJSON = parseJSONText "InstanceStateChangeReasonCode"
@@ -351,9 +369,11 @@ instance ToText MarketType where
         OnDemand -> "on_demand"
         Spot -> "spot"
 
-instance Hashable MarketType
-instance ToQuery  MarketType
-instance ToHeader MarketType
+instance Hashable     MarketType
+instance ToByteString MarketType
+instance ToPath       MarketType
+instance ToQuery      MarketType
+instance ToHeader     MarketType
 
 instance ToJSON MarketType where
     toJSON = toJSONText
@@ -390,9 +410,11 @@ instance ToText StepState where
         SSPending -> "pending"
         SSRunning -> "running"
 
-instance Hashable StepState
-instance ToQuery  StepState
-instance ToHeader StepState
+instance Hashable     StepState
+instance ToByteString StepState
+instance ToPath       StepState
+instance ToQuery      StepState
+instance ToHeader     StepState
 
 instance ToJSON StepState where
     toJSON = toJSONText
@@ -414,9 +436,11 @@ instance ToText StepStateChangeReasonCode where
     toText = \case
         None -> "none"
 
-instance Hashable StepStateChangeReasonCode
-instance ToQuery  StepStateChangeReasonCode
-instance ToHeader StepStateChangeReasonCode
+instance Hashable     StepStateChangeReasonCode
+instance ToByteString StepStateChangeReasonCode
+instance ToPath       StepStateChangeReasonCode
+instance ToQuery      StepStateChangeReasonCode
+instance ToHeader     StepStateChangeReasonCode
 
 instance FromJSON StepStateChangeReasonCode where
     parseJSON = parseJSONText "StepStateChangeReasonCode"

--- a/amazonka-glacier/amazonka-glacier.cabal
+++ b/amazonka-glacier/amazonka-glacier.cabal
@@ -121,7 +121,7 @@ test-suite amazonka-glacier-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-glacier == 1.0.0
         , base
         , bytestring

--- a/amazonka-glacier/gen/Network/AWS/Glacier/AbortMultipartUpload.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/AbortMultipartUpload.hs
@@ -124,9 +124,9 @@ instance ToHeaders AbortMultipartUpload where
 instance ToPath AbortMultipartUpload where
         toPath AbortMultipartUpload'{..}
           = mconcat
-              ["/", toText _amuAccountId, "/vaults/",
-               toText _amuVaultName, "/multipart-uploads/",
-               toText _amuUploadId]
+              ["/", toPath _amuAccountId, "/vaults/",
+               toPath _amuVaultName, "/multipart-uploads/",
+               toPath _amuUploadId]
 
 instance ToQuery AbortMultipartUpload where
         toQuery = const mempty

--- a/amazonka-glacier/gen/Network/AWS/Glacier/AbortVaultLock.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/AbortVaultLock.hs
@@ -106,8 +106,8 @@ instance ToHeaders AbortVaultLock where
 instance ToPath AbortVaultLock where
         toPath AbortVaultLock'{..}
           = mconcat
-              ["/", toText _avlAccountId, "/vaults/",
-               toText _avlVaultName, "/lock-policy"]
+              ["/", toPath _avlAccountId, "/vaults/",
+               toPath _avlVaultName, "/lock-policy"]
 
 instance ToQuery AbortVaultLock where
         toQuery = const mempty

--- a/amazonka-glacier/gen/Network/AWS/Glacier/AddTagsToVault.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/AddTagsToVault.hs
@@ -107,8 +107,8 @@ instance ToJSON AddTagsToVault where
 instance ToPath AddTagsToVault where
         toPath AddTagsToVault'{..}
           = mconcat
-              ["/", toText _attvAccountId, "/vaults/",
-               toText _attvVaultName, "/tags"]
+              ["/", toPath _attvAccountId, "/vaults/",
+               toPath _attvVaultName, "/tags"]
 
 instance ToQuery AddTagsToVault where
         toQuery = const (mconcat ["operation=add"])

--- a/amazonka-glacier/gen/Network/AWS/Glacier/CompleteMultipartUpload.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/CompleteMultipartUpload.hs
@@ -180,9 +180,9 @@ instance ToJSON CompleteMultipartUpload where
 instance ToPath CompleteMultipartUpload where
         toPath CompleteMultipartUpload'{..}
           = mconcat
-              ["/", toText _cmuAccountId, "/vaults/",
-               toText _cmuVaultName, "/multipart-uploads/",
-               toText _cmuUploadId]
+              ["/", toPath _cmuAccountId, "/vaults/",
+               toPath _cmuVaultName, "/multipart-uploads/",
+               toPath _cmuUploadId]
 
 instance ToQuery CompleteMultipartUpload where
         toQuery = const mempty

--- a/amazonka-glacier/gen/Network/AWS/Glacier/CompleteVaultLock.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/CompleteVaultLock.hs
@@ -118,9 +118,9 @@ instance ToJSON CompleteVaultLock where
 instance ToPath CompleteVaultLock where
         toPath CompleteVaultLock'{..}
           = mconcat
-              ["/", toText _cvlAccountId, "/vaults/",
-               toText _cvlVaultName, "/lock-policy/",
-               toText _cvlLockId]
+              ["/", toPath _cvlAccountId, "/vaults/",
+               toPath _cvlVaultName, "/lock-policy/",
+               toPath _cvlLockId]
 
 instance ToQuery CompleteVaultLock where
         toQuery = const mempty

--- a/amazonka-glacier/gen/Network/AWS/Glacier/CreateVault.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/CreateVault.hs
@@ -123,8 +123,8 @@ instance ToJSON CreateVault where
 instance ToPath CreateVault where
         toPath CreateVault'{..}
           = mconcat
-              ["/", toText _cvAccountId, "/vaults/",
-               toText _cvVaultName]
+              ["/", toPath _cvAccountId, "/vaults/",
+               toPath _cvVaultName]
 
 instance ToQuery CreateVault where
         toQuery = const mempty

--- a/amazonka-glacier/gen/Network/AWS/Glacier/DeleteArchive.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/DeleteArchive.hs
@@ -121,9 +121,9 @@ instance ToHeaders DeleteArchive where
 instance ToPath DeleteArchive where
         toPath DeleteArchive'{..}
           = mconcat
-              ["/", toText _daAccountId, "/vaults/",
-               toText _daVaultName, "/archives/",
-               toText _daArchiveId]
+              ["/", toPath _daAccountId, "/vaults/",
+               toPath _daVaultName, "/archives/",
+               toPath _daArchiveId]
 
 instance ToQuery DeleteArchive where
         toQuery = const mempty

--- a/amazonka-glacier/gen/Network/AWS/Glacier/DeleteVault.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/DeleteVault.hs
@@ -111,8 +111,8 @@ instance ToHeaders DeleteVault where
 instance ToPath DeleteVault where
         toPath DeleteVault'{..}
           = mconcat
-              ["/", toText _dAccountId, "/vaults/",
-               toText _dVaultName]
+              ["/", toPath _dAccountId, "/vaults/",
+               toPath _dVaultName]
 
 instance ToQuery DeleteVault where
         toQuery = const mempty

--- a/amazonka-glacier/gen/Network/AWS/Glacier/DeleteVaultAccessPolicy.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/DeleteVaultAccessPolicy.hs
@@ -98,8 +98,8 @@ instance ToHeaders DeleteVaultAccessPolicy where
 instance ToPath DeleteVaultAccessPolicy where
         toPath DeleteVaultAccessPolicy'{..}
           = mconcat
-              ["/", toText _dvapAccountId, "/vaults/",
-               toText _dvapVaultName, "/access-policy"]
+              ["/", toPath _dvapAccountId, "/vaults/",
+               toPath _dvapVaultName, "/access-policy"]
 
 instance ToQuery DeleteVaultAccessPolicy where
         toQuery = const mempty

--- a/amazonka-glacier/gen/Network/AWS/Glacier/DeleteVaultNotifications.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/DeleteVaultNotifications.hs
@@ -106,8 +106,8 @@ instance ToHeaders DeleteVaultNotifications where
 instance ToPath DeleteVaultNotifications where
         toPath DeleteVaultNotifications'{..}
           = mconcat
-              ["/", toText _dvnAccountId, "/vaults/",
-               toText _dvnVaultName, "/notification-configuration"]
+              ["/", toPath _dvnAccountId, "/vaults/",
+               toPath _dvnVaultName, "/notification-configuration"]
 
 instance ToQuery DeleteVaultNotifications where
         toQuery = const mempty

--- a/amazonka-glacier/gen/Network/AWS/Glacier/DescribeJob.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/DescribeJob.hs
@@ -136,8 +136,8 @@ instance ToHeaders DescribeJob where
 instance ToPath DescribeJob where
         toPath DescribeJob'{..}
           = mconcat
-              ["/", toText _djAccountId, "/vaults/",
-               toText _djVaultName, "/jobs/", toText _djJobId]
+              ["/", toPath _djAccountId, "/vaults/",
+               toPath _djVaultName, "/jobs/", toPath _djJobId]
 
 instance ToQuery DescribeJob where
         toQuery = const mempty

--- a/amazonka-glacier/gen/Network/AWS/Glacier/DescribeVault.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/DescribeVault.hs
@@ -116,8 +116,8 @@ instance ToHeaders DescribeVault where
 instance ToPath DescribeVault where
         toPath DescribeVault'{..}
           = mconcat
-              ["/", toText _dvAccountId, "/vaults/",
-               toText _dvVaultName]
+              ["/", toPath _dvAccountId, "/vaults/",
+               toPath _dvVaultName]
 
 instance ToQuery DescribeVault where
         toQuery = const mempty

--- a/amazonka-glacier/gen/Network/AWS/Glacier/GetDataRetrievalPolicy.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/GetDataRetrievalPolicy.hs
@@ -91,7 +91,7 @@ instance ToHeaders GetDataRetrievalPolicy where
 instance ToPath GetDataRetrievalPolicy where
         toPath GetDataRetrievalPolicy'{..}
           = mconcat
-              ["/", toText _gdrpAccountId,
+              ["/", toPath _gdrpAccountId,
                "/policies/data-retrieval"]
 
 instance ToQuery GetDataRetrievalPolicy where

--- a/amazonka-glacier/gen/Network/AWS/Glacier/GetJobOutput.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/GetJobOutput.hs
@@ -173,8 +173,8 @@ instance ToHeaders GetJobOutput where
 instance ToPath GetJobOutput where
         toPath GetJobOutput'{..}
           = mconcat
-              ["/", toText _gjoAccountId, "/vaults/",
-               toText _gjoVaultName, "/jobs/", toText _gjoJobId,
+              ["/", toPath _gjoAccountId, "/vaults/",
+               toPath _gjoVaultName, "/jobs/", toPath _gjoJobId,
                "/output"]
 
 instance ToQuery GetJobOutput where

--- a/amazonka-glacier/gen/Network/AWS/Glacier/GetVaultAccessPolicy.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/GetVaultAccessPolicy.hs
@@ -101,8 +101,8 @@ instance ToHeaders GetVaultAccessPolicy where
 instance ToPath GetVaultAccessPolicy where
         toPath GetVaultAccessPolicy'{..}
           = mconcat
-              ["/", toText _gvapAccountId, "/vaults/",
-               toText _gvapVaultName, "/access-policy"]
+              ["/", toPath _gvapAccountId, "/vaults/",
+               toPath _gvapVaultName, "/access-policy"]
 
 instance ToQuery GetVaultAccessPolicy where
         toQuery = const mempty

--- a/amazonka-glacier/gen/Network/AWS/Glacier/GetVaultLock.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/GetVaultLock.hs
@@ -123,8 +123,8 @@ instance ToHeaders GetVaultLock where
 instance ToPath GetVaultLock where
         toPath GetVaultLock'{..}
           = mconcat
-              ["/", toText _gvlAccountId, "/vaults/",
-               toText _gvlVaultName, "/lock-policy"]
+              ["/", toPath _gvlAccountId, "/vaults/",
+               toPath _gvlVaultName, "/lock-policy"]
 
 instance ToQuery GetVaultLock where
         toQuery = const mempty

--- a/amazonka-glacier/gen/Network/AWS/Glacier/GetVaultNotifications.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/GetVaultNotifications.hs
@@ -116,8 +116,8 @@ instance ToHeaders GetVaultNotifications where
 instance ToPath GetVaultNotifications where
         toPath GetVaultNotifications'{..}
           = mconcat
-              ["/", toText _gvnAccountId, "/vaults/",
-               toText _gvnVaultName, "/notification-configuration"]
+              ["/", toPath _gvnAccountId, "/vaults/",
+               toPath _gvnVaultName, "/notification-configuration"]
 
 instance ToQuery GetVaultNotifications where
         toQuery = const mempty

--- a/amazonka-glacier/gen/Network/AWS/Glacier/InitiateJob.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/InitiateJob.hs
@@ -236,8 +236,8 @@ instance ToJSON InitiateJob where
 instance ToPath InitiateJob where
         toPath InitiateJob'{..}
           = mconcat
-              ["/", toText _ijAccountId, "/vaults/",
-               toText _ijVaultName, "/jobs"]
+              ["/", toPath _ijAccountId, "/vaults/",
+               toPath _ijVaultName, "/jobs"]
 
 instance ToQuery InitiateJob where
         toQuery = const mempty

--- a/amazonka-glacier/gen/Network/AWS/Glacier/InitiateMultipartUpload.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/InitiateMultipartUpload.hs
@@ -166,8 +166,8 @@ instance ToJSON InitiateMultipartUpload where
 instance ToPath InitiateMultipartUpload where
         toPath InitiateMultipartUpload'{..}
           = mconcat
-              ["/", toText _imuAccountId, "/vaults/",
-               toText _imuVaultName, "/multipart-uploads"]
+              ["/", toPath _imuAccountId, "/vaults/",
+               toPath _imuVaultName, "/multipart-uploads"]
 
 instance ToQuery InitiateMultipartUpload where
         toQuery = const mempty

--- a/amazonka-glacier/gen/Network/AWS/Glacier/InitiateVaultLock.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/InitiateVaultLock.hs
@@ -142,8 +142,8 @@ instance ToJSON InitiateVaultLock where
 instance ToPath InitiateVaultLock where
         toPath InitiateVaultLock'{..}
           = mconcat
-              ["/", toText _ivlAccountId, "/vaults/",
-               toText _ivlVaultName, "/lock-policy"]
+              ["/", toPath _ivlAccountId, "/vaults/",
+               toPath _ivlVaultName, "/lock-policy"]
 
 instance ToQuery InitiateVaultLock where
         toQuery = const mempty

--- a/amazonka-glacier/gen/Network/AWS/Glacier/ListJobs.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/ListJobs.hs
@@ -183,8 +183,8 @@ instance ToHeaders ListJobs where
 instance ToPath ListJobs where
         toPath ListJobs'{..}
           = mconcat
-              ["/", toText _ljAccountId, "/vaults/",
-               toText _ljVaultName, "/jobs"]
+              ["/", toPath _ljAccountId, "/vaults/",
+               toPath _ljVaultName, "/jobs"]
 
 instance ToQuery ListJobs where
         toQuery ListJobs'{..}

--- a/amazonka-glacier/gen/Network/AWS/Glacier/ListMultipartUploads.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/ListMultipartUploads.hs
@@ -154,8 +154,8 @@ instance ToHeaders ListMultipartUploads where
 instance ToPath ListMultipartUploads where
         toPath ListMultipartUploads'{..}
           = mconcat
-              ["/", toText _lmuAccountId, "/vaults/",
-               toText _lmuVaultName, "/multipart-uploads"]
+              ["/", toPath _lmuAccountId, "/vaults/",
+               toPath _lmuVaultName, "/multipart-uploads"]
 
 instance ToQuery ListMultipartUploads where
         toQuery ListMultipartUploads'{..}

--- a/amazonka-glacier/gen/Network/AWS/Glacier/ListParts.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/ListParts.hs
@@ -167,9 +167,9 @@ instance ToHeaders ListParts where
 instance ToPath ListParts where
         toPath ListParts'{..}
           = mconcat
-              ["/", toText _lpAccountId, "/vaults/",
-               toText _lpVaultName, "/multipart-uploads/",
-               toText _lpUploadId]
+              ["/", toPath _lpAccountId, "/vaults/",
+               toPath _lpVaultName, "/multipart-uploads/",
+               toPath _lpUploadId]
 
 instance ToQuery ListParts where
         toQuery ListParts'{..}

--- a/amazonka-glacier/gen/Network/AWS/Glacier/ListTagsForVault.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/ListTagsForVault.hs
@@ -97,8 +97,8 @@ instance ToHeaders ListTagsForVault where
 instance ToPath ListTagsForVault where
         toPath ListTagsForVault'{..}
           = mconcat
-              ["/", toText _ltfvAccountId, "/vaults/",
-               toText _ltfvVaultName, "/tags"]
+              ["/", toPath _ltfvAccountId, "/vaults/",
+               toPath _ltfvVaultName, "/tags"]
 
 instance ToQuery ListTagsForVault where
         toQuery = const mempty

--- a/amazonka-glacier/gen/Network/AWS/Glacier/ListVaults.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/ListVaults.hs
@@ -131,7 +131,7 @@ instance ToHeaders ListVaults where
 
 instance ToPath ListVaults where
         toPath ListVaults'{..}
-          = mconcat ["/", toText _lvAccountId, "/vaults"]
+          = mconcat ["/", toPath _lvAccountId, "/vaults"]
 
 instance ToQuery ListVaults where
         toQuery ListVaults'{..}

--- a/amazonka-glacier/gen/Network/AWS/Glacier/RemoveTagsFromVault.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/RemoveTagsFromVault.hs
@@ -105,8 +105,8 @@ instance ToJSON RemoveTagsFromVault where
 instance ToPath RemoveTagsFromVault where
         toPath RemoveTagsFromVault'{..}
           = mconcat
-              ["/", toText _rtfvAccountId, "/vaults/",
-               toText _rtfvVaultName, "/tags"]
+              ["/", toPath _rtfvAccountId, "/vaults/",
+               toPath _rtfvVaultName, "/tags"]
 
 instance ToQuery RemoveTagsFromVault where
         toQuery = const (mconcat ["operation=remove"])

--- a/amazonka-glacier/gen/Network/AWS/Glacier/SetDataRetrievalPolicy.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/SetDataRetrievalPolicy.hs
@@ -103,7 +103,7 @@ instance ToJSON SetDataRetrievalPolicy where
 instance ToPath SetDataRetrievalPolicy where
         toPath SetDataRetrievalPolicy'{..}
           = mconcat
-              ["/", toText _sdrpAccountId,
+              ["/", toPath _sdrpAccountId,
                "/policies/data-retrieval"]
 
 instance ToQuery SetDataRetrievalPolicy where

--- a/amazonka-glacier/gen/Network/AWS/Glacier/SetVaultAccessPolicy.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/SetVaultAccessPolicy.hs
@@ -107,8 +107,8 @@ instance ToJSON SetVaultAccessPolicy where
 instance ToPath SetVaultAccessPolicy where
         toPath SetVaultAccessPolicy'{..}
           = mconcat
-              ["/", toText _svapAccountId, "/vaults/",
-               toText _svapVaultName, "/access-policy"]
+              ["/", toPath _svapAccountId, "/vaults/",
+               toPath _svapVaultName, "/access-policy"]
 
 instance ToQuery SetVaultAccessPolicy where
         toQuery = const mempty

--- a/amazonka-glacier/gen/Network/AWS/Glacier/SetVaultNotifications.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/SetVaultNotifications.hs
@@ -138,8 +138,8 @@ instance ToJSON SetVaultNotifications where
 instance ToPath SetVaultNotifications where
         toPath SetVaultNotifications'{..}
           = mconcat
-              ["/", toText _svnAccountId, "/vaults/",
-               toText _svnVaultName, "/notification-configuration"]
+              ["/", toPath _svnAccountId, "/vaults/",
+               toPath _svnVaultName, "/notification-configuration"]
 
 instance ToQuery SetVaultNotifications where
         toQuery = const mempty

--- a/amazonka-glacier/gen/Network/AWS/Glacier/Types/Sum.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/Types/Sum.hs
@@ -36,9 +36,11 @@ instance ToText ActionCode where
         ArchiveRetrieval -> "archiveretrieval"
         InventoryRetrieval -> "inventoryretrieval"
 
-instance Hashable ActionCode
-instance ToQuery  ActionCode
-instance ToHeader ActionCode
+instance Hashable     ActionCode
+instance ToByteString ActionCode
+instance ToPath       ActionCode
+instance ToQuery      ActionCode
+instance ToHeader     ActionCode
 
 instance FromJSON ActionCode where
     parseJSON = parseJSONText "ActionCode"
@@ -63,9 +65,11 @@ instance ToText StatusCode where
         InProgress -> "inprogress"
         Succeeded -> "succeeded"
 
-instance Hashable StatusCode
-instance ToQuery  StatusCode
-instance ToHeader StatusCode
+instance Hashable     StatusCode
+instance ToByteString StatusCode
+instance ToPath       StatusCode
+instance ToQuery      StatusCode
+instance ToHeader     StatusCode
 
 instance FromJSON StatusCode where
     parseJSON = parseJSONText "StatusCode"

--- a/amazonka-glacier/gen/Network/AWS/Glacier/UploadArchive.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/UploadArchive.hs
@@ -164,8 +164,8 @@ instance ToHeaders UploadArchive where
 instance ToPath UploadArchive where
         toPath UploadArchive'{..}
           = mconcat
-              ["/", toText _uaAccountId, "/vaults/",
-               toText _uaVaultName, "/archives"]
+              ["/", toPath _uaAccountId, "/vaults/",
+               toPath _uaVaultName, "/archives"]
 
 instance ToQuery UploadArchive where
         toQuery = const mempty

--- a/amazonka-glacier/gen/Network/AWS/Glacier/UploadMultipartPart.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/UploadMultipartPart.hs
@@ -189,9 +189,9 @@ instance ToHeaders UploadMultipartPart where
 instance ToPath UploadMultipartPart where
         toPath UploadMultipartPart'{..}
           = mconcat
-              ["/", toText _umpAccountId, "/vaults/",
-               toText _umpVaultName, "/multipart-uploads/",
-               toText _umpUploadId]
+              ["/", toPath _umpAccountId, "/vaults/",
+               toPath _umpVaultName, "/multipart-uploads/",
+               toPath _umpUploadId]
 
 instance ToQuery UploadMultipartPart where
         toQuery = const mempty

--- a/amazonka-iam/amazonka-iam.cabal
+++ b/amazonka-iam/amazonka-iam.cabal
@@ -226,7 +226,7 @@ test-suite amazonka-iam-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-iam == 1.0.0
         , base
         , bytestring

--- a/amazonka-iam/gen/Network/AWS/IAM/Types/Sum.hs
+++ b/amazonka-iam/gen/Network/AWS/IAM/Types/Sum.hs
@@ -39,9 +39,11 @@ instance ToText AssignmentStatusType where
         Assigned -> "assigned"
         Unassigned -> "unassigned"
 
-instance Hashable AssignmentStatusType
-instance ToQuery  AssignmentStatusType
-instance ToHeader AssignmentStatusType
+instance Hashable     AssignmentStatusType
+instance ToByteString AssignmentStatusType
+instance ToPath       AssignmentStatusType
+instance ToQuery      AssignmentStatusType
+instance ToHeader     AssignmentStatusType
 
 data EncodingType
     = Pem
@@ -60,9 +62,11 @@ instance ToText EncodingType where
         Pem -> "pem"
         SSH -> "ssh"
 
-instance Hashable EncodingType
-instance ToQuery  EncodingType
-instance ToHeader EncodingType
+instance Hashable     EncodingType
+instance ToByteString EncodingType
+instance ToPath       EncodingType
+instance ToQuery      EncodingType
+instance ToHeader     EncodingType
 
 data EntityType
     = Group
@@ -90,9 +94,11 @@ instance ToText EntityType where
         Role -> "role"
         User -> "user"
 
-instance Hashable EntityType
-instance ToQuery  EntityType
-instance ToHeader EntityType
+instance Hashable     EntityType
+instance ToByteString EntityType
+instance ToPath       EntityType
+instance ToQuery      EntityType
+instance ToHeader     EntityType
 
 data PolicyScopeType
     = AWS
@@ -114,9 +120,11 @@ instance ToText PolicyScopeType where
         All -> "all"
         Local -> "local"
 
-instance Hashable PolicyScopeType
-instance ToQuery  PolicyScopeType
-instance ToHeader PolicyScopeType
+instance Hashable     PolicyScopeType
+instance ToByteString PolicyScopeType
+instance ToPath       PolicyScopeType
+instance ToQuery      PolicyScopeType
+instance ToHeader     PolicyScopeType
 
 data ReportFormatType =
     TextCSV
@@ -132,9 +140,11 @@ instance ToText ReportFormatType where
     toText = \case
         TextCSV -> "text/csv"
 
-instance Hashable ReportFormatType
-instance ToQuery  ReportFormatType
-instance ToHeader ReportFormatType
+instance Hashable     ReportFormatType
+instance ToByteString ReportFormatType
+instance ToPath       ReportFormatType
+instance ToQuery      ReportFormatType
+instance ToHeader     ReportFormatType
 
 instance FromXML ReportFormatType where
     parseXML = parseXMLText "ReportFormatType"
@@ -159,9 +169,11 @@ instance ToText ReportStateType where
         Inprogress -> "inprogress"
         Started -> "started"
 
-instance Hashable ReportStateType
-instance ToQuery  ReportStateType
-instance ToHeader ReportStateType
+instance Hashable     ReportStateType
+instance ToByteString ReportStateType
+instance ToPath       ReportStateType
+instance ToQuery      ReportStateType
+instance ToHeader     ReportStateType
 
 instance FromXML ReportStateType where
     parseXML = parseXMLText "ReportStateType"
@@ -183,9 +195,11 @@ instance ToText StatusType where
         Active -> "active"
         Inactive -> "inactive"
 
-instance Hashable StatusType
-instance ToQuery  StatusType
-instance ToHeader StatusType
+instance Hashable     StatusType
+instance ToByteString StatusType
+instance ToPath       StatusType
+instance ToQuery      StatusType
+instance ToHeader     StatusType
 
 instance FromXML StatusType where
     parseXML = parseXMLText "StatusType"
@@ -276,9 +290,11 @@ instance ToText SummaryKeyType where
         UsersQuota -> "usersquota"
         VersionsPerPolicyQuota -> "versionsperpolicyquota"
 
-instance Hashable SummaryKeyType
-instance ToQuery  SummaryKeyType
-instance ToHeader SummaryKeyType
+instance Hashable     SummaryKeyType
+instance ToByteString SummaryKeyType
+instance ToPath       SummaryKeyType
+instance ToQuery      SummaryKeyType
+instance ToHeader     SummaryKeyType
 
 instance FromXML SummaryKeyType where
     parseXML = parseXMLText "SummaryKeyType"

--- a/amazonka-importexport/amazonka-importexport.cabal
+++ b/amazonka-importexport/amazonka-importexport.cabal
@@ -69,7 +69,7 @@ test-suite amazonka-importexport-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-importexport == 1.0.0
         , base
         , bytestring

--- a/amazonka-importexport/gen/Network/AWS/ImportExport/Types/Sum.hs
+++ b/amazonka-importexport/gen/Network/AWS/ImportExport/Types/Sum.hs
@@ -37,9 +37,11 @@ instance ToText JobType where
         Export -> "export"
         Import -> "import"
 
-instance Hashable JobType
-instance ToQuery  JobType
-instance ToHeader JobType
+instance Hashable     JobType
+instance ToByteString JobType
+instance ToPath       JobType
+instance ToQuery      JobType
+instance ToHeader     JobType
 
 instance FromXML JobType where
     parseXML = parseXMLText "JobType"

--- a/amazonka-kinesis/amazonka-kinesis.cabal
+++ b/amazonka-kinesis/amazonka-kinesis.cabal
@@ -73,7 +73,7 @@ test-suite amazonka-kinesis-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-kinesis == 1.0.0
         , base
         , bytestring

--- a/amazonka-kinesis/gen/Network/AWS/Kinesis/Types/Sum.hs
+++ b/amazonka-kinesis/gen/Network/AWS/Kinesis/Types/Sum.hs
@@ -42,9 +42,11 @@ instance ToText ShardIteratorType where
         Latest -> "latest"
         TrimHorizon -> "trim_horizon"
 
-instance Hashable ShardIteratorType
-instance ToQuery  ShardIteratorType
-instance ToHeader ShardIteratorType
+instance Hashable     ShardIteratorType
+instance ToByteString ShardIteratorType
+instance ToPath       ShardIteratorType
+instance ToQuery      ShardIteratorType
+instance ToHeader     ShardIteratorType
 
 instance ToJSON ShardIteratorType where
     toJSON = toJSONText
@@ -72,9 +74,11 @@ instance ToText StreamStatus where
         Deleting -> "deleting"
         Updating -> "updating"
 
-instance Hashable StreamStatus
-instance ToQuery  StreamStatus
-instance ToHeader StreamStatus
+instance Hashable     StreamStatus
+instance ToByteString StreamStatus
+instance ToPath       StreamStatus
+instance ToQuery      StreamStatus
+instance ToHeader     StreamStatus
 
 instance FromJSON StreamStatus where
     parseJSON = parseJSONText "StreamStatus"

--- a/amazonka-kms/amazonka-kms.cabal
+++ b/amazonka-kms/amazonka-kms.cabal
@@ -155,7 +155,7 @@ test-suite amazonka-kms-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-kms == 1.0.0
         , base
         , bytestring

--- a/amazonka-kms/gen/Network/AWS/KMS/Types/Sum.hs
+++ b/amazonka-kms/gen/Network/AWS/KMS/Types/Sum.hs
@@ -36,9 +36,11 @@ instance ToText DataKeySpec where
         AES128 -> "aes_128"
         AES256 -> "aes_256"
 
-instance Hashable DataKeySpec
-instance ToQuery  DataKeySpec
-instance ToHeader DataKeySpec
+instance Hashable     DataKeySpec
+instance ToByteString DataKeySpec
+instance ToPath       DataKeySpec
+instance ToQuery      DataKeySpec
+instance ToHeader     DataKeySpec
 
 instance ToJSON DataKeySpec where
     toJSON = toJSONText
@@ -78,9 +80,11 @@ instance ToText GrantOperation where
         ReEncryptTo -> "reencryptto"
         RetireGrant -> "retiregrant"
 
-instance Hashable GrantOperation
-instance ToQuery  GrantOperation
-instance ToHeader GrantOperation
+instance Hashable     GrantOperation
+instance ToByteString GrantOperation
+instance ToPath       GrantOperation
+instance ToQuery      GrantOperation
+instance ToHeader     GrantOperation
 
 instance ToJSON GrantOperation where
     toJSON = toJSONText
@@ -102,9 +106,11 @@ instance ToText KeyUsageType where
     toText = \case
         EncryptDecrypt -> "encrypt_decrypt"
 
-instance Hashable KeyUsageType
-instance ToQuery  KeyUsageType
-instance ToHeader KeyUsageType
+instance Hashable     KeyUsageType
+instance ToByteString KeyUsageType
+instance ToPath       KeyUsageType
+instance ToQuery      KeyUsageType
+instance ToHeader     KeyUsageType
 
 instance ToJSON KeyUsageType where
     toJSON = toJSONText

--- a/amazonka-lambda/amazonka-lambda.cabal
+++ b/amazonka-lambda/amazonka-lambda.cabal
@@ -82,7 +82,7 @@ test-suite amazonka-lambda-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-lambda == 1.0.0
         , base
         , bytestring

--- a/amazonka-lambda/gen/Network/AWS/Lambda/AddPermission.hs
+++ b/amazonka-lambda/gen/Network/AWS/Lambda/AddPermission.hs
@@ -175,7 +175,7 @@ instance ToJSON AddPermission where
 instance ToPath AddPermission where
         toPath AddPermission'{..}
           = mconcat
-              ["/2015-03-31/functions/", toText _apFunctionName,
+              ["/2015-03-31/functions/", toPath _apFunctionName,
                "/versions/HEAD/policy"]
 
 instance ToQuery AddPermission where

--- a/amazonka-lambda/gen/Network/AWS/Lambda/DeleteEventSourceMapping.hs
+++ b/amazonka-lambda/gen/Network/AWS/Lambda/DeleteEventSourceMapping.hs
@@ -87,7 +87,7 @@ instance ToPath DeleteEventSourceMapping where
         toPath DeleteEventSourceMapping'{..}
           = mconcat
               ["/2015-03-31/event-source-mappings/",
-               toText _desmUUId]
+               toPath _desmUUId]
 
 instance ToQuery DeleteEventSourceMapping where
         toQuery = const mempty

--- a/amazonka-lambda/gen/Network/AWS/Lambda/DeleteFunction.hs
+++ b/amazonka-lambda/gen/Network/AWS/Lambda/DeleteFunction.hs
@@ -87,7 +87,7 @@ instance ToHeaders DeleteFunction where
 instance ToPath DeleteFunction where
         toPath DeleteFunction'{..}
           = mconcat
-              ["/2015-03-31/functions/", toText _dfFunctionName]
+              ["/2015-03-31/functions/", toPath _dfFunctionName]
 
 instance ToQuery DeleteFunction where
         toQuery = const mempty

--- a/amazonka-lambda/gen/Network/AWS/Lambda/GetEventSourceMapping.hs
+++ b/amazonka-lambda/gen/Network/AWS/Lambda/GetEventSourceMapping.hs
@@ -87,7 +87,7 @@ instance ToPath GetEventSourceMapping where
         toPath GetEventSourceMapping'{..}
           = mconcat
               ["/2015-03-31/event-source-mappings/",
-               toText _gesmUUId]
+               toPath _gesmUUId]
 
 instance ToQuery GetEventSourceMapping where
         toQuery = const mempty

--- a/amazonka-lambda/gen/Network/AWS/Lambda/GetFunction.hs
+++ b/amazonka-lambda/gen/Network/AWS/Lambda/GetFunction.hs
@@ -96,7 +96,7 @@ instance ToHeaders GetFunction where
 instance ToPath GetFunction where
         toPath GetFunction'{..}
           = mconcat
-              ["/2015-03-31/functions/", toText _gfFunctionName,
+              ["/2015-03-31/functions/", toPath _gfFunctionName,
                "/versions/HEAD"]
 
 instance ToQuery GetFunction where

--- a/amazonka-lambda/gen/Network/AWS/Lambda/GetFunctionConfiguration.hs
+++ b/amazonka-lambda/gen/Network/AWS/Lambda/GetFunctionConfiguration.hs
@@ -99,7 +99,7 @@ instance ToHeaders GetFunctionConfiguration where
 instance ToPath GetFunctionConfiguration where
         toPath GetFunctionConfiguration'{..}
           = mconcat
-              ["/2015-03-31/functions/", toText _gfcFunctionName,
+              ["/2015-03-31/functions/", toPath _gfcFunctionName,
                "/versions/HEAD/configuration"]
 
 instance ToQuery GetFunctionConfiguration where

--- a/amazonka-lambda/gen/Network/AWS/Lambda/GetPolicy.hs
+++ b/amazonka-lambda/gen/Network/AWS/Lambda/GetPolicy.hs
@@ -91,7 +91,7 @@ instance ToHeaders GetPolicy where
 instance ToPath GetPolicy where
         toPath GetPolicy'{..}
           = mconcat
-              ["/2015-03-31/functions/", toText _gpFunctionName,
+              ["/2015-03-31/functions/", toPath _gpFunctionName,
                "/versions/HEAD/policy"]
 
 instance ToQuery GetPolicy where

--- a/amazonka-lambda/gen/Network/AWS/Lambda/Invoke.hs
+++ b/amazonka-lambda/gen/Network/AWS/Lambda/Invoke.hs
@@ -157,7 +157,7 @@ instance ToJSON Invoke where
 instance ToPath Invoke where
         toPath Invoke'{..}
           = mconcat
-              ["/2015-03-31/functions/", toText _iFunctionName,
+              ["/2015-03-31/functions/", toPath _iFunctionName,
                "/invocations"]
 
 instance ToQuery Invoke where

--- a/amazonka-lambda/gen/Network/AWS/Lambda/RemovePermission.hs
+++ b/amazonka-lambda/gen/Network/AWS/Lambda/RemovePermission.hs
@@ -97,8 +97,8 @@ instance ToHeaders RemovePermission where
 instance ToPath RemovePermission where
         toPath RemovePermission'{..}
           = mconcat
-              ["/2015-03-31/functions/", toText _rpFunctionName,
-               "/versions/HEAD/policy/", toText _rpStatementId]
+              ["/2015-03-31/functions/", toPath _rpFunctionName,
+               "/versions/HEAD/policy/", toPath _rpStatementId]
 
 instance ToQuery RemovePermission where
         toQuery = const mempty

--- a/amazonka-lambda/gen/Network/AWS/Lambda/Types/Sum.hs
+++ b/amazonka-lambda/gen/Network/AWS/Lambda/Types/Sum.hs
@@ -36,9 +36,11 @@ instance ToText EventSourcePosition where
         Latest -> "latest"
         TrimHorizon -> "trim_horizon"
 
-instance Hashable EventSourcePosition
-instance ToQuery  EventSourcePosition
-instance ToHeader EventSourcePosition
+instance Hashable     EventSourcePosition
+instance ToByteString EventSourcePosition
+instance ToPath       EventSourcePosition
+instance ToQuery      EventSourcePosition
+instance ToHeader     EventSourcePosition
 
 instance ToJSON EventSourcePosition where
     toJSON = toJSONText
@@ -63,9 +65,11 @@ instance ToText InvocationType where
         Event -> "event"
         RequestResponse -> "requestresponse"
 
-instance Hashable InvocationType
-instance ToQuery  InvocationType
-instance ToHeader InvocationType
+instance Hashable     InvocationType
+instance ToByteString InvocationType
+instance ToPath       InvocationType
+instance ToQuery      InvocationType
+instance ToHeader     InvocationType
 
 instance ToJSON InvocationType where
     toJSON = toJSONText
@@ -87,9 +91,11 @@ instance ToText LogType where
         None -> "none"
         Tail -> "tail"
 
-instance Hashable LogType
-instance ToQuery  LogType
-instance ToHeader LogType
+instance Hashable     LogType
+instance ToByteString LogType
+instance ToPath       LogType
+instance ToQuery      LogType
+instance ToHeader     LogType
 
 instance ToJSON LogType where
     toJSON = toJSONText
@@ -111,9 +117,11 @@ instance ToText Runtime where
         JAVA8 -> "java8"
         Nodejs -> "nodejs"
 
-instance Hashable Runtime
-instance ToQuery  Runtime
-instance ToHeader Runtime
+instance Hashable     Runtime
+instance ToByteString Runtime
+instance ToPath       Runtime
+instance ToQuery      Runtime
+instance ToHeader     Runtime
 
 instance ToJSON Runtime where
     toJSON = toJSONText

--- a/amazonka-lambda/gen/Network/AWS/Lambda/UpdateEventSourceMapping.hs
+++ b/amazonka-lambda/gen/Network/AWS/Lambda/UpdateEventSourceMapping.hs
@@ -135,7 +135,7 @@ instance ToPath UpdateEventSourceMapping where
         toPath UpdateEventSourceMapping'{..}
           = mconcat
               ["/2015-03-31/event-source-mappings/",
-               toText _uesmUUId]
+               toPath _uesmUUId]
 
 instance ToQuery UpdateEventSourceMapping where
         toQuery = const mempty

--- a/amazonka-lambda/gen/Network/AWS/Lambda/UpdateFunctionCode.hs
+++ b/amazonka-lambda/gen/Network/AWS/Lambda/UpdateFunctionCode.hs
@@ -144,7 +144,7 @@ instance ToJSON UpdateFunctionCode where
 instance ToPath UpdateFunctionCode where
         toPath UpdateFunctionCode'{..}
           = mconcat
-              ["/2015-03-31/functions/", toText _uFunctionName,
+              ["/2015-03-31/functions/", toPath _uFunctionName,
                "/versions/HEAD/code"]
 
 instance ToQuery UpdateFunctionCode where

--- a/amazonka-lambda/gen/Network/AWS/Lambda/UpdateFunctionConfiguration.hs
+++ b/amazonka-lambda/gen/Network/AWS/Lambda/UpdateFunctionConfiguration.hs
@@ -163,7 +163,7 @@ instance ToJSON UpdateFunctionConfiguration where
 instance ToPath UpdateFunctionConfiguration where
         toPath UpdateFunctionConfiguration'{..}
           = mconcat
-              ["/2015-03-31/functions/", toText _ufcFunctionName,
+              ["/2015-03-31/functions/", toPath _ufcFunctionName,
                "/versions/HEAD/configuration"]
 
 instance ToQuery UpdateFunctionConfiguration where

--- a/amazonka-ml/amazonka-ml.cabal
+++ b/amazonka-ml/amazonka-ml.cabal
@@ -82,7 +82,7 @@ test-suite amazonka-ml-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-ml == 1.0.0
         , base
         , bytestring

--- a/amazonka-ml/gen/Network/AWS/MachineLearning/Types/Sum.hs
+++ b/amazonka-ml/gen/Network/AWS/MachineLearning/Types/Sum.hs
@@ -38,9 +38,11 @@ instance ToText Algorithm where
     toText = \case
         Sgd -> "sgd"
 
-instance Hashable Algorithm
-instance ToQuery  Algorithm
-instance ToHeader Algorithm
+instance Hashable     Algorithm
+instance ToByteString Algorithm
+instance ToPath       Algorithm
+instance ToQuery      Algorithm
+instance ToHeader     Algorithm
 
 instance FromJSON Algorithm where
     parseJSON = parseJSONText "Algorithm"
@@ -97,9 +99,11 @@ instance ToText BatchPredictionFilterVariable where
         BatchName -> "name"
         BatchStatus -> "status"
 
-instance Hashable BatchPredictionFilterVariable
-instance ToQuery  BatchPredictionFilterVariable
-instance ToHeader BatchPredictionFilterVariable
+instance Hashable     BatchPredictionFilterVariable
+instance ToByteString BatchPredictionFilterVariable
+instance ToPath       BatchPredictionFilterVariable
+instance ToQuery      BatchPredictionFilterVariable
+instance ToHeader     BatchPredictionFilterVariable
 
 instance ToJSON BatchPredictionFilterVariable where
     toJSON = toJSONText
@@ -149,9 +153,11 @@ instance ToText DataSourceFilterVariable where
         DataName -> "name"
         DataStatus -> "status"
 
-instance Hashable DataSourceFilterVariable
-instance ToQuery  DataSourceFilterVariable
-instance ToHeader DataSourceFilterVariable
+instance Hashable     DataSourceFilterVariable
+instance ToByteString DataSourceFilterVariable
+instance ToPath       DataSourceFilterVariable
+instance ToQuery      DataSourceFilterVariable
+instance ToHeader     DataSourceFilterVariable
 
 instance ToJSON DataSourceFilterVariable where
     toJSON = toJSONText
@@ -176,9 +182,11 @@ instance ToText DetailsAttributes where
         Algorithm -> "algorithm"
         PredictiveModelType -> "predictivemodeltype"
 
-instance Hashable DetailsAttributes
-instance ToQuery  DetailsAttributes
-instance ToHeader DetailsAttributes
+instance Hashable     DetailsAttributes
+instance ToByteString DetailsAttributes
+instance ToPath       DetailsAttributes
+instance ToQuery      DetailsAttributes
+instance ToHeader     DetailsAttributes
 
 instance FromJSON DetailsAttributes where
     parseJSON = parseJSONText "DetailsAttributes"
@@ -216,9 +224,11 @@ instance ToText EntityStatus where
         Inprogress -> "inprogress"
         Pending -> "pending"
 
-instance Hashable EntityStatus
-instance ToQuery  EntityStatus
-instance ToHeader EntityStatus
+instance Hashable     EntityStatus
+instance ToByteString EntityStatus
+instance ToPath       EntityStatus
+instance ToQuery      EntityStatus
+instance ToHeader     EntityStatus
 
 instance FromJSON EntityStatus where
     parseJSON = parseJSONText "EntityStatus"
@@ -274,9 +284,11 @@ instance ToText EvaluationFilterVariable where
         EvalName -> "name"
         EvalStatus -> "status"
 
-instance Hashable EvaluationFilterVariable
-instance ToQuery  EvaluationFilterVariable
-instance ToHeader EvaluationFilterVariable
+instance Hashable     EvaluationFilterVariable
+instance ToByteString EvaluationFilterVariable
+instance ToPath       EvaluationFilterVariable
+instance ToQuery      EvaluationFilterVariable
+instance ToHeader     EvaluationFilterVariable
 
 instance ToJSON EvaluationFilterVariable where
     toJSON = toJSONText
@@ -322,9 +334,11 @@ instance ToText MLModelFilterVariable where
         MLMFVTrainingDataSourceId -> "trainingdatasourceid"
         MLMFVTrainingDataURI -> "trainingdatauri"
 
-instance Hashable MLModelFilterVariable
-instance ToQuery  MLModelFilterVariable
-instance ToHeader MLModelFilterVariable
+instance Hashable     MLModelFilterVariable
+instance ToByteString MLModelFilterVariable
+instance ToPath       MLModelFilterVariable
+instance ToQuery      MLModelFilterVariable
+instance ToHeader     MLModelFilterVariable
 
 instance ToJSON MLModelFilterVariable where
     toJSON = toJSONText
@@ -349,9 +363,11 @@ instance ToText MLModelType where
         Multiclass -> "multiclass"
         Regression -> "regression"
 
-instance Hashable MLModelType
-instance ToQuery  MLModelType
-instance ToHeader MLModelType
+instance Hashable     MLModelType
+instance ToByteString MLModelType
+instance ToPath       MLModelType
+instance ToQuery      MLModelType
+instance ToHeader     MLModelType
 
 instance ToJSON MLModelType where
     toJSON = toJSONText
@@ -382,9 +398,11 @@ instance ToText RealtimeEndpointStatus where
         RESReady -> "ready"
         RESUpdating -> "updating"
 
-instance Hashable RealtimeEndpointStatus
-instance ToQuery  RealtimeEndpointStatus
-instance ToHeader RealtimeEndpointStatus
+instance Hashable     RealtimeEndpointStatus
+instance ToByteString RealtimeEndpointStatus
+instance ToPath       RealtimeEndpointStatus
+instance ToQuery      RealtimeEndpointStatus
+instance ToHeader     RealtimeEndpointStatus
 
 instance FromJSON RealtimeEndpointStatus where
     parseJSON = parseJSONText "RealtimeEndpointStatus"
@@ -411,9 +429,11 @@ instance ToText SortOrder where
         Asc -> "asc"
         Dsc -> "dsc"
 
-instance Hashable SortOrder
-instance ToQuery  SortOrder
-instance ToHeader SortOrder
+instance Hashable     SortOrder
+instance ToByteString SortOrder
+instance ToPath       SortOrder
+instance ToQuery      SortOrder
+instance ToHeader     SortOrder
 
 instance ToJSON SortOrder where
     toJSON = toJSONText

--- a/amazonka-opsworks/amazonka-opsworks.cabal
+++ b/amazonka-opsworks/amazonka-opsworks.cabal
@@ -169,7 +169,7 @@ test-suite amazonka-opsworks-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-opsworks == 1.0.0
         , base
         , bytestring

--- a/amazonka-opsworks/gen/Network/AWS/OpsWorks/Types/Sum.hs
+++ b/amazonka-opsworks/gen/Network/AWS/OpsWorks/Types/Sum.hs
@@ -39,9 +39,11 @@ instance ToText AppAttributesKeys where
         DocumentRoot -> "documentroot"
         RailsEnv -> "railsenv"
 
-instance Hashable AppAttributesKeys
-instance ToQuery  AppAttributesKeys
-instance ToHeader AppAttributesKeys
+instance Hashable     AppAttributesKeys
+instance ToByteString AppAttributesKeys
+instance ToPath       AppAttributesKeys
+instance ToQuery      AppAttributesKeys
+instance ToHeader     AppAttributesKeys
 
 instance ToJSON AppAttributesKeys where
     toJSON = toJSONText
@@ -78,9 +80,11 @@ instance ToText AppType where
         Rails -> "rails"
         Static -> "static"
 
-instance Hashable AppType
-instance ToQuery  AppType
-instance ToHeader AppType
+instance Hashable     AppType
+instance ToByteString AppType
+instance ToPath       AppType
+instance ToQuery      AppType
+instance ToHeader     AppType
 
 instance ToJSON AppType where
     toJSON = toJSONText
@@ -105,9 +109,11 @@ instance ToText Architecture where
         I386 -> "i386"
         X86_64 -> "x86_64"
 
-instance Hashable Architecture
-instance ToQuery  Architecture
-instance ToHeader Architecture
+instance Hashable     Architecture
+instance ToByteString Architecture
+instance ToPath       Architecture
+instance ToQuery      Architecture
+instance ToHeader     Architecture
 
 instance ToJSON Architecture where
     toJSON = toJSONText
@@ -132,9 +138,11 @@ instance ToText AutoScalingType where
         Load -> "load"
         Timer -> "timer"
 
-instance Hashable AutoScalingType
-instance ToQuery  AutoScalingType
-instance ToHeader AutoScalingType
+instance Hashable     AutoScalingType
+instance ToByteString AutoScalingType
+instance ToPath       AutoScalingType
+instance ToQuery      AutoScalingType
+instance ToHeader     AutoScalingType
 
 instance ToJSON AutoScalingType where
     toJSON = toJSONText
@@ -189,9 +197,11 @@ instance ToText DeploymentCommandName where
         UpdateCustomCookbooks -> "update_custom_cookbooks"
         UpdateDependencies -> "update_dependencies"
 
-instance Hashable DeploymentCommandName
-instance ToQuery  DeploymentCommandName
-instance ToHeader DeploymentCommandName
+instance Hashable     DeploymentCommandName
+instance ToByteString DeploymentCommandName
+instance ToPath       DeploymentCommandName
+instance ToQuery      DeploymentCommandName
+instance ToHeader     DeploymentCommandName
 
 instance ToJSON DeploymentCommandName where
     toJSON = toJSONText
@@ -282,9 +292,11 @@ instance ToText LayerAttributesKeys where
         RubyVersion -> "rubyversion"
         RubygemsVersion -> "rubygemsversion"
 
-instance Hashable LayerAttributesKeys
-instance ToQuery  LayerAttributesKeys
-instance ToHeader LayerAttributesKeys
+instance Hashable     LayerAttributesKeys
+instance ToByteString LayerAttributesKeys
+instance ToPath       LayerAttributesKeys
+instance ToQuery      LayerAttributesKeys
+instance ToHeader     LayerAttributesKeys
 
 instance ToJSON LayerAttributesKeys where
     toJSON = toJSONText
@@ -333,9 +345,11 @@ instance ToText LayerType where
         RailsApp -> "rails-app"
         Web -> "web"
 
-instance Hashable LayerType
-instance ToQuery  LayerType
-instance ToHeader LayerType
+instance Hashable     LayerType
+instance ToByteString LayerType
+instance ToPath       LayerType
+instance ToQuery      LayerType
+instance ToHeader     LayerType
 
 instance ToJSON LayerType where
     toJSON = toJSONText
@@ -360,9 +374,11 @@ instance ToText RootDeviceType where
         EBS -> "ebs"
         InstanceStore -> "instance-store"
 
-instance Hashable RootDeviceType
-instance ToQuery  RootDeviceType
-instance ToHeader RootDeviceType
+instance Hashable     RootDeviceType
+instance ToByteString RootDeviceType
+instance ToPath       RootDeviceType
+instance ToQuery      RootDeviceType
+instance ToHeader     RootDeviceType
 
 instance ToJSON RootDeviceType where
     toJSON = toJSONText
@@ -393,9 +409,11 @@ instance ToText SourceType where
         S3 -> "s3"
         SVN -> "svn"
 
-instance Hashable SourceType
-instance ToQuery  SourceType
-instance ToHeader SourceType
+instance Hashable     SourceType
+instance ToByteString SourceType
+instance ToPath       SourceType
+instance ToQuery      SourceType
+instance ToHeader     SourceType
 
 instance ToJSON SourceType where
     toJSON = toJSONText
@@ -417,9 +435,11 @@ instance ToText StackAttributesKeys where
     toText = \case
         Color -> "color"
 
-instance Hashable StackAttributesKeys
-instance ToQuery  StackAttributesKeys
-instance ToHeader StackAttributesKeys
+instance Hashable     StackAttributesKeys
+instance ToByteString StackAttributesKeys
+instance ToPath       StackAttributesKeys
+instance ToQuery      StackAttributesKeys
+instance ToHeader     StackAttributesKeys
 
 instance ToJSON StackAttributesKeys where
     toJSON = toJSONText
@@ -444,9 +464,11 @@ instance ToText VirtualizationType where
         HVM -> "hvm"
         Paravirtual -> "paravirtual"
 
-instance Hashable VirtualizationType
-instance ToQuery  VirtualizationType
-instance ToHeader VirtualizationType
+instance Hashable     VirtualizationType
+instance ToByteString VirtualizationType
+instance ToPath       VirtualizationType
+instance ToQuery      VirtualizationType
+instance ToHeader     VirtualizationType
 
 instance FromJSON VirtualizationType where
     parseJSON = parseJSONText "VirtualizationType"
@@ -471,9 +493,11 @@ instance ToText VolumeType where
         IO1 -> "io1"
         Standard -> "standard"
 
-instance Hashable VolumeType
-instance ToQuery  VolumeType
-instance ToHeader VolumeType
+instance Hashable     VolumeType
+instance ToByteString VolumeType
+instance ToPath       VolumeType
+instance ToQuery      VolumeType
+instance ToHeader     VolumeType
 
 instance ToJSON VolumeType where
     toJSON = toJSONText

--- a/amazonka-rds/amazonka-rds.cabal
+++ b/amazonka-rds/amazonka-rds.cabal
@@ -142,7 +142,7 @@ test-suite amazonka-rds-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-rds == 1.0.0
         , base
         , bytestring

--- a/amazonka-rds/gen/Network/AWS/RDS/Types/Sum.hs
+++ b/amazonka-rds/gen/Network/AWS/RDS/Types/Sum.hs
@@ -36,9 +36,11 @@ instance ToText ApplyMethod where
         Immediate -> "immediate"
         PendingReboot -> "pending-reboot"
 
-instance Hashable ApplyMethod
-instance ToQuery  ApplyMethod
-instance ToHeader ApplyMethod
+instance Hashable     ApplyMethod
+instance ToByteString ApplyMethod
+instance ToPath       ApplyMethod
+instance ToQuery      ApplyMethod
+instance ToHeader     ApplyMethod
 
 instance FromXML ApplyMethod where
     parseXML = parseXMLText "ApplyMethod"
@@ -66,9 +68,11 @@ instance ToText SourceType where
         DBSecurityGroup -> "db-security-group"
         DBSnapshot -> "db-snapshot"
 
-instance Hashable SourceType
-instance ToQuery  SourceType
-instance ToHeader SourceType
+instance Hashable     SourceType
+instance ToByteString SourceType
+instance ToPath       SourceType
+instance ToQuery      SourceType
+instance ToHeader     SourceType
 
 instance FromXML SourceType where
     parseXML = parseXMLText "SourceType"

--- a/amazonka-redshift/amazonka-redshift.cabal
+++ b/amazonka-redshift/amazonka-redshift.cabal
@@ -142,7 +142,7 @@ test-suite amazonka-redshift-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-redshift == 1.0.0
         , base
         , bytestring

--- a/amazonka-redshift/gen/Network/AWS/Redshift/Types/Sum.hs
+++ b/amazonka-redshift/gen/Network/AWS/Redshift/Types/Sum.hs
@@ -36,9 +36,11 @@ instance ToText ParameterApplyType where
         Dynamic -> "dynamic"
         Static -> "static"
 
-instance Hashable ParameterApplyType
-instance ToQuery  ParameterApplyType
-instance ToHeader ParameterApplyType
+instance Hashable     ParameterApplyType
+instance ToByteString ParameterApplyType
+instance ToPath       ParameterApplyType
+instance ToQuery      ParameterApplyType
+instance ToHeader     ParameterApplyType
 
 instance FromXML ParameterApplyType where
     parseXML = parseXMLText "ParameterApplyType"
@@ -66,9 +68,11 @@ instance ToText SourceType where
         ClusterSecurityGroup -> "cluster-security-group"
         ClusterSnapshot -> "cluster-snapshot"
 
-instance Hashable SourceType
-instance ToQuery  SourceType
-instance ToHeader SourceType
+instance Hashable     SourceType
+instance ToByteString SourceType
+instance ToPath       SourceType
+instance ToQuery      SourceType
+instance ToHeader     SourceType
 
 instance FromXML SourceType where
     parseXML = parseXMLText "SourceType"

--- a/amazonka-route53-domains/amazonka-route53-domains.cabal
+++ b/amazonka-route53-domains/amazonka-route53-domains.cabal
@@ -75,7 +75,7 @@ test-suite amazonka-route53-domains-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-route53-domains == 1.0.0
         , base
         , bytestring

--- a/amazonka-route53-domains/gen/Network/AWS/Route53Domains/Types/Sum.hs
+++ b/amazonka-route53-domains/gen/Network/AWS/Route53Domains/Types/Sum.hs
@@ -45,9 +45,11 @@ instance ToText ContactType where
         PublicBody -> "public_body"
         Reseller -> "reseller"
 
-instance Hashable ContactType
-instance ToQuery  ContactType
-instance ToHeader ContactType
+instance Hashable     ContactType
+instance ToByteString ContactType
+instance ToPath       ContactType
+instance ToQuery      ContactType
+instance ToHeader     ContactType
 
 instance ToJSON ContactType where
     toJSON = toJSONText
@@ -753,9 +755,11 @@ instance ToText CountryCode where
         ZM -> "zm"
         ZW -> "zw"
 
-instance Hashable CountryCode
-instance ToQuery  CountryCode
-instance ToHeader CountryCode
+instance Hashable     CountryCode
+instance ToByteString CountryCode
+instance ToPath       CountryCode
+instance ToQuery      CountryCode
+instance ToHeader     CountryCode
 
 instance ToJSON CountryCode where
     toJSON = toJSONText
@@ -798,9 +802,11 @@ instance ToText DomainAvailability where
         UnavailablePremium -> "unavailable_premium"
         UnavailableRestricted -> "unavailable_restricted"
 
-instance Hashable DomainAvailability
-instance ToQuery  DomainAvailability
-instance ToHeader DomainAvailability
+instance Hashable     DomainAvailability
+instance ToByteString DomainAvailability
+instance ToPath       DomainAvailability
+instance ToQuery      DomainAvailability
+instance ToHeader     DomainAvailability
 
 instance FromJSON DomainAvailability where
     parseJSON = parseJSONText "DomainAvailability"
@@ -876,9 +882,11 @@ instance ToText ExtraParamName where
         SgIdNumber -> "sg_id_number"
         VatNumber -> "vat_number"
 
-instance Hashable ExtraParamName
-instance ToQuery  ExtraParamName
-instance ToHeader ExtraParamName
+instance Hashable     ExtraParamName
+instance ToByteString ExtraParamName
+instance ToPath       ExtraParamName
+instance ToQuery      ExtraParamName
+instance ToHeader     ExtraParamName
 
 instance ToJSON ExtraParamName where
     toJSON = toJSONText
@@ -912,9 +920,11 @@ instance ToText OperationStatus where
         Submitted -> "submitted"
         Successful -> "successful"
 
-instance Hashable OperationStatus
-instance ToQuery  OperationStatus
-instance ToHeader OperationStatus
+instance Hashable     OperationStatus
+instance ToByteString OperationStatus
+instance ToPath       OperationStatus
+instance ToQuery      OperationStatus
+instance ToHeader     OperationStatus
 
 instance FromJSON OperationStatus where
     parseJSON = parseJSONText "OperationStatus"
@@ -951,9 +961,11 @@ instance ToText OperationType where
         UpdateDomainContact -> "update_domain_contact"
         UpdateNameserver -> "update_nameserver"
 
-instance Hashable OperationType
-instance ToQuery  OperationType
-instance ToHeader OperationType
+instance Hashable     OperationType
+instance ToByteString OperationType
+instance ToPath       OperationType
+instance ToQuery      OperationType
+instance ToHeader     OperationType
 
 instance FromJSON OperationType where
     parseJSON = parseJSONText "OperationType"

--- a/amazonka-route53/amazonka-route53.cabal
+++ b/amazonka-route53/amazonka-route53.cabal
@@ -93,7 +93,7 @@ test-suite amazonka-route53-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-route53 == 1.0.0
         , base
         , bytestring

--- a/amazonka-route53/gen/Network/AWS/Route53/AssociateVPCWithHostedZone.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/AssociateVPCWithHostedZone.hs
@@ -120,7 +120,7 @@ instance ToPath AssociateVPCWithHostedZone where
         toPath AssociateVPCWithHostedZone'{..}
           = mconcat
               ["/2013-04-01/hostedzone/",
-               toText _avwhzHostedZoneId, "/associatevpc"]
+               toPath _avwhzHostedZoneId, "/associatevpc"]
 
 instance ToQuery AssociateVPCWithHostedZone where
         toQuery = const mempty

--- a/amazonka-route53/gen/Network/AWS/Route53/ChangeResourceRecordSets.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/ChangeResourceRecordSets.hs
@@ -128,7 +128,7 @@ instance ToHeaders ChangeResourceRecordSets where
 instance ToPath ChangeResourceRecordSets where
         toPath ChangeResourceRecordSets'{..}
           = mconcat
-              ["/2013-04-01/hostedzone/", toText _crrsHostedZoneId,
+              ["/2013-04-01/hostedzone/", toPath _crrsHostedZoneId,
                "/rrset/"]
 
 instance ToQuery ChangeResourceRecordSets where

--- a/amazonka-route53/gen/Network/AWS/Route53/ChangeTagsForResource.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/ChangeTagsForResource.hs
@@ -122,8 +122,8 @@ instance ToHeaders ChangeTagsForResource where
 instance ToPath ChangeTagsForResource where
         toPath ChangeTagsForResource'{..}
           = mconcat
-              ["/2013-04-01/tags/", toText _ctfrResourceType, "/",
-               toText _ctfrResourceId]
+              ["/2013-04-01/tags/", toPath _ctfrResourceType, "/",
+               toPath _ctfrResourceId]
 
 instance ToQuery ChangeTagsForResource where
         toQuery = const mempty

--- a/amazonka-route53/gen/Network/AWS/Route53/DeleteHealthCheck.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/DeleteHealthCheck.hs
@@ -91,7 +91,7 @@ instance ToPath DeleteHealthCheck where
         toPath DeleteHealthCheck'{..}
           = mconcat
               ["/2013-04-01/healthcheck/",
-               toText _dhcHealthCheckId]
+               toPath _dhcHealthCheckId]
 
 instance ToQuery DeleteHealthCheck where
         toQuery = const mempty

--- a/amazonka-route53/gen/Network/AWS/Route53/DeleteHostedZone.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/DeleteHostedZone.hs
@@ -95,7 +95,7 @@ instance ToHeaders DeleteHostedZone where
 
 instance ToPath DeleteHostedZone where
         toPath DeleteHostedZone'{..}
-          = mconcat ["/2013-04-01/hostedzone/", toText _dhzId]
+          = mconcat ["/2013-04-01/hostedzone/", toPath _dhzId]
 
 instance ToQuery DeleteHostedZone where
         toQuery = const mempty

--- a/amazonka-route53/gen/Network/AWS/Route53/DeleteReusableDelegationSet.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/DeleteReusableDelegationSet.hs
@@ -90,7 +90,7 @@ instance ToHeaders DeleteReusableDelegationSet where
 instance ToPath DeleteReusableDelegationSet where
         toPath DeleteReusableDelegationSet'{..}
           = mconcat
-              ["/2013-04-01/delegationset/", toText _drdsId]
+              ["/2013-04-01/delegationset/", toPath _drdsId]
 
 instance ToQuery DeleteReusableDelegationSet where
         toQuery = const mempty

--- a/amazonka-route53/gen/Network/AWS/Route53/DisassociateVPCFromHostedZone.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/DisassociateVPCFromHostedZone.hs
@@ -122,7 +122,7 @@ instance ToPath DisassociateVPCFromHostedZone where
         toPath DisassociateVPCFromHostedZone'{..}
           = mconcat
               ["/2013-04-01/hostedzone/",
-               toText _dvfhzHostedZoneId, "/disassociatevpc"]
+               toPath _dvfhzHostedZoneId, "/disassociatevpc"]
 
 instance ToQuery DisassociateVPCFromHostedZone where
         toQuery = const mempty

--- a/amazonka-route53/gen/Network/AWS/Route53/GetChange.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/GetChange.hs
@@ -90,7 +90,7 @@ instance ToHeaders GetChange where
 
 instance ToPath GetChange where
         toPath GetChange'{..}
-          = mconcat ["/2013-04-01/change/", toText _gcId]
+          = mconcat ["/2013-04-01/change/", toPath _gcId]
 
 instance ToQuery GetChange where
         toQuery = const mempty

--- a/amazonka-route53/gen/Network/AWS/Route53/GetHealthCheck.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/GetHealthCheck.hs
@@ -84,7 +84,7 @@ instance ToPath GetHealthCheck where
         toPath GetHealthCheck'{..}
           = mconcat
               ["/2013-04-01/healthcheck/",
-               toText _ghcHealthCheckId]
+               toPath _ghcHealthCheckId]
 
 instance ToQuery GetHealthCheck where
         toQuery = const mempty

--- a/amazonka-route53/gen/Network/AWS/Route53/GetHealthCheckLastFailureReason.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/GetHealthCheckLastFailureReason.hs
@@ -92,7 +92,7 @@ instance ToPath GetHealthCheckLastFailureReason where
         toPath GetHealthCheckLastFailureReason'{..}
           = mconcat
               ["/2013-04-01/healthcheck/",
-               toText _ghclfrHealthCheckId, "/lastfailurereason"]
+               toPath _ghclfrHealthCheckId, "/lastfailurereason"]
 
 instance ToQuery GetHealthCheckLastFailureReason
          where

--- a/amazonka-route53/gen/Network/AWS/Route53/GetHealthCheckStatus.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/GetHealthCheckStatus.hs
@@ -89,7 +89,7 @@ instance ToPath GetHealthCheckStatus where
         toPath GetHealthCheckStatus'{..}
           = mconcat
               ["/2013-04-01/healthcheck/",
-               toText _ghcsHealthCheckId, "/status"]
+               toPath _ghcsHealthCheckId, "/status"]
 
 instance ToQuery GetHealthCheckStatus where
         toQuery = const mempty

--- a/amazonka-route53/gen/Network/AWS/Route53/GetHostedZone.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/GetHostedZone.hs
@@ -90,7 +90,7 @@ instance ToHeaders GetHostedZone where
 
 instance ToPath GetHostedZone where
         toPath GetHostedZone'{..}
-          = mconcat ["/2013-04-01/hostedzone/", toText _ghzId]
+          = mconcat ["/2013-04-01/hostedzone/", toPath _ghzId]
 
 instance ToQuery GetHostedZone where
         toQuery = const mempty

--- a/amazonka-route53/gen/Network/AWS/Route53/GetReusableDelegationSet.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/GetReusableDelegationSet.hs
@@ -84,7 +84,7 @@ instance ToHeaders GetReusableDelegationSet where
 instance ToPath GetReusableDelegationSet where
         toPath GetReusableDelegationSet'{..}
           = mconcat
-              ["/2013-04-01/delegationset/", toText _grdsId]
+              ["/2013-04-01/delegationset/", toPath _grdsId]
 
 instance ToQuery GetReusableDelegationSet where
         toQuery = const mempty

--- a/amazonka-route53/gen/Network/AWS/Route53/ListResourceRecordSets.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/ListResourceRecordSets.hs
@@ -205,7 +205,7 @@ instance ToHeaders ListResourceRecordSets where
 instance ToPath ListResourceRecordSets where
         toPath ListResourceRecordSets'{..}
           = mconcat
-              ["/2013-04-01/hostedzone/", toText _lrrsHostedZoneId,
+              ["/2013-04-01/hostedzone/", toPath _lrrsHostedZoneId,
                "/rrset"]
 
 instance ToQuery ListResourceRecordSets where

--- a/amazonka-route53/gen/Network/AWS/Route53/ListTagsForResource.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/ListTagsForResource.hs
@@ -96,8 +96,8 @@ instance ToHeaders ListTagsForResource where
 instance ToPath ListTagsForResource where
         toPath ListTagsForResource'{..}
           = mconcat
-              ["/2013-04-01/tags/", toText _ltfrResourceType, "/",
-               toText _ltfrResourceId]
+              ["/2013-04-01/tags/", toPath _ltfrResourceType, "/",
+               toPath _ltfrResourceId]
 
 instance ToQuery ListTagsForResource where
         toQuery = const mempty

--- a/amazonka-route53/gen/Network/AWS/Route53/ListTagsForResources.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/ListTagsForResources.hs
@@ -104,7 +104,7 @@ instance ToHeaders ListTagsForResources where
 instance ToPath ListTagsForResources where
         toPath ListTagsForResources'{..}
           = mconcat
-              ["/2013-04-01/tags/", toText _lResourceType]
+              ["/2013-04-01/tags/", toPath _lResourceType]
 
 instance ToQuery ListTagsForResources where
         toQuery = const mempty

--- a/amazonka-route53/gen/Network/AWS/Route53/Types/Sum.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/Types/Sum.hs
@@ -40,9 +40,11 @@ instance ToText ChangeAction where
         Delete -> "delete"
         Upsert -> "upsert"
 
-instance Hashable ChangeAction
-instance ToQuery  ChangeAction
-instance ToHeader ChangeAction
+instance Hashable     ChangeAction
+instance ToByteString ChangeAction
+instance ToPath       ChangeAction
+instance ToQuery      ChangeAction
+instance ToHeader     ChangeAction
 
 instance ToXML ChangeAction where
     toXML = toXMLText
@@ -64,9 +66,11 @@ instance ToText ChangeStatus where
         Insync -> "insync"
         Pending -> "pending"
 
-instance Hashable ChangeStatus
-instance ToQuery  ChangeStatus
-instance ToHeader ChangeStatus
+instance Hashable     ChangeStatus
+instance ToByteString ChangeStatus
+instance ToPath       ChangeStatus
+instance ToQuery      ChangeStatus
+instance ToHeader     ChangeStatus
 
 instance FromXML ChangeStatus where
     parseXML = parseXMLText "ChangeStatus"
@@ -88,9 +92,11 @@ instance ToText Failover where
         Primary -> "primary"
         Secondary -> "secondary"
 
-instance Hashable Failover
-instance ToQuery  Failover
-instance ToHeader Failover
+instance Hashable     Failover
+instance ToByteString Failover
+instance ToPath       Failover
+instance ToQuery      Failover
+instance ToHeader     Failover
 
 instance FromXML Failover where
     parseXML = parseXMLText "Failover"
@@ -124,9 +130,11 @@ instance ToText HealthCheckType where
         HTTPStrMatch -> "http_str_match"
         TCP -> "tcp"
 
-instance Hashable HealthCheckType
-instance ToQuery  HealthCheckType
-instance ToHeader HealthCheckType
+instance Hashable     HealthCheckType
+instance ToByteString HealthCheckType
+instance ToPath       HealthCheckType
+instance ToQuery      HealthCheckType
+instance ToHeader     HealthCheckType
 
 instance FromXML HealthCheckType where
     parseXML = parseXMLText "HealthCheckType"
@@ -175,9 +183,11 @@ instance ToText RecordType where
         Srv -> "srv"
         Txt -> "txt"
 
-instance Hashable RecordType
-instance ToQuery  RecordType
-instance ToHeader RecordType
+instance Hashable     RecordType
+instance ToByteString RecordType
+instance ToPath       RecordType
+instance ToQuery      RecordType
+instance ToHeader     RecordType
 
 instance FromXML RecordType where
     parseXML = parseXMLText "RecordType"
@@ -202,9 +212,11 @@ instance ToText TagResourceType where
         Healthcheck -> "healthcheck"
         Hostedzone -> "hostedzone"
 
-instance Hashable TagResourceType
-instance ToQuery  TagResourceType
-instance ToHeader TagResourceType
+instance Hashable     TagResourceType
+instance ToByteString TagResourceType
+instance ToPath       TagResourceType
+instance ToQuery      TagResourceType
+instance ToHeader     TagResourceType
 
 instance FromXML TagResourceType where
     parseXML = parseXMLText "TagResourceType"
@@ -253,9 +265,11 @@ instance ToText VPCRegion where
         UsWest1 -> "us-west-1"
         UsWest2 -> "us-west-2"
 
-instance Hashable VPCRegion
-instance ToQuery  VPCRegion
-instance ToHeader VPCRegion
+instance Hashable     VPCRegion
+instance ToByteString VPCRegion
+instance ToPath       VPCRegion
+instance ToQuery      VPCRegion
+instance ToHeader     VPCRegion
 
 instance FromXML VPCRegion where
     parseXML = parseXMLText "VPCRegion"

--- a/amazonka-route53/gen/Network/AWS/Route53/UpdateHealthCheck.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/UpdateHealthCheck.hs
@@ -186,7 +186,7 @@ instance ToPath UpdateHealthCheck where
         toPath UpdateHealthCheck'{..}
           = mconcat
               ["/2013-04-01/healthcheck/",
-               toText _uhcHealthCheckId]
+               toPath _uhcHealthCheckId]
 
 instance ToQuery UpdateHealthCheck where
         toQuery = const mempty

--- a/amazonka-route53/gen/Network/AWS/Route53/UpdateHostedZoneComment.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/UpdateHostedZoneComment.hs
@@ -101,7 +101,7 @@ instance ToHeaders UpdateHostedZoneComment where
 
 instance ToPath UpdateHostedZoneComment where
         toPath UpdateHostedZoneComment'{..}
-          = mconcat ["/2013-04-01/hostedzone/", toText _uhzcId]
+          = mconcat ["/2013-04-01/hostedzone/", toPath _uhzcId]
 
 instance ToQuery UpdateHostedZoneComment where
         toQuery = const mempty

--- a/amazonka-route53/src/Network/AWS/Route53/Internal.hs
+++ b/amazonka-route53/src/Network/AWS/Route53/Internal.hs
@@ -1,15 +1,13 @@
+-- |
 -- Module      : Network.AWS.Route53.Internal
 -- Copyright   : (c) 2013-2015 Brendan Hay
--- License     : This Source Code Form is subject to the terms of
---               the Mozilla Public License, v. 2.0.
---               A copy of the MPL can be found in the LICENSE file or
---               you can obtain it at http://mozilla.org/MPL/2.0/.
+-- License     : Mozilla Public License, v. 2.0.
 -- Maintainer  : Brendan Hay <brendan.g.hay@gmail.com>
 -- Stability   : experimental
 -- Portability : non-portable (GHC extensions)
-
+--
 module Network.AWS.Route53.Internal
     ( Region (..)
     ) where
 
-import Network.AWS.Types (Region(..))
+import           Network.AWS.Types (Region (..))

--- a/amazonka-s3/amazonka-s3.cabal
+++ b/amazonka-s3/amazonka-s3.cabal
@@ -98,6 +98,9 @@ library
     build-depends:
           amazonka-core == 1.0.0.*
         , base          >= 4.7     && < 5
+        , bytestring >= 0.9
+        , containers >= 0.5
+        , lens       >= 4.4
 
 test-suite amazonka-s3-test
     type:              exitcode-stdio-1.0
@@ -116,7 +119,7 @@ test-suite amazonka-s3-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-s3 == 1.0.0
         , base
         , bytestring

--- a/amazonka-s3/amazonka-s3.cabal
+++ b/amazonka-s3/amazonka-s3.cabal
@@ -98,9 +98,8 @@ library
     build-depends:
           amazonka-core == 1.0.0.*
         , base          >= 4.7     && < 5
-        , bytestring >= 0.9
-        , containers >= 0.5
-        , lens       >= 4.4
+        , lens >= 4.4
+        , text >= 1.1
 
 test-suite amazonka-s3-test
     type:              exitcode-stdio-1.0

--- a/amazonka-s3/gen/Network/AWS/S3/AbortMultipartUpload.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/AbortMultipartUpload.hs
@@ -113,7 +113,7 @@ instance ToHeaders AbortMultipartUpload where
 instance ToPath AbortMultipartUpload where
         toPath AbortMultipartUpload'{..}
           = mconcat
-              ["/", toText _amuBucket, "/", toText _amuKey]
+              ["/", toPath _amuBucket, "/", toPath _amuKey]
 
 instance ToQuery AbortMultipartUpload where
         toQuery AbortMultipartUpload'{..}

--- a/amazonka-s3/gen/Network/AWS/S3/CompleteMultipartUpload.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/CompleteMultipartUpload.hs
@@ -140,7 +140,7 @@ instance ToHeaders CompleteMultipartUpload where
 
 instance ToPath CompleteMultipartUpload where
         toPath CompleteMultipartUpload'{..}
-          = mconcat ["/", toText _cBucket, "/", toText _cKey]
+          = mconcat ["/", toPath _cBucket, "/", toPath _cKey]
 
 instance ToQuery CompleteMultipartUpload where
         toQuery CompleteMultipartUpload'{..}

--- a/amazonka-s3/gen/Network/AWS/S3/CopyObject.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/CopyObject.hs
@@ -435,7 +435,7 @@ instance ToHeaders CopyObject where
 
 instance ToPath CopyObject where
         toPath CopyObject'{..}
-          = mconcat ["/", toText _coBucket, "/", toText _coKey]
+          = mconcat ["/", toPath _coBucket, "/", toPath _coKey]
 
 instance ToQuery CopyObject where
         toQuery = const mempty

--- a/amazonka-s3/gen/Network/AWS/S3/CreateBucket.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/CreateBucket.hs
@@ -157,7 +157,7 @@ instance ToHeaders CreateBucket where
 
 instance ToPath CreateBucket where
         toPath CreateBucket'{..}
-          = mconcat ["/", toText _cbBucket]
+          = mconcat ["/", toPath _cbBucket]
 
 instance ToQuery CreateBucket where
         toQuery = const mempty

--- a/amazonka-s3/gen/Network/AWS/S3/CreateMultipartUpload.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/CreateMultipartUpload.hs
@@ -338,7 +338,7 @@ instance ToHeaders CreateMultipartUpload where
 instance ToPath CreateMultipartUpload where
         toPath CreateMultipartUpload'{..}
           = mconcat
-              ["/", toText _cmuBucket, "/", toText _cmuKey]
+              ["/", toPath _cmuBucket, "/", toPath _cmuKey]
 
 instance ToQuery CreateMultipartUpload where
         toQuery = const (mconcat ["uploads"])

--- a/amazonka-s3/gen/Network/AWS/S3/DeleteBucket.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/DeleteBucket.hs
@@ -73,7 +73,7 @@ instance ToHeaders DeleteBucket where
 
 instance ToPath DeleteBucket where
         toPath DeleteBucket'{..}
-          = mconcat ["/", toText _dbBucket]
+          = mconcat ["/", toPath _dbBucket]
 
 instance ToQuery DeleteBucket where
         toQuery = const mempty

--- a/amazonka-s3/gen/Network/AWS/S3/DeleteBucketCORS.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/DeleteBucketCORS.hs
@@ -71,7 +71,7 @@ instance ToHeaders DeleteBucketCORS where
 
 instance ToPath DeleteBucketCORS where
         toPath DeleteBucketCORS'{..}
-          = mconcat ["/", toText _dbcBucket]
+          = mconcat ["/", toPath _dbcBucket]
 
 instance ToQuery DeleteBucketCORS where
         toQuery = const (mconcat ["cors"])

--- a/amazonka-s3/gen/Network/AWS/S3/DeleteBucketLifecycle.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/DeleteBucketLifecycle.hs
@@ -72,7 +72,7 @@ instance ToHeaders DeleteBucketLifecycle where
 
 instance ToPath DeleteBucketLifecycle where
         toPath DeleteBucketLifecycle'{..}
-          = mconcat ["/", toText _dblBucket]
+          = mconcat ["/", toPath _dblBucket]
 
 instance ToQuery DeleteBucketLifecycle where
         toQuery = const (mconcat ["lifecycle"])

--- a/amazonka-s3/gen/Network/AWS/S3/DeleteBucketPolicy.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/DeleteBucketPolicy.hs
@@ -72,7 +72,7 @@ instance ToHeaders DeleteBucketPolicy where
 
 instance ToPath DeleteBucketPolicy where
         toPath DeleteBucketPolicy'{..}
-          = mconcat ["/", toText _dbpBucket]
+          = mconcat ["/", toPath _dbpBucket]
 
 instance ToQuery DeleteBucketPolicy where
         toQuery = const (mconcat ["policy"])

--- a/amazonka-s3/gen/Network/AWS/S3/DeleteBucketReplication.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/DeleteBucketReplication.hs
@@ -73,7 +73,7 @@ instance ToHeaders DeleteBucketReplication where
 
 instance ToPath DeleteBucketReplication where
         toPath DeleteBucketReplication'{..}
-          = mconcat ["/", toText _dbrBucket]
+          = mconcat ["/", toPath _dbrBucket]
 
 instance ToQuery DeleteBucketReplication where
         toQuery = const (mconcat ["replication"])

--- a/amazonka-s3/gen/Network/AWS/S3/DeleteBucketTagging.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/DeleteBucketTagging.hs
@@ -72,7 +72,7 @@ instance ToHeaders DeleteBucketTagging where
 
 instance ToPath DeleteBucketTagging where
         toPath DeleteBucketTagging'{..}
-          = mconcat ["/", toText _dbtBucket]
+          = mconcat ["/", toPath _dbtBucket]
 
 instance ToQuery DeleteBucketTagging where
         toQuery = const (mconcat ["tagging"])

--- a/amazonka-s3/gen/Network/AWS/S3/DeleteBucketWebsite.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/DeleteBucketWebsite.hs
@@ -72,7 +72,7 @@ instance ToHeaders DeleteBucketWebsite where
 
 instance ToPath DeleteBucketWebsite where
         toPath DeleteBucketWebsite'{..}
-          = mconcat ["/", toText _dbwBucket]
+          = mconcat ["/", toPath _dbwBucket]
 
 instance ToQuery DeleteBucketWebsite where
         toQuery = const (mconcat ["website"])

--- a/amazonka-s3/gen/Network/AWS/S3/DeleteObject.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/DeleteObject.hs
@@ -125,7 +125,7 @@ instance ToHeaders DeleteObject where
 
 instance ToPath DeleteObject where
         toPath DeleteObject'{..}
-          = mconcat ["/", toText _doBucket, "/", toText _doKey]
+          = mconcat ["/", toPath _doBucket, "/", toPath _doKey]
 
 instance ToQuery DeleteObject where
         toQuery DeleteObject'{..}

--- a/amazonka-s3/gen/Network/AWS/S3/DeleteObjects.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/DeleteObjects.hs
@@ -122,7 +122,7 @@ instance ToHeaders DeleteObjects where
 
 instance ToPath DeleteObjects where
         toPath DeleteObjects'{..}
-          = mconcat ["/", toText _dosBucket]
+          = mconcat ["/", toPath _dosBucket]
 
 instance ToQuery DeleteObjects where
         toQuery = const (mconcat ["delete"])

--- a/amazonka-s3/gen/Network/AWS/S3/GetBucketACL.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/GetBucketACL.hs
@@ -82,7 +82,7 @@ instance ToHeaders GetBucketACL where
 
 instance ToPath GetBucketACL where
         toPath GetBucketACL'{..}
-          = mconcat ["/", toText _gbaBucket]
+          = mconcat ["/", toPath _gbaBucket]
 
 instance ToQuery GetBucketACL where
         toQuery = const (mconcat ["acl"])

--- a/amazonka-s3/gen/Network/AWS/S3/GetBucketCORS.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/GetBucketCORS.hs
@@ -79,7 +79,7 @@ instance ToHeaders GetBucketCORS where
 
 instance ToPath GetBucketCORS where
         toPath GetBucketCORS'{..}
-          = mconcat ["/", toText _gbcBucket]
+          = mconcat ["/", toPath _gbcBucket]
 
 instance ToQuery GetBucketCORS where
         toQuery = const (mconcat ["cors"])

--- a/amazonka-s3/gen/Network/AWS/S3/GetBucketLifecycle.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/GetBucketLifecycle.hs
@@ -80,7 +80,7 @@ instance ToHeaders GetBucketLifecycle where
 
 instance ToPath GetBucketLifecycle where
         toPath GetBucketLifecycle'{..}
-          = mconcat ["/", toText _gBucket]
+          = mconcat ["/", toPath _gBucket]
 
 instance ToQuery GetBucketLifecycle where
         toQuery = const (mconcat ["lifecycle"])

--- a/amazonka-s3/gen/Network/AWS/S3/GetBucketLocation.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/GetBucketLocation.hs
@@ -78,7 +78,7 @@ instance ToHeaders GetBucketLocation where
 
 instance ToPath GetBucketLocation where
         toPath GetBucketLocation'{..}
-          = mconcat ["/", toText _gblBucket]
+          = mconcat ["/", toPath _gblBucket]
 
 instance ToQuery GetBucketLocation where
         toQuery = const (mconcat ["location"])

--- a/amazonka-s3/gen/Network/AWS/S3/GetBucketLogging.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/GetBucketLogging.hs
@@ -79,7 +79,7 @@ instance ToHeaders GetBucketLogging where
 
 instance ToPath GetBucketLogging where
         toPath GetBucketLogging'{..}
-          = mconcat ["/", toText _getBucket]
+          = mconcat ["/", toPath _getBucket]
 
 instance ToQuery GetBucketLogging where
         toQuery = const (mconcat ["logging"])

--- a/amazonka-s3/gen/Network/AWS/S3/GetBucketNotificationConfiguration.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/GetBucketNotificationConfiguration.hs
@@ -79,7 +79,7 @@ instance ToHeaders GetBucketNotificationConfiguration
 instance ToPath GetBucketNotificationConfiguration
          where
         toPath GetBucketNotificationConfiguration'{..}
-          = mconcat ["/", toText _gbncBucket]
+          = mconcat ["/", toPath _gbncBucket]
 
 instance ToQuery GetBucketNotificationConfiguration
          where

--- a/amazonka-s3/gen/Network/AWS/S3/GetBucketPolicy.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/GetBucketPolicy.hs
@@ -78,7 +78,7 @@ instance ToHeaders GetBucketPolicy where
 
 instance ToPath GetBucketPolicy where
         toPath GetBucketPolicy'{..}
-          = mconcat ["/", toText _gbpBucket]
+          = mconcat ["/", toPath _gbpBucket]
 
 instance ToQuery GetBucketPolicy where
         toQuery = const (mconcat ["policy"])

--- a/amazonka-s3/gen/Network/AWS/S3/GetBucketReplication.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/GetBucketReplication.hs
@@ -79,7 +79,7 @@ instance ToHeaders GetBucketReplication where
 
 instance ToPath GetBucketReplication where
         toPath GetBucketReplication'{..}
-          = mconcat ["/", toText _gbrBucket]
+          = mconcat ["/", toPath _gbrBucket]
 
 instance ToQuery GetBucketReplication where
         toQuery = const (mconcat ["replication"])

--- a/amazonka-s3/gen/Network/AWS/S3/GetBucketRequestPayment.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/GetBucketRequestPayment.hs
@@ -79,7 +79,7 @@ instance ToHeaders GetBucketRequestPayment where
 
 instance ToPath GetBucketRequestPayment where
         toPath GetBucketRequestPayment'{..}
-          = mconcat ["/", toText _gbrpBucket]
+          = mconcat ["/", toPath _gbrpBucket]
 
 instance ToQuery GetBucketRequestPayment where
         toQuery = const (mconcat ["requestPayment"])

--- a/amazonka-s3/gen/Network/AWS/S3/GetBucketTagging.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/GetBucketTagging.hs
@@ -79,7 +79,7 @@ instance ToHeaders GetBucketTagging where
 
 instance ToPath GetBucketTagging where
         toPath GetBucketTagging'{..}
-          = mconcat ["/", toText _gbtBucket]
+          = mconcat ["/", toPath _gbtBucket]
 
 instance ToQuery GetBucketTagging where
         toQuery = const (mconcat ["tagging"])

--- a/amazonka-s3/gen/Network/AWS/S3/GetBucketVersioning.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/GetBucketVersioning.hs
@@ -79,7 +79,7 @@ instance ToHeaders GetBucketVersioning where
 
 instance ToPath GetBucketVersioning where
         toPath GetBucketVersioning'{..}
-          = mconcat ["/", toText _gbvBucket]
+          = mconcat ["/", toPath _gbvBucket]
 
 instance ToQuery GetBucketVersioning where
         toQuery = const (mconcat ["versioning"])

--- a/amazonka-s3/gen/Network/AWS/S3/GetBucketWebsite.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/GetBucketWebsite.hs
@@ -87,7 +87,7 @@ instance ToHeaders GetBucketWebsite where
 
 instance ToPath GetBucketWebsite where
         toPath GetBucketWebsite'{..}
-          = mconcat ["/", toText _gbwBucket]
+          = mconcat ["/", toPath _gbwBucket]
 
 instance ToQuery GetBucketWebsite where
         toQuery = const (mconcat ["website"])

--- a/amazonka-s3/gen/Network/AWS/S3/GetObject.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/GetObject.hs
@@ -308,7 +308,7 @@ instance ToHeaders GetObject where
 
 instance ToPath GetObject where
         toPath GetObject'{..}
-          = mconcat ["/", toText _goBucket, "/", toText _goKey]
+          = mconcat ["/", toPath _goBucket, "/", toPath _goKey]
 
 instance ToQuery GetObject where
         toQuery GetObject'{..}

--- a/amazonka-s3/gen/Network/AWS/S3/GetObjectACL.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/GetObjectACL.hs
@@ -113,7 +113,7 @@ instance ToHeaders GetObjectACL where
 instance ToPath GetObjectACL where
         toPath GetObjectACL'{..}
           = mconcat
-              ["/", toText _goaBucket, "/", toText _goaKey]
+              ["/", toPath _goaBucket, "/", toPath _goaKey]
 
 instance ToQuery GetObjectACL where
         toQuery GetObjectACL'{..}

--- a/amazonka-s3/gen/Network/AWS/S3/GetObjectTorrent.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/GetObjectTorrent.hs
@@ -101,7 +101,7 @@ instance ToHeaders GetObjectTorrent where
 instance ToPath GetObjectTorrent where
         toPath GetObjectTorrent'{..}
           = mconcat
-              ["/", toText _gotBucket, "/", toText _gotKey]
+              ["/", toPath _gotBucket, "/", toPath _gotKey]
 
 instance ToQuery GetObjectTorrent where
         toQuery = const (mconcat ["torrent"])

--- a/amazonka-s3/gen/Network/AWS/S3/HeadBucket.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/HeadBucket.hs
@@ -72,7 +72,7 @@ instance ToHeaders HeadBucket where
 
 instance ToPath HeadBucket where
         toPath HeadBucket'{..}
-          = mconcat ["/", toText _hbBucket]
+          = mconcat ["/", toPath _hbBucket]
 
 instance ToQuery HeadBucket where
         toQuery = const mempty

--- a/amazonka-s3/gen/Network/AWS/S3/HeadObject.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/HeadObject.hs
@@ -255,7 +255,7 @@ instance ToHeaders HeadObject where
 
 instance ToPath HeadObject where
         toPath HeadObject'{..}
-          = mconcat ["/", toText _hoBucket, "/", toText _hoKey]
+          = mconcat ["/", toPath _hoBucket, "/", toPath _hoKey]
 
 instance ToQuery HeadObject where
         toQuery HeadObject'{..}

--- a/amazonka-s3/gen/Network/AWS/S3/ListMultipartUploads.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/ListMultipartUploads.hs
@@ -84,7 +84,7 @@ data ListMultipartUploads = ListMultipartUploads'
     , _lmuEncodingType   :: !(Maybe EncodingType)
     , _lmuMaxUploads     :: !(Maybe Int)
     , _lmuUploadIdMarker :: !(Maybe Text)
-    , _lmuDelimiter      :: !(Maybe Char)
+    , _lmuDelimiter      :: !(Maybe Delimiter)
     , _lmuBucket         :: !BucketName
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
@@ -128,7 +128,7 @@ lmuUploadIdMarker :: Lens' ListMultipartUploads (Maybe Text)
 lmuUploadIdMarker = lens _lmuUploadIdMarker (\ s a -> s{_lmuUploadIdMarker = a});
 
 -- | Character you use to group keys.
-lmuDelimiter :: Lens' ListMultipartUploads (Maybe Char)
+lmuDelimiter :: Lens' ListMultipartUploads (Maybe Delimiter)
 lmuDelimiter = lens _lmuDelimiter (\ s a -> s{_lmuDelimiter = a});
 
 -- | FIXME: Undocumented member.
@@ -172,7 +172,7 @@ instance ToHeaders ListMultipartUploads where
 
 instance ToPath ListMultipartUploads where
         toPath ListMultipartUploads'{..}
-          = mconcat ["/", toText _lmuBucket]
+          = mconcat ["/", toPath _lmuBucket]
 
 instance ToQuery ListMultipartUploads where
         toQuery ListMultipartUploads'{..}
@@ -225,7 +225,7 @@ data ListMultipartUploadsResponse = ListMultipartUploadsResponse'
     , _lmursUploads            :: !(Maybe [MultipartUpload])
     , _lmursIsTruncated        :: !(Maybe Bool)
     , _lmursNextUploadIdMarker :: !(Maybe Text)
-    , _lmursDelimiter          :: !(Maybe Char)
+    , _lmursDelimiter          :: !(Maybe Delimiter)
     , _lmursStatus             :: !Int
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
@@ -302,7 +302,7 @@ lmursNextUploadIdMarker :: Lens' ListMultipartUploadsResponse (Maybe Text)
 lmursNextUploadIdMarker = lens _lmursNextUploadIdMarker (\ s a -> s{_lmursNextUploadIdMarker = a});
 
 -- | FIXME: Undocumented member.
-lmursDelimiter :: Lens' ListMultipartUploadsResponse (Maybe Char)
+lmursDelimiter :: Lens' ListMultipartUploadsResponse (Maybe Delimiter)
 lmursDelimiter = lens _lmursDelimiter (\ s a -> s{_lmursDelimiter = a});
 
 -- | FIXME: Undocumented member.

--- a/amazonka-s3/gen/Network/AWS/S3/ListObjectVersions.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/ListObjectVersions.hs
@@ -85,7 +85,7 @@ data ListObjectVersions = ListObjectVersions'
     , _lovEncodingType    :: !(Maybe EncodingType)
     , _lovVersionIdMarker :: !(Maybe Text)
     , _lovMaxKeys         :: !(Maybe Int)
-    , _lovDelimiter       :: !(Maybe Char)
+    , _lovDelimiter       :: !(Maybe Delimiter)
     , _lovBucket          :: !BucketName
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
@@ -124,7 +124,7 @@ lovMaxKeys :: Lens' ListObjectVersions (Maybe Int)
 lovMaxKeys = lens _lovMaxKeys (\ s a -> s{_lovMaxKeys = a});
 
 -- | A delimiter is a character you use to group keys.
-lovDelimiter :: Lens' ListObjectVersions (Maybe Char)
+lovDelimiter :: Lens' ListObjectVersions (Maybe Delimiter)
 lovDelimiter = lens _lovDelimiter (\ s a -> s{_lovDelimiter = a});
 
 -- | FIXME: Undocumented member.
@@ -170,7 +170,7 @@ instance ToHeaders ListObjectVersions where
 
 instance ToPath ListObjectVersions where
         toPath ListObjectVersions'{..}
-          = mconcat ["/", toText _lovBucket]
+          = mconcat ["/", toPath _lovBucket]
 
 instance ToQuery ListObjectVersions where
         toQuery ListObjectVersions'{..}
@@ -226,7 +226,7 @@ data ListObjectVersionsResponse = ListObjectVersionsResponse'
     , _lovrsVersionIdMarker     :: !(Maybe Text)
     , _lovrsMaxKeys             :: !(Maybe Int)
     , _lovrsIsTruncated         :: !(Maybe Bool)
-    , _lovrsDelimiter           :: !(Maybe Char)
+    , _lovrsDelimiter           :: !(Maybe Delimiter)
     , _lovrsStatus              :: !Int
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
@@ -305,7 +305,7 @@ lovrsIsTruncated :: Lens' ListObjectVersionsResponse (Maybe Bool)
 lovrsIsTruncated = lens _lovrsIsTruncated (\ s a -> s{_lovrsIsTruncated = a});
 
 -- | FIXME: Undocumented member.
-lovrsDelimiter :: Lens' ListObjectVersionsResponse (Maybe Char)
+lovrsDelimiter :: Lens' ListObjectVersionsResponse (Maybe Delimiter)
 lovrsDelimiter = lens _lovrsDelimiter (\ s a -> s{_lovrsDelimiter = a});
 
 -- | FIXME: Undocumented member.

--- a/amazonka-s3/gen/Network/AWS/S3/ListObjects.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/ListObjects.hs
@@ -80,7 +80,7 @@ data ListObjects = ListObjects'
     , _loEncodingType :: !(Maybe EncodingType)
     , _loMarker       :: !(Maybe Text)
     , _loMaxKeys      :: !(Maybe Int)
-    , _loDelimiter    :: !(Maybe Char)
+    , _loDelimiter    :: !(Maybe Delimiter)
     , _loBucket       :: !BucketName
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
@@ -114,7 +114,7 @@ loMaxKeys :: Lens' ListObjects (Maybe Int)
 loMaxKeys = lens _loMaxKeys (\ s a -> s{_loMaxKeys = a});
 
 -- | A delimiter is a character you use to group keys.
-loDelimiter :: Lens' ListObjects (Maybe Char)
+loDelimiter :: Lens' ListObjects (Maybe Delimiter)
 loDelimiter = lens _loDelimiter (\ s a -> s{_loDelimiter = a});
 
 -- | FIXME: Undocumented member.
@@ -161,7 +161,7 @@ instance ToHeaders ListObjects where
 
 instance ToPath ListObjects where
         toPath ListObjects'{..}
-          = mconcat ["/", toText _loBucket]
+          = mconcat ["/", toPath _loBucket]
 
 instance ToQuery ListObjects where
         toQuery ListObjects'{..}
@@ -206,7 +206,7 @@ data ListObjectsResponse = ListObjectsResponse'
     , _lorsNextMarker     :: !(Maybe Text)
     , _lorsMaxKeys        :: !(Maybe Int)
     , _lorsIsTruncated    :: !(Maybe Bool)
-    , _lorsDelimiter      :: !(Maybe Char)
+    , _lorsDelimiter      :: !(Maybe Delimiter)
     , _lorsStatus         :: !Int
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
@@ -272,7 +272,7 @@ lorsIsTruncated :: Lens' ListObjectsResponse (Maybe Bool)
 lorsIsTruncated = lens _lorsIsTruncated (\ s a -> s{_lorsIsTruncated = a});
 
 -- | FIXME: Undocumented member.
-lorsDelimiter :: Lens' ListObjectsResponse (Maybe Char)
+lorsDelimiter :: Lens' ListObjectsResponse (Maybe Delimiter)
 lorsDelimiter = lens _lorsDelimiter (\ s a -> s{_lorsDelimiter = a});
 
 -- | FIXME: Undocumented member.

--- a/amazonka-s3/gen/Network/AWS/S3/ListParts.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/ListParts.hs
@@ -158,7 +158,7 @@ instance ToHeaders ListParts where
 
 instance ToPath ListParts where
         toPath ListParts'{..}
-          = mconcat ["/", toText _lpBucket, "/", toText _lpKey]
+          = mconcat ["/", toPath _lpBucket, "/", toPath _lpKey]
 
 instance ToQuery ListParts where
         toQuery ListParts'{..}

--- a/amazonka-s3/gen/Network/AWS/S3/PutBucketACL.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/PutBucketACL.hs
@@ -160,7 +160,7 @@ instance ToHeaders PutBucketACL where
 
 instance ToPath PutBucketACL where
         toPath PutBucketACL'{..}
-          = mconcat ["/", toText _pbaBucket]
+          = mconcat ["/", toPath _pbaBucket]
 
 instance ToQuery PutBucketACL where
         toQuery = const (mconcat ["acl"])

--- a/amazonka-s3/gen/Network/AWS/S3/PutBucketCORS.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/PutBucketCORS.hs
@@ -97,7 +97,7 @@ instance ToHeaders PutBucketCORS where
 
 instance ToPath PutBucketCORS where
         toPath PutBucketCORS'{..}
-          = mconcat ["/", toText _pbcBucket]
+          = mconcat ["/", toPath _pbcBucket]
 
 instance ToQuery PutBucketCORS where
         toQuery = const (mconcat ["cors"])

--- a/amazonka-s3/gen/Network/AWS/S3/PutBucketLifecycle.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/PutBucketLifecycle.hs
@@ -99,7 +99,7 @@ instance ToHeaders PutBucketLifecycle where
 
 instance ToPath PutBucketLifecycle where
         toPath PutBucketLifecycle'{..}
-          = mconcat ["/", toText _pBucket]
+          = mconcat ["/", toPath _pBucket]
 
 instance ToQuery PutBucketLifecycle where
         toQuery = const (mconcat ["lifecycle"])

--- a/amazonka-s3/gen/Network/AWS/S3/PutBucketLogging.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/PutBucketLogging.hs
@@ -99,7 +99,7 @@ instance ToHeaders PutBucketLogging where
 
 instance ToPath PutBucketLogging where
         toPath PutBucketLogging'{..}
-          = mconcat ["/", toText _pblBucket]
+          = mconcat ["/", toPath _pblBucket]
 
 instance ToQuery PutBucketLogging where
         toQuery = const (mconcat ["logging"])

--- a/amazonka-s3/gen/Network/AWS/S3/PutBucketNotificationConfiguration.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/PutBucketNotificationConfiguration.hs
@@ -94,7 +94,7 @@ instance ToHeaders PutBucketNotificationConfiguration
 instance ToPath PutBucketNotificationConfiguration
          where
         toPath PutBucketNotificationConfiguration'{..}
-          = mconcat ["/", toText _pbncBucket]
+          = mconcat ["/", toPath _pbncBucket]
 
 instance ToQuery PutBucketNotificationConfiguration
          where

--- a/amazonka-s3/gen/Network/AWS/S3/PutBucketPolicy.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/PutBucketPolicy.hs
@@ -94,7 +94,7 @@ instance ToHeaders PutBucketPolicy where
 
 instance ToPath PutBucketPolicy where
         toPath PutBucketPolicy'{..}
-          = mconcat ["/", toText _pbpBucket]
+          = mconcat ["/", toPath _pbpBucket]
 
 instance ToQuery PutBucketPolicy where
         toQuery = const (mconcat ["policy"])

--- a/amazonka-s3/gen/Network/AWS/S3/PutBucketReplication.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/PutBucketReplication.hs
@@ -99,7 +99,7 @@ instance ToHeaders PutBucketReplication where
 
 instance ToPath PutBucketReplication where
         toPath PutBucketReplication'{..}
-          = mconcat ["/", toText _pbrBucket]
+          = mconcat ["/", toPath _pbrBucket]
 
 instance ToQuery PutBucketReplication where
         toQuery = const (mconcat ["replication"])

--- a/amazonka-s3/gen/Network/AWS/S3/PutBucketRequestPayment.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/PutBucketRequestPayment.hs
@@ -104,7 +104,7 @@ instance ToHeaders PutBucketRequestPayment where
 
 instance ToPath PutBucketRequestPayment where
         toPath PutBucketRequestPayment'{..}
-          = mconcat ["/", toText _pbrpBucket]
+          = mconcat ["/", toPath _pbrpBucket]
 
 instance ToQuery PutBucketRequestPayment where
         toQuery = const (mconcat ["requestPayment"])

--- a/amazonka-s3/gen/Network/AWS/S3/PutBucketTagging.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/PutBucketTagging.hs
@@ -97,7 +97,7 @@ instance ToHeaders PutBucketTagging where
 
 instance ToPath PutBucketTagging where
         toPath PutBucketTagging'{..}
-          = mconcat ["/", toText _pbtBucket]
+          = mconcat ["/", toPath _pbtBucket]
 
 instance ToQuery PutBucketTagging where
         toQuery = const (mconcat ["tagging"])

--- a/amazonka-s3/gen/Network/AWS/S3/PutBucketVersioning.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/PutBucketVersioning.hs
@@ -111,7 +111,7 @@ instance ToHeaders PutBucketVersioning where
 
 instance ToPath PutBucketVersioning where
         toPath PutBucketVersioning'{..}
-          = mconcat ["/", toText _pbvBucket]
+          = mconcat ["/", toPath _pbvBucket]
 
 instance ToQuery PutBucketVersioning where
         toQuery = const (mconcat ["versioning"])

--- a/amazonka-s3/gen/Network/AWS/S3/PutBucketWebsite.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/PutBucketWebsite.hs
@@ -97,7 +97,7 @@ instance ToHeaders PutBucketWebsite where
 
 instance ToPath PutBucketWebsite where
         toPath PutBucketWebsite'{..}
-          = mconcat ["/", toText _pbwBucket]
+          = mconcat ["/", toPath _pbwBucket]
 
 instance ToQuery PutBucketWebsite where
         toQuery = const (mconcat ["website"])

--- a/amazonka-s3/gen/Network/AWS/S3/PutObject.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/PutObject.hs
@@ -363,7 +363,7 @@ instance ToHeaders PutObject where
 
 instance ToPath PutObject where
         toPath PutObject'{..}
-          = mconcat ["/", toText _poBucket, "/", toText _poKey]
+          = mconcat ["/", toPath _poBucket, "/", toPath _poKey]
 
 instance ToQuery PutObject where
         toQuery = const mempty

--- a/amazonka-s3/gen/Network/AWS/S3/PutObjectACL.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/PutObjectACL.hs
@@ -189,7 +189,7 @@ instance ToHeaders PutObjectACL where
 instance ToPath PutObjectACL where
         toPath PutObjectACL'{..}
           = mconcat
-              ["/", toText _poaBucket, "/", toText _poaKey]
+              ["/", toPath _poaBucket, "/", toPath _poaKey]
 
 instance ToQuery PutObjectACL where
         toQuery = const (mconcat ["acl"])

--- a/amazonka-s3/gen/Network/AWS/S3/RestoreObject.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/RestoreObject.hs
@@ -123,7 +123,7 @@ instance ToHeaders RestoreObject where
 
 instance ToPath RestoreObject where
         toPath RestoreObject'{..}
-          = mconcat ["/", toText _roBucket, "/", toText _roKey]
+          = mconcat ["/", toPath _roBucket, "/", toPath _roKey]
 
 instance ToQuery RestoreObject where
         toQuery RestoreObject'{..}

--- a/amazonka-s3/gen/Network/AWS/S3/Types/Sum.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/Types/Sum.hs
@@ -43,9 +43,11 @@ instance ToText BucketCannedACL where
         BPublicRead -> "public-read"
         BPublicReadWrite -> "public-read-write"
 
-instance Hashable BucketCannedACL
-instance ToQuery  BucketCannedACL
-instance ToHeader BucketCannedACL
+instance Hashable     BucketCannedACL
+instance ToByteString BucketCannedACL
+instance ToPath       BucketCannedACL
+instance ToQuery      BucketCannedACL
+instance ToHeader     BucketCannedACL
 
 instance ToXML BucketCannedACL where
     toXML = toXMLText
@@ -70,9 +72,11 @@ instance ToText BucketLogsPermission where
         Read -> "read"
         Write -> "write"
 
-instance Hashable BucketLogsPermission
-instance ToQuery  BucketLogsPermission
-instance ToHeader BucketLogsPermission
+instance Hashable     BucketLogsPermission
+instance ToByteString BucketLogsPermission
+instance ToPath       BucketLogsPermission
+instance ToQuery      BucketLogsPermission
+instance ToHeader     BucketLogsPermission
 
 instance FromXML BucketLogsPermission where
     parseXML = parseXMLText "BucketLogsPermission"
@@ -97,9 +101,11 @@ instance ToText BucketVersioningStatus where
         BVSEnabled -> "enabled"
         BVSSuspended -> "suspended"
 
-instance Hashable BucketVersioningStatus
-instance ToQuery  BucketVersioningStatus
-instance ToHeader BucketVersioningStatus
+instance Hashable     BucketVersioningStatus
+instance ToByteString BucketVersioningStatus
+instance ToPath       BucketVersioningStatus
+instance ToQuery      BucketVersioningStatus
+instance ToHeader     BucketVersioningStatus
 
 instance FromXML BucketVersioningStatus where
     parseXML = parseXMLText "BucketVersioningStatus"
@@ -127,9 +133,11 @@ instance ToText EncodingType where
     toText = \case
         URL -> "url"
 
-instance Hashable EncodingType
-instance ToQuery  EncodingType
-instance ToHeader EncodingType
+instance Hashable     EncodingType
+instance ToByteString EncodingType
+instance ToPath       EncodingType
+instance ToQuery      EncodingType
+instance ToHeader     EncodingType
 
 instance FromXML EncodingType where
     parseXML = parseXMLText "EncodingType"
@@ -164,9 +172,11 @@ instance ToText Event where
         S3ObjectCreatedPut -> "s3:objectcreated:put"
         S3ReducedRedundancyLostObject -> "s3:reducedredundancylostobject"
 
-instance Hashable Event
-instance ToQuery  Event
-instance ToHeader Event
+instance Hashable     Event
+instance ToByteString Event
+instance ToPath       Event
+instance ToQuery      Event
+instance ToHeader     Event
 
 instance FromXML Event where
     parseXML = parseXMLText "Event"
@@ -191,9 +201,11 @@ instance ToText ExpirationStatus where
         ESDisabled -> "disabled"
         ESEnabled -> "enabled"
 
-instance Hashable ExpirationStatus
-instance ToQuery  ExpirationStatus
-instance ToHeader ExpirationStatus
+instance Hashable     ExpirationStatus
+instance ToByteString ExpirationStatus
+instance ToPath       ExpirationStatus
+instance ToQuery      ExpirationStatus
+instance ToHeader     ExpirationStatus
 
 instance FromXML ExpirationStatus where
     parseXML = parseXMLText "ExpirationStatus"
@@ -218,9 +230,11 @@ instance ToText MFADelete where
         MDDisabled -> "disabled"
         MDEnabled -> "enabled"
 
-instance Hashable MFADelete
-instance ToQuery  MFADelete
-instance ToHeader MFADelete
+instance Hashable     MFADelete
+instance ToByteString MFADelete
+instance ToPath       MFADelete
+instance ToQuery      MFADelete
+instance ToHeader     MFADelete
 
 instance ToXML MFADelete where
     toXML = toXMLText
@@ -242,9 +256,11 @@ instance ToText MFADeleteStatus where
         MDSDisabled -> "disabled"
         MDSEnabled -> "enabled"
 
-instance Hashable MFADeleteStatus
-instance ToQuery  MFADeleteStatus
-instance ToHeader MFADeleteStatus
+instance Hashable     MFADeleteStatus
+instance ToByteString MFADeleteStatus
+instance ToPath       MFADeleteStatus
+instance ToQuery      MFADeleteStatus
+instance ToHeader     MFADeleteStatus
 
 instance FromXML MFADeleteStatus where
     parseXML = parseXMLText "MFADeleteStatus"
@@ -266,9 +282,11 @@ instance ToText MetadataDirective where
         Copy -> "copy"
         Replace -> "replace"
 
-instance Hashable MetadataDirective
-instance ToQuery  MetadataDirective
-instance ToHeader MetadataDirective
+instance Hashable     MetadataDirective
+instance ToByteString MetadataDirective
+instance ToPath       MetadataDirective
+instance ToQuery      MetadataDirective
+instance ToHeader     MetadataDirective
 
 instance ToXML MetadataDirective where
     toXML = toXMLText
@@ -302,9 +320,11 @@ instance ToText ObjectCannedACL where
         OPublicRead -> "public-read"
         OPublicReadWrite -> "public-read-write"
 
-instance Hashable ObjectCannedACL
-instance ToQuery  ObjectCannedACL
-instance ToHeader ObjectCannedACL
+instance Hashable     ObjectCannedACL
+instance ToByteString ObjectCannedACL
+instance ToPath       ObjectCannedACL
+instance ToQuery      ObjectCannedACL
+instance ToHeader     ObjectCannedACL
 
 instance ToXML ObjectCannedACL where
     toXML = toXMLText
@@ -329,9 +349,11 @@ instance ToText ObjectStorageClass where
         OSCReducedRedundancy -> "reduced_redundancy"
         OSCStandard -> "standard"
 
-instance Hashable ObjectStorageClass
-instance ToQuery  ObjectStorageClass
-instance ToHeader ObjectStorageClass
+instance Hashable     ObjectStorageClass
+instance ToByteString ObjectStorageClass
+instance ToPath       ObjectStorageClass
+instance ToQuery      ObjectStorageClass
+instance ToHeader     ObjectStorageClass
 
 instance FromXML ObjectStorageClass where
     parseXML = parseXMLText "ObjectStorageClass"
@@ -350,9 +372,11 @@ instance ToText ObjectVersionStorageClass where
     toText = \case
         OVSCStandard -> "standard"
 
-instance Hashable ObjectVersionStorageClass
-instance ToQuery  ObjectVersionStorageClass
-instance ToHeader ObjectVersionStorageClass
+instance Hashable     ObjectVersionStorageClass
+instance ToByteString ObjectVersionStorageClass
+instance ToPath       ObjectVersionStorageClass
+instance ToQuery      ObjectVersionStorageClass
+instance ToHeader     ObjectVersionStorageClass
 
 instance FromXML ObjectVersionStorageClass where
     parseXML = parseXMLText "ObjectVersionStorageClass"
@@ -374,9 +398,11 @@ instance ToText Payer where
         BucketOwner -> "bucketowner"
         Requester -> "requester"
 
-instance Hashable Payer
-instance ToQuery  Payer
-instance ToHeader Payer
+instance Hashable     Payer
+instance ToByteString Payer
+instance ToPath       Payer
+instance ToQuery      Payer
+instance ToHeader     Payer
 
 instance FromXML Payer where
     parseXML = parseXMLText "Payer"
@@ -410,9 +436,11 @@ instance ToText Permission where
         PWrite -> "write"
         PWriteAcp -> "write_acp"
 
-instance Hashable Permission
-instance ToQuery  Permission
-instance ToHeader Permission
+instance Hashable     Permission
+instance ToByteString Permission
+instance ToPath       Permission
+instance ToQuery      Permission
+instance ToHeader     Permission
 
 instance FromXML Permission where
     parseXML = parseXMLText "Permission"
@@ -437,9 +465,11 @@ instance ToText Protocol where
         HTTP -> "http"
         HTTPS -> "https"
 
-instance Hashable Protocol
-instance ToQuery  Protocol
-instance ToHeader Protocol
+instance Hashable     Protocol
+instance ToByteString Protocol
+instance ToPath       Protocol
+instance ToQuery      Protocol
+instance ToHeader     Protocol
 
 instance FromXML Protocol where
     parseXML = parseXMLText "Protocol"
@@ -464,9 +494,11 @@ instance ToText ReplicationRuleStatus where
         Disabled -> "disabled"
         Enabled -> "enabled"
 
-instance Hashable ReplicationRuleStatus
-instance ToQuery  ReplicationRuleStatus
-instance ToHeader ReplicationRuleStatus
+instance Hashable     ReplicationRuleStatus
+instance ToByteString ReplicationRuleStatus
+instance ToPath       ReplicationRuleStatus
+instance ToQuery      ReplicationRuleStatus
+instance ToHeader     ReplicationRuleStatus
 
 instance FromXML ReplicationRuleStatus where
     parseXML = parseXMLText "ReplicationRuleStatus"
@@ -497,9 +529,11 @@ instance ToText ReplicationStatus where
         Pending -> "pending"
         Replica -> "replica"
 
-instance Hashable ReplicationStatus
-instance ToQuery  ReplicationStatus
-instance ToHeader ReplicationStatus
+instance Hashable     ReplicationStatus
+instance ToByteString ReplicationStatus
+instance ToPath       ReplicationStatus
+instance ToQuery      ReplicationStatus
+instance ToHeader     ReplicationStatus
 
 instance FromXML ReplicationStatus where
     parseXML = parseXMLText "ReplicationStatus"
@@ -520,9 +554,11 @@ instance ToText RequestCharged where
     toText = \case
         RCRequester -> "requester"
 
-instance Hashable RequestCharged
-instance ToQuery  RequestCharged
-instance ToHeader RequestCharged
+instance Hashable     RequestCharged
+instance ToByteString RequestCharged
+instance ToPath       RequestCharged
+instance ToQuery      RequestCharged
+instance ToHeader     RequestCharged
 
 instance FromXML RequestCharged where
     parseXML = parseXMLText "RequestCharged"
@@ -546,9 +582,11 @@ instance ToText RequestPayer where
     toText = \case
         RPRequester -> "requester"
 
-instance Hashable RequestPayer
-instance ToQuery  RequestPayer
-instance ToHeader RequestPayer
+instance Hashable     RequestPayer
+instance ToByteString RequestPayer
+instance ToPath       RequestPayer
+instance ToQuery      RequestPayer
+instance ToHeader     RequestPayer
 
 instance ToXML RequestPayer where
     toXML = toXMLText
@@ -567,9 +605,11 @@ instance ToText ServerSideEncryption where
     toText = \case
         AES256 -> "aes256"
 
-instance Hashable ServerSideEncryption
-instance ToQuery  ServerSideEncryption
-instance ToHeader ServerSideEncryption
+instance Hashable     ServerSideEncryption
+instance ToByteString ServerSideEncryption
+instance ToPath       ServerSideEncryption
+instance ToQuery      ServerSideEncryption
+instance ToHeader     ServerSideEncryption
 
 instance FromXML ServerSideEncryption where
     parseXML = parseXMLText "ServerSideEncryption"
@@ -594,9 +634,11 @@ instance ToText StorageClass where
         ReducedRedundancy -> "reduced_redundancy"
         Standard -> "standard"
 
-instance Hashable StorageClass
-instance ToQuery  StorageClass
-instance ToHeader StorageClass
+instance Hashable     StorageClass
+instance ToByteString StorageClass
+instance ToPath       StorageClass
+instance ToQuery      StorageClass
+instance ToHeader     StorageClass
 
 instance FromXML StorageClass where
     parseXML = parseXMLText "StorageClass"
@@ -618,9 +660,11 @@ instance ToText TransitionStorageClass where
     toText = \case
         Glacier -> "glacier"
 
-instance Hashable TransitionStorageClass
-instance ToQuery  TransitionStorageClass
-instance ToHeader TransitionStorageClass
+instance Hashable     TransitionStorageClass
+instance ToByteString TransitionStorageClass
+instance ToPath       TransitionStorageClass
+instance ToQuery      TransitionStorageClass
+instance ToHeader     TransitionStorageClass
 
 instance FromXML TransitionStorageClass where
     parseXML = parseXMLText "TransitionStorageClass"
@@ -648,9 +692,11 @@ instance ToText Type where
         CanonicalUser -> "canonicaluser"
         Group -> "group"
 
-instance Hashable Type
-instance ToQuery  Type
-instance ToHeader Type
+instance Hashable     Type
+instance ToByteString Type
+instance ToPath       Type
+instance ToQuery      Type
+instance ToHeader     Type
 
 instance FromXML Type where
     parseXML = parseXMLText "Type"

--- a/amazonka-s3/gen/Network/AWS/S3/UploadPart.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/UploadPart.hs
@@ -212,7 +212,7 @@ instance ToHeaders UploadPart where
 
 instance ToPath UploadPart where
         toPath UploadPart'{..}
-          = mconcat ["/", toText _upBucket, "/", toText _upKey]
+          = mconcat ["/", toPath _upBucket, "/", toPath _upKey]
 
 instance ToQuery UploadPart where
         toQuery UploadPart'{..}

--- a/amazonka-s3/gen/Network/AWS/S3/UploadPartCopy.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/UploadPartCopy.hs
@@ -283,7 +283,7 @@ instance ToHeaders UploadPartCopy where
 instance ToPath UploadPartCopy where
         toPath UploadPartCopy'{..}
           = mconcat
-              ["/", toText _upcBucket, "/", toText _upcKey]
+              ["/", toPath _upcBucket, "/", toPath _upcKey]
 
 instance ToQuery UploadPartCopy where
         toQuery UploadPartCopy'{..}

--- a/amazonka-s3/src/Network/AWS/S3/Internal.hs
+++ b/amazonka-s3/src/Network/AWS/S3/Internal.hs
@@ -164,6 +164,7 @@ keyName :: Delimiter -> Traversal' ObjectKey Text
 keyName c = _ObjectKeySnoc False c . _2
 {-# INLINE keyName #-}
 
+-- | Traverse the path components of an object key using the specified delimiter.
 keyComponents :: Delimiter -> IndexedTraversal' Int ObjectKey Text
 keyComponents !c f (ObjectKey k) = cat <$> traversed f split
   where

--- a/amazonka-s3/src/Network/AWS/S3/Internal.hs
+++ b/amazonka-s3/src/Network/AWS/S3/Internal.hs
@@ -21,6 +21,7 @@ module Network.AWS.S3.Internal
     , ETag            (..)
     , ObjectVersionId (..)
     , ObjectKey       (..)
+    , Delimiter
     , _Key
     , segments
     , _KeyHead
@@ -113,31 +114,33 @@ newtype ObjectKey = ObjectKey Text
 
 instance ToPath ObjectKey
 
+type Delimiter = Char
+
 _Key :: Iso' ObjectKey Text
 _Key = iso (\(ObjectKey k) -> k) ObjectKey
 {-# INLINE _Key #-}
 
-segments :: Char -> IndexedTraversal' Int ObjectKey Text
+segments :: Delimiter -> IndexedTraversal' Int ObjectKey Text
 segments c f k = joinKey c <$> traversed f (splitKey c k)
 {-# INLINE segments #-}
 
-_KeyHead :: Char -> Traversal' ObjectKey Text
+_KeyHead :: Delimiter -> Traversal' ObjectKey Text
 _KeyHead c = _KeyCons c . _1
 {-# INLINE _KeyHead #-}
 
-_KeyLast :: Char -> Traversal' ObjectKey Text
+_KeyLast :: Delimiter -> Traversal' ObjectKey Text
 _KeyLast c = _KeySnoc c . _2
 {-# INLINE _KeyLast #-}
 
 -- The following are modelled on the respective _Cons and _Snoc type classes:
 
-_KeyCons :: Char -> Prism' ObjectKey (Text, [Text])
+_KeyCons :: Delimiter -> Prism' ObjectKey (Text, [Text])
 _KeyCons c = prism (joinKey c . uncurry (:)) $ \k ->
     case splitKey c k of
         []     -> Left  k
         (x:xs) -> Right (x, xs)
 
-_KeySnoc :: Char -> Prism' ObjectKey ([Text], Text)
+_KeySnoc :: Delimiter -> Prism' ObjectKey ([Text], Text)
 _KeySnoc c = prism (\(xs, x) -> joinKey c (xs ++ [x])) $ \k ->
     case splitKey c k of
         [] -> Left  k

--- a/amazonka-s3/src/Network/AWS/S3/Internal.hs
+++ b/amazonka-s3/src/Network/AWS/S3/Internal.hs
@@ -41,23 +41,7 @@ newtype BucketName = BucketName Text
         , ToQuery
         )
 
-newtype ObjectKey = ObjectKey Text
-    deriving
-        ( Eq
-        , Ord
-        , Read
-        , Show
-        , Data
-        , Typeable
-        , Generic
-        , IsString
-        , FromText
-        , ToText
-        , ToByteString
-        , FromXML
-        , ToXML
-        , ToQuery
-        )
+instance ToPath BucketName
 
 newtype ObjectVersionId = ObjectVersionId Text
     deriving
@@ -76,6 +60,8 @@ newtype ObjectVersionId = ObjectVersionId Text
         , ToXML
         , ToQuery
         )
+
+instance ToPath ObjectVersionId
 
 -- FIXME: Add the difference between weak + strong ETags and their respective
 -- equalities if necessary, see: https://github.com/brendanhay/amazonka/issues/76
@@ -96,3 +82,49 @@ newtype ETag = ETag ByteString
         , ToXML
         , ToQuery
         )
+
+newtype ObjectKey = ObjectKey Text
+    deriving
+        ( Eq
+        , Ord
+        , Read
+        , Show
+        , Data
+        , Typeable
+        , Generic
+        , IsString
+        , FromText
+        , ToText
+        , ToByteString
+        , FromXML
+        , ToXML
+        , ToQuery
+        )
+
+instance ToPath ObjectKey
+
+-- objectKey :: Delimiter -> ByteString -> ObjectKey
+-- objectKey c = DecodedKey c . splitKey c
+
+-- splitKey :: Delimiter -> ByteString -> Seq ByteString
+-- splitKey c = Seq.fromList . BS8.split c
+
+-- components :: Delimiter -> IndexedTraversal' Int ObjectKey ByteString
+-- components c f = \case
+--     DecodedKey _ xs -> DecodedKey c <$> traversed f xs
+--     RawKey       bs -> DecodedKey c <$> traversed f (splitKey c bs)
+
+-- _Last :: Delimiter -> Traversal' ObjectKey ByteString
+-- _Last c f = \case
+--     DecodedKey _ xs -> go xs
+--     RawKey       bs -> go (splitKey c bs)
+--   where
+--     go = fmap (DecodedKey c) . viewR right
+
+--     right (xs :> x) = (xs :>) <$> f x
+--     right EmptyR    = pure EmptyR
+
+
+-- Provide a traversal for components, last etc.
+
+-- Reintroduce some of the changes

--- a/amazonka-s3/src/Network/AWS/S3/Internal.hs
+++ b/amazonka-s3/src/Network/AWS/S3/Internal.hs
@@ -5,16 +5,14 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes                 #-}
 
+-- |
 -- Module      : Network.AWS.S3.Internal
 -- Copyright   : (c) 2013-2015 Brendan Hay
--- License     : This Source Code Form is subject to the terms of
---               the Mozilla Public License, v. 2.0.
---               A copy of the MPL can be found in the LICENSE file or
---               you can obtain it at http://mozilla.org/MPL/2.0/.
+-- License     : This Mozilla Public License, v. 2.0.
 -- Maintainer  : Brendan Hay <brendan.g.hay@gmail.com>
 -- Stability   : experimental
 -- Portability : non-portable (GHC extensions)
-
+--
 module Network.AWS.S3.Internal
     ( Region
     , BucketName      (..)

--- a/amazonka-s3/test/Main.hs
+++ b/amazonka-s3/test/Main.hs
@@ -10,9 +10,9 @@
 --
 module Main (main) where
 
-import Test.Tasty
-import Test.AWS.S3
-import Test.AWS.S3.Internal
+import           Test.AWS.S3
+import           Test.AWS.S3.Internal
+import           Test.Tasty
 
 main :: IO ()
 main = defaultMain $ testGroup "S3"

--- a/amazonka-s3/test/Main.hs
+++ b/amazonka-s3/test/Main.hs
@@ -10,9 +10,9 @@
 --
 module Main (main) where
 
-import           Test.AWS.S3
-import           Test.AWS.S3.Internal
-import           Test.Tasty
+import Test.Tasty
+import Test.AWS.S3
+import Test.AWS.S3.Internal
 
 main :: IO ()
 main = defaultMain $ testGroup "S3"

--- a/amazonka-s3/test/Test/AWS/S3.hs
+++ b/amazonka-s3/test/Test/AWS/S3.hs
@@ -19,10 +19,13 @@ import           Network.AWS.Prelude
 import           Network.AWS.S3
 import           Test.AWS.Gen.S3
 import           Test.AWS.Prelude
+import qualified Test.AWS.S3.ObjectKey as ObjectKey
 import           Test.Tasty
 
 tests :: [TestTree]
-tests = []
+tests =
+    [ ObjectKey.tests
+    ]
 
 fixtures :: [TestTree]
 fixtures =

--- a/amazonka-s3/test/Test/AWS/S3/ObjectKey.hs
+++ b/amazonka-s3/test/Test/AWS/S3/ObjectKey.hs
@@ -10,37 +10,27 @@
 --
 module Test.AWS.S3.ObjectKey (tests) where
 
-import           Data.String
 import           Network.AWS.Prelude
 import           Network.AWS.S3
 import           Test.Tasty
 import           Test.Tasty.HUnit
 
--- FIXME: convert to quick/smallcheck
+-- FIXME: expand, convert to quick/smallcheck properties.
 tests :: TestTree
 tests = testGroup "object key"
     [ testGroup "encoding"
         [ testCase "without delimiters" $
-            "key" @=? encodedKey (objectKey '%' "key")
+            "key" @=? toPath (objectKey '%' "key")
 
         , testCase "without leading prefix" $
-            "some/obj%26ect" @=? encodedKey (objectKey '/' "some/obj&ect")
+            "some/obj%23ect" @=? toPath (objectKey '/' "some/obj#ect")
 
         , testCase "custom delimiter" $
-            "^some^obj%25ect^foo" @=? encodedKey (objectKey '^' "^some^obj%ect^foo")
+            "^some^obj%25ect^foo" @=?
+                 toPath (objectKey '^' "^some^obj%ect^foo")
 
         , testCase "leading prefix" $
-            decoded @=? either ($ '/') id (decodedKey encoded)
-        ]
-
-    , testGroup "text"
-        [ testCase "deserialise" $
-            Right decoded @=? (either ($ '/') id . decodedKey <$> fromText decoded)
+             "/some=1/path%20to/foo=bar/object%20here" @=?
+                 toPath (objectKey '/' "/some=1/path to/foo=bar/object here")
         ]
     ]
-
-encoded :: ObjectKey
-encoded = objectKey '/' decoded
-
-decoded :: IsString a => a
-decoded = "/some=1/path to/foo=bar/object here"

--- a/amazonka-s3/test/Test/AWS/S3/ObjectKey.hs
+++ b/amazonka-s3/test/Test/AWS/S3/ObjectKey.hs
@@ -20,17 +20,17 @@ tests :: TestTree
 tests = testGroup "object key"
     [ testGroup "encoding"
         [ testCase "without delimiters" $
-            "key" @=? toPath (objectKey '%' "key")
+            "key" @=? toBS (toPath (ObjectKey "key"))
 
         , testCase "without leading prefix" $
-            "some/obj%23ect" @=? toPath (objectKey '/' "some/obj#ect")
+            "some/obj%23ect" @=? toBS (toPath (ObjectKey "some/obj#ect"))
 
         , testCase "custom delimiter" $
-            "^some^obj%25ect^foo" @=?
-                 toPath (objectKey '^' "^some^obj%ect^foo")
+            "%5Esome%5Eobj%25ect%5Efoo" @=?
+                 toBS (toPath (ObjectKey "^some^obj%ect^foo"))
 
         , testCase "leading prefix" $
              "/some=1/path%20to/foo=bar/object%20here" @=?
-                 toPath (objectKey '/' "/some=1/path to/foo=bar/object here")
+                 toBS (toPath (ObjectKey "/some=1/path to/foo=bar/object here"))
         ]
     ]

--- a/amazonka-s3/test/Test/AWS/S3/ObjectKey.hs
+++ b/amazonka-s3/test/Test/AWS/S3/ObjectKey.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module      : Test.AWS.S3.ObjectKey
+-- Copyright   : (c) 2013-2015 Brendan Hay
+-- License     : Mozilla Public License, v. 2.0.
+-- Maintainer  : Brendan Hay <brendan.g.hay@gmail.com>
+-- Stability   : experimental
+-- Portability : non-portable (GHC extensions)
+--
+module Test.AWS.S3.ObjectKey (tests) where
+
+import           Data.String
+import           Network.AWS.Prelude
+import           Network.AWS.S3
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+-- FIXME: convert to quick/smallcheck
+tests :: TestTree
+tests = testGroup "object key"
+    [ testGroup "encoding"
+        [ testCase "without delimiters" $
+            "key" @=? encodedKey (objectKey '%' "key")
+
+        , testCase "without leading prefix" $
+            "some/obj%26ect" @=? encodedKey (objectKey '/' "some/obj&ect")
+
+        , testCase "custom delimiter" $
+            "^some^obj%25ect^foo" @=? encodedKey (objectKey '^' "^some^obj%ect^foo")
+
+        , testCase "leading prefix" $
+            decoded @=? either ($ '/') id (decodedKey encoded)
+        ]
+
+    , testGroup "text"
+        [ testCase "deserialise" $
+            Right decoded @=? (either ($ '/') id . decodedKey <$> fromText decoded)
+        ]
+    ]
+
+encoded :: ObjectKey
+encoded = objectKey '/' decoded
+
+decoded :: IsString a => a
+decoded = "/some=1/path to/foo=bar/object here"

--- a/amazonka-sdb/amazonka-sdb.cabal
+++ b/amazonka-sdb/amazonka-sdb.cabal
@@ -83,7 +83,7 @@ test-suite amazonka-sdb-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-sdb == 1.0.0
         , base
         , bytestring

--- a/amazonka-ses/amazonka-ses.cabal
+++ b/amazonka-ses/amazonka-ses.cabal
@@ -87,7 +87,7 @@ test-suite amazonka-ses-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-ses == 1.0.0
         , base
         , bytestring

--- a/amazonka-ses/gen/Network/AWS/SES/Types/Sum.hs
+++ b/amazonka-ses/gen/Network/AWS/SES/Types/Sum.hs
@@ -36,9 +36,11 @@ instance ToText IdentityType where
         Domain -> "domain"
         EmailAddress -> "emailaddress"
 
-instance Hashable IdentityType
-instance ToQuery  IdentityType
-instance ToHeader IdentityType
+instance Hashable     IdentityType
+instance ToByteString IdentityType
+instance ToPath       IdentityType
+instance ToQuery      IdentityType
+instance ToHeader     IdentityType
 
 data NotificationType
     = Delivery
@@ -60,9 +62,11 @@ instance ToText NotificationType where
         Complaint -> "complaint"
         Delivery -> "delivery"
 
-instance Hashable NotificationType
-instance ToQuery  NotificationType
-instance ToHeader NotificationType
+instance Hashable     NotificationType
+instance ToByteString NotificationType
+instance ToPath       NotificationType
+instance ToQuery      NotificationType
+instance ToHeader     NotificationType
 
 data VerificationStatus
     = NotStarted
@@ -90,9 +94,11 @@ instance ToText VerificationStatus where
         Success -> "success"
         TemporaryFailure -> "temporaryfailure"
 
-instance Hashable VerificationStatus
-instance ToQuery  VerificationStatus
-instance ToHeader VerificationStatus
+instance Hashable     VerificationStatus
+instance ToByteString VerificationStatus
+instance ToPath       VerificationStatus
+instance ToQuery      VerificationStatus
+instance ToHeader     VerificationStatus
 
 instance FromXML VerificationStatus where
     parseXML = parseXMLText "VerificationStatus"

--- a/amazonka-sns/amazonka-sns.cabal
+++ b/amazonka-sns/amazonka-sns.cabal
@@ -99,7 +99,7 @@ test-suite amazonka-sns-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-sns == 1.0.0
         , base
         , bytestring

--- a/amazonka-sqs/amazonka-sqs.cabal
+++ b/amazonka-sqs/amazonka-sqs.cabal
@@ -102,7 +102,7 @@ test-suite amazonka-sqs-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-sqs == 1.0.0
         , base
         , bytestring

--- a/amazonka-sqs/gen/Network/AWS/SQS/Types/Sum.hs
+++ b/amazonka-sqs/gen/Network/AWS/SQS/Types/Sum.hs
@@ -69,9 +69,11 @@ instance ToText QueueAttributeName where
         RedrivePolicy -> "redrivepolicy"
         VisibilityTimeout -> "visibilitytimeout"
 
-instance Hashable QueueAttributeName
-instance ToQuery  QueueAttributeName
-instance ToHeader QueueAttributeName
+instance Hashable     QueueAttributeName
+instance ToByteString QueueAttributeName
+instance ToPath       QueueAttributeName
+instance ToQuery      QueueAttributeName
+instance ToHeader     QueueAttributeName
 
 instance FromXML QueueAttributeName where
     parseXML = parseXMLText "QueueAttributeName"

--- a/amazonka-ssm/amazonka-ssm.cabal
+++ b/amazonka-ssm/amazonka-ssm.cabal
@@ -83,7 +83,7 @@ test-suite amazonka-ssm-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-ssm == 1.0.0
         , base
         , bytestring

--- a/amazonka-ssm/gen/Network/AWS/SSM/Types/Sum.hs
+++ b/amazonka-ssm/gen/Network/AWS/SSM/Types/Sum.hs
@@ -36,9 +36,11 @@ instance ToText AssociationFilterKey where
         AFKInstanceId -> "instanceid"
         AFKName -> "name"
 
-instance Hashable AssociationFilterKey
-instance ToQuery  AssociationFilterKey
-instance ToHeader AssociationFilterKey
+instance Hashable     AssociationFilterKey
+instance ToByteString AssociationFilterKey
+instance ToPath       AssociationFilterKey
+instance ToQuery      AssociationFilterKey
+instance ToHeader     AssociationFilterKey
 
 instance ToJSON AssociationFilterKey where
     toJSON = toJSONText
@@ -63,9 +65,11 @@ instance ToText AssociationStatusName where
         Pending -> "pending"
         Success -> "success"
 
-instance Hashable AssociationStatusName
-instance ToQuery  AssociationStatusName
-instance ToHeader AssociationStatusName
+instance Hashable     AssociationStatusName
+instance ToByteString AssociationStatusName
+instance ToPath       AssociationStatusName
+instance ToQuery      AssociationStatusName
+instance ToHeader     AssociationStatusName
 
 instance ToJSON AssociationStatusName where
     toJSON = toJSONText
@@ -87,9 +91,11 @@ instance ToText DocumentFilterKey where
     toText = \case
         Name -> "name"
 
-instance Hashable DocumentFilterKey
-instance ToQuery  DocumentFilterKey
-instance ToHeader DocumentFilterKey
+instance Hashable     DocumentFilterKey
+instance ToByteString DocumentFilterKey
+instance ToPath       DocumentFilterKey
+instance ToQuery      DocumentFilterKey
+instance ToHeader     DocumentFilterKey
 
 instance ToJSON DocumentFilterKey where
     toJSON = toJSONText
@@ -114,9 +120,11 @@ instance ToText DocumentStatus where
         Creating -> "creating"
         Deleting -> "deleting"
 
-instance Hashable DocumentStatus
-instance ToQuery  DocumentStatus
-instance ToHeader DocumentStatus
+instance Hashable     DocumentStatus
+instance ToByteString DocumentStatus
+instance ToPath       DocumentStatus
+instance ToQuery      DocumentStatus
+instance ToHeader     DocumentStatus
 
 instance FromJSON DocumentStatus where
     parseJSON = parseJSONText "DocumentStatus"
@@ -141,9 +149,11 @@ instance ToText Fault where
         Server -> "server"
         Unknown -> "unknown"
 
-instance Hashable Fault
-instance ToQuery  Fault
-instance ToHeader Fault
+instance Hashable     Fault
+instance ToByteString Fault
+instance ToPath       Fault
+instance ToQuery      Fault
+instance ToHeader     Fault
 
 instance FromJSON Fault where
     parseJSON = parseJSONText "Fault"

--- a/amazonka-storagegateway/amazonka-storagegateway.cabal
+++ b/amazonka-storagegateway/amazonka-storagegateway.cabal
@@ -133,7 +133,7 @@ test-suite amazonka-storagegateway-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-storagegateway == 1.0.0
         , base
         , bytestring

--- a/amazonka-sts/amazonka-sts.cabal
+++ b/amazonka-sts/amazonka-sts.cabal
@@ -118,7 +118,7 @@ test-suite amazonka-sts-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-sts == 1.0.0
         , base
         , bytestring

--- a/amazonka-support/amazonka-support.cabal
+++ b/amazonka-support/amazonka-support.cabal
@@ -123,7 +123,7 @@ test-suite amazonka-support-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-support == 1.0.0
         , base
         , bytestring

--- a/amazonka-swf/amazonka-swf.cabal
+++ b/amazonka-swf/amazonka-swf.cabal
@@ -104,7 +104,7 @@ test-suite amazonka-swf-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-swf == 1.0.0
         , base
         , bytestring

--- a/amazonka-swf/gen/Network/AWS/SWF/Types/Sum.hs
+++ b/amazonka-swf/gen/Network/AWS/SWF/Types/Sum.hs
@@ -42,9 +42,11 @@ instance ToText ActivityTaskTimeoutType where
         ATTTScheduleToStart -> "schedule_to_start"
         ATTTStartToClose -> "start_to_close"
 
-instance Hashable ActivityTaskTimeoutType
-instance ToQuery  ActivityTaskTimeoutType
-instance ToHeader ActivityTaskTimeoutType
+instance Hashable     ActivityTaskTimeoutType
+instance ToByteString ActivityTaskTimeoutType
+instance ToPath       ActivityTaskTimeoutType
+instance ToQuery      ActivityTaskTimeoutType
+instance ToHeader     ActivityTaskTimeoutType
 
 instance FromJSON ActivityTaskTimeoutType where
     parseJSON = parseJSONText "ActivityTaskTimeoutType"
@@ -66,9 +68,11 @@ instance ToText CancelTimerFailedCause where
         CTFCOperationNotPermitted -> "operation_not_permitted"
         CTFCTimerIdUnknown -> "timer_id_unknown"
 
-instance Hashable CancelTimerFailedCause
-instance ToQuery  CancelTimerFailedCause
-instance ToHeader CancelTimerFailedCause
+instance Hashable     CancelTimerFailedCause
+instance ToByteString CancelTimerFailedCause
+instance ToPath       CancelTimerFailedCause
+instance ToQuery      CancelTimerFailedCause
+instance ToHeader     CancelTimerFailedCause
 
 instance FromJSON CancelTimerFailedCause where
     parseJSON = parseJSONText "CancelTimerFailedCause"
@@ -90,9 +94,11 @@ instance ToText CancelWorkflowExecutionFailedCause where
         COperationNotPermitted -> "operation_not_permitted"
         CUnhandledDecision -> "unhandled_decision"
 
-instance Hashable CancelWorkflowExecutionFailedCause
-instance ToQuery  CancelWorkflowExecutionFailedCause
-instance ToHeader CancelWorkflowExecutionFailedCause
+instance Hashable     CancelWorkflowExecutionFailedCause
+instance ToByteString CancelWorkflowExecutionFailedCause
+instance ToPath       CancelWorkflowExecutionFailedCause
+instance ToQuery      CancelWorkflowExecutionFailedCause
+instance ToHeader     CancelWorkflowExecutionFailedCause
 
 instance FromJSON CancelWorkflowExecutionFailedCause where
     parseJSON = parseJSONText "CancelWorkflowExecutionFailedCause"
@@ -117,9 +123,11 @@ instance ToText ChildPolicy where
         RequestCancel -> "request_cancel"
         Terminate -> "terminate"
 
-instance Hashable ChildPolicy
-instance ToQuery  ChildPolicy
-instance ToHeader ChildPolicy
+instance Hashable     ChildPolicy
+instance ToByteString ChildPolicy
+instance ToPath       ChildPolicy
+instance ToQuery      ChildPolicy
+instance ToHeader     ChildPolicy
 
 instance ToJSON ChildPolicy where
     toJSON = toJSONText
@@ -156,9 +164,11 @@ instance ToText CloseStatus where
         Terminated -> "terminated"
         TimedOut -> "timed_out"
 
-instance Hashable CloseStatus
-instance ToQuery  CloseStatus
-instance ToHeader CloseStatus
+instance Hashable     CloseStatus
+instance ToByteString CloseStatus
+instance ToPath       CloseStatus
+instance ToQuery      CloseStatus
+instance ToHeader     CloseStatus
 
 instance ToJSON CloseStatus where
     toJSON = toJSONText
@@ -183,9 +193,11 @@ instance ToText CompleteWorkflowExecutionFailedCause where
         CWEFCOperationNotPermitted -> "operation_not_permitted"
         CWEFCUnhandledDecision -> "unhandled_decision"
 
-instance Hashable CompleteWorkflowExecutionFailedCause
-instance ToQuery  CompleteWorkflowExecutionFailedCause
-instance ToHeader CompleteWorkflowExecutionFailedCause
+instance Hashable     CompleteWorkflowExecutionFailedCause
+instance ToByteString CompleteWorkflowExecutionFailedCause
+instance ToPath       CompleteWorkflowExecutionFailedCause
+instance ToQuery      CompleteWorkflowExecutionFailedCause
+instance ToHeader     CompleteWorkflowExecutionFailedCause
 
 instance FromJSON CompleteWorkflowExecutionFailedCause where
     parseJSON = parseJSONText "CompleteWorkflowExecutionFailedCause"
@@ -228,9 +240,11 @@ instance ToText ContinueAsNewWorkflowExecutionFailedCause where
         CANWEFCWorkflowTypeDeprecated -> "workflow_type_deprecated"
         CANWEFCWorkflowTypeDoesNotExist -> "workflow_type_does_not_exist"
 
-instance Hashable ContinueAsNewWorkflowExecutionFailedCause
-instance ToQuery  ContinueAsNewWorkflowExecutionFailedCause
-instance ToHeader ContinueAsNewWorkflowExecutionFailedCause
+instance Hashable     ContinueAsNewWorkflowExecutionFailedCause
+instance ToByteString ContinueAsNewWorkflowExecutionFailedCause
+instance ToPath       ContinueAsNewWorkflowExecutionFailedCause
+instance ToQuery      ContinueAsNewWorkflowExecutionFailedCause
+instance ToHeader     ContinueAsNewWorkflowExecutionFailedCause
 
 instance FromJSON ContinueAsNewWorkflowExecutionFailedCause where
     parseJSON = parseJSONText "ContinueAsNewWorkflowExecutionFailedCause"
@@ -249,9 +263,11 @@ instance ToText DecisionTaskTimeoutType where
     toText = \case
         StartToClose -> "start_to_close"
 
-instance Hashable DecisionTaskTimeoutType
-instance ToQuery  DecisionTaskTimeoutType
-instance ToHeader DecisionTaskTimeoutType
+instance Hashable     DecisionTaskTimeoutType
+instance ToByteString DecisionTaskTimeoutType
+instance ToPath       DecisionTaskTimeoutType
+instance ToQuery      DecisionTaskTimeoutType
+instance ToHeader     DecisionTaskTimeoutType
 
 instance FromJSON DecisionTaskTimeoutType where
     parseJSON = parseJSONText "DecisionTaskTimeoutType"
@@ -303,9 +319,11 @@ instance ToText DecisionType where
         StartChildWorkflowExecution -> "startchildworkflowexecution"
         StartTimer -> "starttimer"
 
-instance Hashable DecisionType
-instance ToQuery  DecisionType
-instance ToHeader DecisionType
+instance Hashable     DecisionType
+instance ToByteString DecisionType
+instance ToPath       DecisionType
+instance ToQuery      DecisionType
+instance ToHeader     DecisionType
 
 instance ToJSON DecisionType where
     toJSON = toJSONText
@@ -462,9 +480,11 @@ instance ToText EventType where
         WorkflowExecutionTerminated -> "workflowexecutionterminated"
         WorkflowExecutionTimedOut -> "workflowexecutiontimedout"
 
-instance Hashable EventType
-instance ToQuery  EventType
-instance ToHeader EventType
+instance Hashable     EventType
+instance ToByteString EventType
+instance ToPath       EventType
+instance ToQuery      EventType
+instance ToHeader     EventType
 
 instance FromJSON EventType where
     parseJSON = parseJSONText "EventType"
@@ -486,9 +506,11 @@ instance ToText ExecutionStatus where
         Closed -> "closed"
         Open -> "open"
 
-instance Hashable ExecutionStatus
-instance ToQuery  ExecutionStatus
-instance ToHeader ExecutionStatus
+instance Hashable     ExecutionStatus
+instance ToByteString ExecutionStatus
+instance ToPath       ExecutionStatus
+instance ToQuery      ExecutionStatus
+instance ToHeader     ExecutionStatus
 
 instance FromJSON ExecutionStatus where
     parseJSON = parseJSONText "ExecutionStatus"
@@ -510,9 +532,11 @@ instance ToText FailWorkflowExecutionFailedCause where
         FWEFCOperationNotPermitted -> "operation_not_permitted"
         FWEFCUnhandledDecision -> "unhandled_decision"
 
-instance Hashable FailWorkflowExecutionFailedCause
-instance ToQuery  FailWorkflowExecutionFailedCause
-instance ToHeader FailWorkflowExecutionFailedCause
+instance Hashable     FailWorkflowExecutionFailedCause
+instance ToByteString FailWorkflowExecutionFailedCause
+instance ToPath       FailWorkflowExecutionFailedCause
+instance ToQuery      FailWorkflowExecutionFailedCause
+instance ToHeader     FailWorkflowExecutionFailedCause
 
 instance FromJSON FailWorkflowExecutionFailedCause where
     parseJSON = parseJSONText "FailWorkflowExecutionFailedCause"
@@ -531,9 +555,11 @@ instance ToText RecordMarkerFailedCause where
     toText = \case
         RMFCOperationNotPermitted -> "operation_not_permitted"
 
-instance Hashable RecordMarkerFailedCause
-instance ToQuery  RecordMarkerFailedCause
-instance ToHeader RecordMarkerFailedCause
+instance Hashable     RecordMarkerFailedCause
+instance ToByteString RecordMarkerFailedCause
+instance ToPath       RecordMarkerFailedCause
+instance ToQuery      RecordMarkerFailedCause
+instance ToHeader     RecordMarkerFailedCause
 
 instance FromJSON RecordMarkerFailedCause where
     parseJSON = parseJSONText "RecordMarkerFailedCause"
@@ -555,9 +581,11 @@ instance ToText RegistrationStatus where
         Deprecated -> "deprecated"
         Registered -> "registered"
 
-instance Hashable RegistrationStatus
-instance ToQuery  RegistrationStatus
-instance ToHeader RegistrationStatus
+instance Hashable     RegistrationStatus
+instance ToByteString RegistrationStatus
+instance ToPath       RegistrationStatus
+instance ToQuery      RegistrationStatus
+instance ToHeader     RegistrationStatus
 
 instance ToJSON RegistrationStatus where
     toJSON = toJSONText
@@ -582,9 +610,11 @@ instance ToText RequestCancelActivityTaskFailedCause where
         RCATFCActivityIdUnknown -> "activity_id_unknown"
         RCATFCOperationNotPermitted -> "operation_not_permitted"
 
-instance Hashable RequestCancelActivityTaskFailedCause
-instance ToQuery  RequestCancelActivityTaskFailedCause
-instance ToHeader RequestCancelActivityTaskFailedCause
+instance Hashable     RequestCancelActivityTaskFailedCause
+instance ToByteString RequestCancelActivityTaskFailedCause
+instance ToPath       RequestCancelActivityTaskFailedCause
+instance ToQuery      RequestCancelActivityTaskFailedCause
+instance ToHeader     RequestCancelActivityTaskFailedCause
 
 instance FromJSON RequestCancelActivityTaskFailedCause where
     parseJSON = parseJSONText "RequestCancelActivityTaskFailedCause"
@@ -609,9 +639,11 @@ instance ToText RequestCancelExternalWorkflowExecutionFailedCause where
         RCEWEFCRequestCancelExternalWorkflowExecutionRateExceeded -> "request_cancel_external_workflow_execution_rate_exceeded"
         RCEWEFCUnknownExternalWorkflowExecution -> "unknown_external_workflow_execution"
 
-instance Hashable RequestCancelExternalWorkflowExecutionFailedCause
-instance ToQuery  RequestCancelExternalWorkflowExecutionFailedCause
-instance ToHeader RequestCancelExternalWorkflowExecutionFailedCause
+instance Hashable     RequestCancelExternalWorkflowExecutionFailedCause
+instance ToByteString RequestCancelExternalWorkflowExecutionFailedCause
+instance ToPath       RequestCancelExternalWorkflowExecutionFailedCause
+instance ToQuery      RequestCancelExternalWorkflowExecutionFailedCause
+instance ToHeader     RequestCancelExternalWorkflowExecutionFailedCause
 
 instance FromJSON RequestCancelExternalWorkflowExecutionFailedCause where
     parseJSON = parseJSONText "RequestCancelExternalWorkflowExecutionFailedCause"
@@ -660,9 +692,11 @@ instance ToText ScheduleActivityTaskFailedCause where
         SATFCOpenActivitiesLimitExceeded -> "open_activities_limit_exceeded"
         SATFCOperationNotPermitted -> "operation_not_permitted"
 
-instance Hashable ScheduleActivityTaskFailedCause
-instance ToQuery  ScheduleActivityTaskFailedCause
-instance ToHeader ScheduleActivityTaskFailedCause
+instance Hashable     ScheduleActivityTaskFailedCause
+instance ToByteString ScheduleActivityTaskFailedCause
+instance ToPath       ScheduleActivityTaskFailedCause
+instance ToQuery      ScheduleActivityTaskFailedCause
+instance ToHeader     ScheduleActivityTaskFailedCause
 
 instance FromJSON ScheduleActivityTaskFailedCause where
     parseJSON = parseJSONText "ScheduleActivityTaskFailedCause"
@@ -687,9 +721,11 @@ instance ToText SignalExternalWorkflowExecutionFailedCause where
         SEWEFCSignalExternalWorkflowExecutionRateExceeded -> "signal_external_workflow_execution_rate_exceeded"
         SEWEFCUnknownExternalWorkflowExecution -> "unknown_external_workflow_execution"
 
-instance Hashable SignalExternalWorkflowExecutionFailedCause
-instance ToQuery  SignalExternalWorkflowExecutionFailedCause
-instance ToHeader SignalExternalWorkflowExecutionFailedCause
+instance Hashable     SignalExternalWorkflowExecutionFailedCause
+instance ToByteString SignalExternalWorkflowExecutionFailedCause
+instance ToPath       SignalExternalWorkflowExecutionFailedCause
+instance ToQuery      SignalExternalWorkflowExecutionFailedCause
+instance ToHeader     SignalExternalWorkflowExecutionFailedCause
 
 instance FromJSON SignalExternalWorkflowExecutionFailedCause where
     parseJSON = parseJSONText "SignalExternalWorkflowExecutionFailedCause"
@@ -738,9 +774,11 @@ instance ToText StartChildWorkflowExecutionFailedCause where
         SCWEFCWorkflowTypeDeprecated -> "workflow_type_deprecated"
         SCWEFCWorkflowTypeDoesNotExist -> "workflow_type_does_not_exist"
 
-instance Hashable StartChildWorkflowExecutionFailedCause
-instance ToQuery  StartChildWorkflowExecutionFailedCause
-instance ToHeader StartChildWorkflowExecutionFailedCause
+instance Hashable     StartChildWorkflowExecutionFailedCause
+instance ToByteString StartChildWorkflowExecutionFailedCause
+instance ToPath       StartChildWorkflowExecutionFailedCause
+instance ToQuery      StartChildWorkflowExecutionFailedCause
+instance ToHeader     StartChildWorkflowExecutionFailedCause
 
 instance FromJSON StartChildWorkflowExecutionFailedCause where
     parseJSON = parseJSONText "StartChildWorkflowExecutionFailedCause"
@@ -768,9 +806,11 @@ instance ToText StartTimerFailedCause where
         TimerCreationRateExceeded -> "timer_creation_rate_exceeded"
         TimerIdAlreadyInUse -> "timer_id_already_in_use"
 
-instance Hashable StartTimerFailedCause
-instance ToQuery  StartTimerFailedCause
-instance ToHeader StartTimerFailedCause
+instance Hashable     StartTimerFailedCause
+instance ToByteString StartTimerFailedCause
+instance ToPath       StartTimerFailedCause
+instance ToQuery      StartTimerFailedCause
+instance ToHeader     StartTimerFailedCause
 
 instance FromJSON StartTimerFailedCause where
     parseJSON = parseJSONText "StartTimerFailedCause"
@@ -789,9 +829,11 @@ instance ToText WorkflowExecutionCancelRequestedCause where
     toText = \case
         ChildPolicyApplied -> "child_policy_applied"
 
-instance Hashable WorkflowExecutionCancelRequestedCause
-instance ToQuery  WorkflowExecutionCancelRequestedCause
-instance ToHeader WorkflowExecutionCancelRequestedCause
+instance Hashable     WorkflowExecutionCancelRequestedCause
+instance ToByteString WorkflowExecutionCancelRequestedCause
+instance ToPath       WorkflowExecutionCancelRequestedCause
+instance ToQuery      WorkflowExecutionCancelRequestedCause
+instance ToHeader     WorkflowExecutionCancelRequestedCause
 
 instance FromJSON WorkflowExecutionCancelRequestedCause where
     parseJSON = parseJSONText "WorkflowExecutionCancelRequestedCause"
@@ -816,9 +858,11 @@ instance ToText WorkflowExecutionTerminatedCause where
         WETCEventLimitExceeded -> "event_limit_exceeded"
         WETCOperatorInitiated -> "operator_initiated"
 
-instance Hashable WorkflowExecutionTerminatedCause
-instance ToQuery  WorkflowExecutionTerminatedCause
-instance ToHeader WorkflowExecutionTerminatedCause
+instance Hashable     WorkflowExecutionTerminatedCause
+instance ToByteString WorkflowExecutionTerminatedCause
+instance ToPath       WorkflowExecutionTerminatedCause
+instance ToQuery      WorkflowExecutionTerminatedCause
+instance ToHeader     WorkflowExecutionTerminatedCause
 
 instance FromJSON WorkflowExecutionTerminatedCause where
     parseJSON = parseJSONText "WorkflowExecutionTerminatedCause"
@@ -837,9 +881,11 @@ instance ToText WorkflowExecutionTimeoutType where
     toText = \case
         WETTStartToClose -> "start_to_close"
 
-instance Hashable WorkflowExecutionTimeoutType
-instance ToQuery  WorkflowExecutionTimeoutType
-instance ToHeader WorkflowExecutionTimeoutType
+instance Hashable     WorkflowExecutionTimeoutType
+instance ToByteString WorkflowExecutionTimeoutType
+instance ToPath       WorkflowExecutionTimeoutType
+instance ToQuery      WorkflowExecutionTimeoutType
+instance ToHeader     WorkflowExecutionTimeoutType
 
 instance FromJSON WorkflowExecutionTimeoutType where
     parseJSON = parseJSONText "WorkflowExecutionTimeoutType"

--- a/amazonka-workspaces/amazonka-workspaces.cabal
+++ b/amazonka-workspaces/amazonka-workspaces.cabal
@@ -68,7 +68,7 @@ test-suite amazonka-workspaces-test
 
     build-depends:
           amazonka-core == 1.0.0
-        , amazonka-test
+        , amazonka-test == 1.0.0
         , amazonka-workspaces == 1.0.0
         , base
         , bytestring

--- a/amazonka-workspaces/gen/Network/AWS/WorkSpaces/Types/Sum.hs
+++ b/amazonka-workspaces/gen/Network/AWS/WorkSpaces/Types/Sum.hs
@@ -39,9 +39,11 @@ instance ToText Compute where
         Standard -> "standard"
         Value -> "value"
 
-instance Hashable Compute
-instance ToQuery  Compute
-instance ToHeader Compute
+instance Hashable     Compute
+instance ToByteString Compute
+instance ToPath       Compute
+instance ToQuery      Compute
+instance ToHeader     Compute
 
 instance FromJSON Compute where
     parseJSON = parseJSONText "Compute"
@@ -72,9 +74,11 @@ instance ToText WorkspaceDirectoryState where
         Registered -> "registered"
         Registering -> "registering"
 
-instance Hashable WorkspaceDirectoryState
-instance ToQuery  WorkspaceDirectoryState
-instance ToHeader WorkspaceDirectoryState
+instance Hashable     WorkspaceDirectoryState
+instance ToByteString WorkspaceDirectoryState
+instance ToPath       WorkspaceDirectoryState
+instance ToQuery      WorkspaceDirectoryState
+instance ToHeader     WorkspaceDirectoryState
 
 instance FromJSON WorkspaceDirectoryState where
     parseJSON = parseJSONText "WorkspaceDirectoryState"
@@ -96,9 +100,11 @@ instance ToText WorkspaceDirectoryType where
         AdConnector -> "ad_connector"
         SimpleAd -> "simple_ad"
 
-instance Hashable WorkspaceDirectoryType
-instance ToQuery  WorkspaceDirectoryType
-instance ToHeader WorkspaceDirectoryType
+instance Hashable     WorkspaceDirectoryType
+instance ToByteString WorkspaceDirectoryType
+instance ToPath       WorkspaceDirectoryType
+instance ToQuery      WorkspaceDirectoryType
+instance ToHeader     WorkspaceDirectoryType
 
 instance FromJSON WorkspaceDirectoryType where
     parseJSON = parseJSONText "WorkspaceDirectoryType"
@@ -144,9 +150,11 @@ instance ToText WorkspaceState where
         WSTerminating -> "terminating"
         WSUnhealthy -> "unhealthy"
 
-instance Hashable WorkspaceState
-instance ToQuery  WorkspaceState
-instance ToHeader WorkspaceState
+instance Hashable     WorkspaceState
+instance ToByteString WorkspaceState
+instance ToPath       WorkspaceState
+instance ToQuery      WorkspaceState
+instance ToHeader     WorkspaceState
 
 instance FromJSON WorkspaceState where
     parseJSON = parseJSONText "WorkspaceState"

--- a/core/src/Network/AWS/Data/Path.hs
+++ b/core/src/Network/AWS/Data/Path.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- |
@@ -10,16 +11,19 @@
 --
 module Network.AWS.Data.Path where
 
-import           Data.ByteString.Char8 (ByteString)
-import qualified Data.ByteString.Char8 as BS
-import qualified Data.Foldable         as Fold
-import           Data.Monoid           (mempty)
-import           Data.Text             (Text)
+import qualified Data.ByteString.Char8       as BS
+import qualified Data.Foldable               as Fold
+import           Data.Monoid                 (mempty)
+import           Network.AWS.Data.ByteString
+import           Network.HTTP.Types.URI
 
 class ToPath a where
-    toPath :: a -> Text
+    toPath :: a -> ByteString
 
-instance ToPath Text where
+    default toPath :: ToByteString a => a -> ByteString
+    toPath = urlEncode False . toBS
+
+instance ToPath ByteString where
     toPath = id
 
 collapsePath :: ByteString -> ByteString

--- a/core/src/Network/AWS/Data/Text.hs
+++ b/core/src/Network/AWS/Data/Text.hs
@@ -19,6 +19,7 @@ module Network.AWS.Data.Text
     , fromText
     , fromTextError
     , takeLowerText
+    , takeText
     , matchCI
 
     -- * Serialisation
@@ -62,6 +63,9 @@ fromText = A.parseOnly parser
 
 takeLowerText :: Parser Text
 takeLowerText = Text.toLower <$> A.takeText
+
+takeText :: Parser Text
+takeText = A.takeText
 
 matchCI :: Text -> a -> Parser a
 matchCI x y = A.asciiCI x <* A.endOfInput >> return y

--- a/core/src/Network/AWS/Prelude.hs
+++ b/core/src/Network/AWS/Prelude.hs
@@ -44,6 +44,7 @@ import           Network.AWS.Types           as Export hiding (AccessKey,
                                                         Endpoint, Seconds,
                                                         SecretKey)
 import           Network.HTTP.Types.Status   as Export (Status (..))
+import           Network.HTTP.Types.URI      as Export (urlDecode, urlEncode)
 import           Numeric.Natural             as Export (Natural)
 
 infixl 7 .!@

--- a/core/src/Network/AWS/Request.hs
+++ b/core/src/Network/AWS/Request.hs
@@ -112,8 +112,8 @@ putBody x = defaultRequest x
 defaultRequest :: (ToPath a, ToQuery a, ToHeaders a) => a -> Request a
 defaultRequest x = Request
     { _rqMethod  = GET
-    , _rqPath    = toPath    x
-    , _rqQuery   = toQuery   x
+    , _rqPath    = toBS (toPath x)
+    , _rqQuery   = toQuery x
     , _rqHeaders = toHeaders x
     , _rqBody    = ""
     }

--- a/core/src/Network/AWS/Request.hs
+++ b/core/src/Network/AWS/Request.hs
@@ -48,7 +48,6 @@ module Network.AWS.Request
 import           Control.Lens
 import           Data.Maybe
 import           Data.Monoid
-import qualified Data.Text.Encoding           as Text
 import           Network.AWS.Data.Body
 import           Network.AWS.Data.ByteString
 import           Network.AWS.Data.Headers
@@ -113,8 +112,8 @@ putBody x = defaultRequest x
 defaultRequest :: (ToPath a, ToQuery a, ToHeaders a) => a -> Request a
 defaultRequest x = Request
     { _rqMethod  = GET
-    , _rqPath    = Text.encodeUtf8 (toPath x)
-    , _rqQuery   = toQuery x
+    , _rqPath    = toPath    x
+    , _rqQuery   = toQuery   x
     , _rqHeaders = toHeaders x
     , _rqBody    = ""
     }

--- a/gen/config/s3.json
+++ b/gen/config/s3.json
@@ -74,7 +74,7 @@
         },
         "Delimiter": {
             "replacedBy": {
-                "name": "Char",
+                "name": "Delimiter",
                 "deriving": []
             }
         },

--- a/gen/config/s3.json
+++ b/gen/config/s3.json
@@ -2,6 +2,10 @@
     "referenceUrl": "http://docs.aws.amazon.com/AmazonS3/latest/API/Welcome.html",
     "operationUrl": "http://docs.aws.amazon.com/AmazonS3/latest/API/",
     "libraryName": "amazonka-s3",
+    "extraDependencies": [
+        "text >= 1.1",
+        "lens >= 4.4"
+    ],
     "operationPlugins": {
         "DeleteObjects": ["contentMD5"],
         "PutBucketCORS": ["contentMD5"],

--- a/gen/config/s3.json
+++ b/gen/config/s3.json
@@ -3,9 +3,8 @@
     "operationUrl": "http://docs.aws.amazon.com/AmazonS3/latest/API/",
     "libraryName": "amazonka-s3",
     "extraDependencies": [
-        "bytestring >= 0.9",
-        "containers >= 0.5",
-        "lens       >= 4.4"
+        "text >= 1.1",
+        "lens >= 4.4"
     ],
     "operationPlugins": {
         "DeleteObjects": ["contentMD5"],

--- a/gen/config/s3.json
+++ b/gen/config/s3.json
@@ -3,8 +3,9 @@
     "operationUrl": "http://docs.aws.amazon.com/AmazonS3/latest/API/",
     "libraryName": "amazonka-s3",
     "extraDependencies": [
-        "text >= 1.1",
-        "lens >= 4.4"
+        "bytestring >= 0.9",
+        "containers >= 0.5",
+        "lens       >= 4.4"
     ],
     "operationPlugins": {
         "DeleteObjects": ["contentMD5"],

--- a/gen/src/Gen/AST/Data/Syntax.hs
+++ b/gen/src/Gen/AST/Data/Syntax.hs
@@ -533,7 +533,7 @@ toQueryE p = either pair field
     field = toGenericE p toQ "toQuery" toQMap toQList
 
 toPathE :: Either Text Field -> Exp
-toPathE = either str (app (var "toText") . var . fieldAccessor)
+toPathE = either str (app (var "toPath") . var . fieldAccessor)
 
 toBodyE :: Field -> Exp
 toBodyE = var . fieldAccessor

--- a/gen/src/Gen/Types.hs
+++ b/gen/src/Gen/Types.hs
@@ -132,14 +132,15 @@ data Versions = Versions
 makeClassy ''Versions
 
 data Config = Config
-    { _libraryName      :: Text
-    , _referenceUrl     :: Text
-    , _operationUrl     :: Text
-    , _operationModules :: [NS]
-    , _operationPlugins :: Map Id [Text]
-    , _typeModules      :: [NS]
-    , _typeOverrides    :: Map Id Override
-    , _ignoredWaiters   :: Set Id
+    { _libraryName       :: Text
+    , _referenceUrl      :: Text
+    , _operationUrl      :: Text
+    , _operationModules  :: [NS]
+    , _operationPlugins  :: Map Id [Text]
+    , _typeModules       :: [NS]
+    , _typeOverrides     :: Map Id Override
+    , _ignoredWaiters    :: Set Id
+    , _extraDependencies :: [Text]
     }
 
 makeClassy ''Config
@@ -149,11 +150,12 @@ instance FromJSON Config where
         <$> o .:  "libraryName"
         <*> o .:  "referenceUrl"
         <*> o .:  "operationUrl"
-        <*> o .:? "operationModules" .!= mempty
-        <*> o .:? "operationPlugins" .!= mempty
-        <*> o .:? "typeModules"      .!= mempty
-        <*> o .:? "typeOverrides"    .!= mempty
-        <*> o .:? "ignoredWaiters"   .!= mempty
+        <*> o .:? "operationModules"  .!= mempty
+        <*> o .:? "operationPlugins"  .!= mempty
+        <*> o .:? "typeModules"       .!= mempty
+        <*> o .:? "typeOverrides"     .!= mempty
+        <*> o .:? "ignoredWaiters"    .!= mempty
+        <*> o .:? "extraDependencies" .!= mempty
 
 data Library = Library
     { _versions' :: Versions
@@ -181,24 +183,25 @@ instance ToJSON Library where
       where
         Object y = toJSON (l ^. metadata)
         Object x = object
-            [ "referenceUrl"     .= (l ^. referenceUrl)
-            , "operationUrl"     .= (l ^. operationUrl)
-            , "plainDescription" .= Desc 0 (l ^. documentation)
-            , "cabalDescription" .= Desc 4 (l ^. documentation)
-            , "documentation"    .= (l ^. documentation)
-            , "libraryName"      .= (l ^. libraryName)
-            , "libraryNamespace" .= (l ^. libraryNS)
-            , "libraryVersion"   .= (l ^. libraryVersion)
-            , "clientVersion"    .= (l ^. clientVersion)
-            , "coreVersion"      .= (l ^. coreVersion)
-            , "serviceInstance"  .= (l ^.  instance')
-            , "typeModules"      .= sort (l ^.  typeModules)
-            , "operationModules" .= sort (l ^.  operationModules)
-            , "exposedModules"   .= sort (l ^.  exposedModules)
-            , "otherModules"     .= sort (l ^.  otherModules)
-            , "operations"       .= (l ^.. operations . each)
-            , "shapes"           .= sort (l ^.. shapes . each)
-            , "waiters"          .= (l ^.. waiters . each)
+            [ "referenceUrl"      .= (l ^. referenceUrl)
+            , "operationUrl"      .= (l ^. operationUrl)
+            , "plainDescription"  .= Desc 0 (l ^. documentation)
+            , "cabalDescription"  .= Desc 4 (l ^. documentation)
+            , "documentation"     .= (l ^. documentation)
+            , "libraryName"       .= (l ^. libraryName)
+            , "libraryNamespace"  .= (l ^. libraryNS)
+            , "libraryVersion"    .= (l ^. libraryVersion)
+            , "clientVersion"     .= (l ^. clientVersion)
+            , "coreVersion"       .= (l ^. coreVersion)
+            , "serviceInstance"   .= (l ^.  instance')
+            , "typeModules"       .= sort (l ^. typeModules)
+            , "operationModules"  .= sort (l ^. operationModules)
+            , "exposedModules"    .= sort (l ^. exposedModules)
+            , "otherModules"      .= sort (l ^. otherModules)
+            , "extraDependencies" .= sort (l ^. extraDependencies)
+            , "operations"        .= (l ^.. operations . each)
+            , "shapes"            .= sort (l ^.. shapes . each)
+            , "waiters"           .= (l ^.. waiters . each)
             ]
 
 -- FIXME: Remove explicit construction of getters, just use functions.

--- a/gen/stack.yaml
+++ b/gen/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2015-07-15
+resolver: nightly-2015-07-25
 flags:    {}
 packages: ['.']
 extra-deps:

--- a/gen/template/_include/sum.ede
+++ b/gen/template/_include/sum.ede
@@ -17,9 +17,11 @@ instance ToText {{ shape.name }} where
         {{ ctor.key }} -> "{{ ctor.value }}"
       {% endfor %}
 
-instance Hashable {{ shape.name }}
-instance ToQuery  {{ shape.name }}
-instance ToHeader {{ shape.name }}
+instance Hashable     {{ shape.name }}
+instance ToByteString {{ shape.name }}
+instance ToPath       {{ shape.name }}
+instance ToQuery      {{ shape.name }}
+instance ToHeader     {{ shape.name }}
 {% for inst in shape.instances %}
   {% case inst.value %}
   {% when "ToQuery" %}

--- a/gen/template/cabal.ede
+++ b/gen/template/cabal.ede
@@ -41,6 +41,7 @@ library
     build-depends:
           amazonka-core == {{ coreVersion }}.*
         , base          >= 4.7     && < 5
+        , bytestring    >= 0.9
 
 test-suite {{ libraryName }}-test
     type:              exitcode-stdio-1.0
@@ -59,7 +60,7 @@ test-suite {{ libraryName }}-test
 
     build-depends:
           amazonka-core == {{ coreVersion }}
-        , amazonka-test
+        , amazonka-test == {{ coreVersion }}
         , {{ libraryName }} == {{ libraryVersion }}
         , base
         , bytestring

--- a/gen/template/cabal.ede
+++ b/gen/template/cabal.ede
@@ -41,7 +41,9 @@ library
     build-depends:
           amazonka-core == {{ coreVersion }}.*
         , base          >= 4.7     && < 5
-        , bytestring    >= 0.9
+      {% for dep in extraDependencies %}
+        , {{ dep.value }}
+      {% endfor %}
 
 test-suite {{ libraryName }}-test
     type:              exitcode-stdio-1.0

--- a/stack-7.10.1.yaml
+++ b/stack-7.10.1.yaml
@@ -1,4 +1,4 @@
-resolver:   nightly-2015-07-15
+resolver:   nightly-2015-07-25
 flags:      {}
 extra-deps:
   - groom-0.1.2
@@ -58,4 +58,3 @@ packages:
   - amazonka-support
   - amazonka-swf
   - amazonka-workspaces
-


### PR DESCRIPTION
This ensures any encoding of `ObjectKey` and other paths uses `urlEncode False`  for the segments between `/` delimiters.

Additionally some `ObjectKey` combinators are exposed, albeit inefficient due to (re)allocations and the internal representation.

Fixes #143.