### PR TITLE
route53 config: ResourceRecord can be empty in ResourceRecordSet

### DIFF
--- a/gen/overrides/route53.json
+++ b/gen/overrides/route53.json
@@ -15,11 +15,6 @@
                 "Marker"
             ]
         },
-        "ResourceRecordSet": {
-            "required": [
-                "ResourceRecords"
-            ]
-        },
         "ResourceRecordSetRegion": {
             "replaced_by": "Region"
         },


### PR DESCRIPTION
Same as #148 for 0.3. Is it possible to have this released by chance?