### PR TITLE
route53 config: ResourceRecord can be empty in ResourceRecordSet

### DIFF
--- a/gen/config/route53.json
+++ b/gen/config/route53.json
@@ -11,11 +11,6 @@
                 "Marker"
             ]
         },
-        "ResourceRecordSet": {
-            "requiredFields": [
-                "ResourceRecords"
-            ]
-        },
         "ResourceRecordSetRegion": {
             "replacedBy": {
                 "name": "Region",


### PR DESCRIPTION
Example use: creating aliases, see http://docs.aws.amazon.com/Route53/latest/APIReference/CreateAliasRRSAPI.html