### PR TITLE
Empty response (non-)parsing

### DIFF
--- a/amazonka-cloudhsm/gen/Network/AWS/CloudHSM/DeleteHAPG.hs
+++ b/amazonka-cloudhsm/gen/Network/AWS/CloudHSM/DeleteHAPG.hs
@@ -67,7 +67,7 @@ instance AWSRequest DeleteHAPG where
         type Rs DeleteHAPG = DeleteHAPGResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  DeleteHAPGResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-cloudhsm/gen/Network/AWS/CloudHSM/DeleteHSM.hs
+++ b/amazonka-cloudhsm/gen/Network/AWS/CloudHSM/DeleteHSM.hs
@@ -68,7 +68,7 @@ instance AWSRequest DeleteHSM where
         type Rs DeleteHSM = DeleteHSMResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  DeleteHSMResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-cloudhsm/gen/Network/AWS/CloudHSM/DeleteLunaClient.hs
+++ b/amazonka-cloudhsm/gen/Network/AWS/CloudHSM/DeleteLunaClient.hs
@@ -65,7 +65,7 @@ instance AWSRequest DeleteLunaClient where
         type Rs DeleteLunaClient = DeleteLunaClientResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  DeleteLunaClientResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-cloudtrail/gen/Network/AWS/CloudTrail/DeleteTrail.hs
+++ b/amazonka-cloudtrail/gen/Network/AWS/CloudTrail/DeleteTrail.hs
@@ -67,7 +67,7 @@ instance AWSRequest DeleteTrail where
         type Rs DeleteTrail = DeleteTrailResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  DeleteTrailResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-cloudtrail/gen/Network/AWS/CloudTrail/StartLogging.hs
+++ b/amazonka-cloudtrail/gen/Network/AWS/CloudTrail/StartLogging.hs
@@ -67,7 +67,7 @@ instance AWSRequest StartLogging where
         type Rs StartLogging = StartLoggingResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  StartLoggingResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-cloudtrail/gen/Network/AWS/CloudTrail/StopLogging.hs
+++ b/amazonka-cloudtrail/gen/Network/AWS/CloudTrail/StopLogging.hs
@@ -72,7 +72,7 @@ instance AWSRequest StopLogging where
         type Rs StopLogging = StopLoggingResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  StopLoggingResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-codepipeline/gen/Network/AWS/CodePipeline/AcknowledgeJob.hs
+++ b/amazonka-codepipeline/gen/Network/AWS/CodePipeline/AcknowledgeJob.hs
@@ -80,7 +80,7 @@ instance AWSRequest AcknowledgeJob where
         type Rs AcknowledgeJob = AcknowledgeJobResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  AcknowledgeJobResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-codepipeline/gen/Network/AWS/CodePipeline/AcknowledgeThirdPartyJob.hs
+++ b/amazonka-codepipeline/gen/Network/AWS/CodePipeline/AcknowledgeThirdPartyJob.hs
@@ -91,7 +91,7 @@ instance AWSRequest AcknowledgeThirdPartyJob where
              AcknowledgeThirdPartyJobResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  AcknowledgeThirdPartyJobResponse' <$>
                    (pure (fromEnum s)))

--- a/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/SubscribeToDataset.hs
+++ b/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/SubscribeToDataset.hs
@@ -101,7 +101,7 @@ instance AWSRequest SubscribeToDataset where
              SubscribeToDatasetResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  SubscribeToDatasetResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/UnsubscribeFromDataset.hs
+++ b/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/UnsubscribeFromDataset.hs
@@ -101,7 +101,7 @@ instance AWSRequest UnsubscribeFromDataset where
              UnsubscribeFromDatasetResponse
         request = delete
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  UnsubscribeFromDatasetResponse' <$>
                    (pure (fromEnum s)))

--- a/amazonka-datapipeline/gen/Network/AWS/DataPipeline/ActivatePipeline.hs
+++ b/amazonka-datapipeline/gen/Network/AWS/DataPipeline/ActivatePipeline.hs
@@ -93,7 +93,7 @@ instance AWSRequest ActivatePipeline where
         type Rs ActivatePipeline = ActivatePipelineResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  ActivatePipelineResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-datapipeline/gen/Network/AWS/DataPipeline/AddTags.hs
+++ b/amazonka-datapipeline/gen/Network/AWS/DataPipeline/AddTags.hs
@@ -76,7 +76,7 @@ instance AWSRequest AddTags where
         type Rs AddTags = AddTagsResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x -> AddTagsResponse' <$> (pure (fromEnum s)))
 
 instance ToHeaders AddTags where

--- a/amazonka-datapipeline/gen/Network/AWS/DataPipeline/DeactivatePipeline.hs
+++ b/amazonka-datapipeline/gen/Network/AWS/DataPipeline/DeactivatePipeline.hs
@@ -84,7 +84,7 @@ instance AWSRequest DeactivatePipeline where
              DeactivatePipelineResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  DeactivatePipelineResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-datapipeline/gen/Network/AWS/DataPipeline/RemoveTags.hs
+++ b/amazonka-datapipeline/gen/Network/AWS/DataPipeline/RemoveTags.hs
@@ -76,7 +76,7 @@ instance AWSRequest RemoveTags where
         type Rs RemoveTags = RemoveTagsResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  RemoveTagsResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-datapipeline/gen/Network/AWS/DataPipeline/SetTaskStatus.hs
+++ b/amazonka-datapipeline/gen/Network/AWS/DataPipeline/SetTaskStatus.hs
@@ -118,7 +118,7 @@ instance AWSRequest SetTaskStatus where
         type Rs SetTaskStatus = SetTaskStatusResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  SetTaskStatusResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-ds/gen/Network/AWS/DirectoryService/DisableRadius.hs
+++ b/amazonka-ds/gen/Network/AWS/DirectoryService/DisableRadius.hs
@@ -68,7 +68,7 @@ instance AWSRequest DisableRadius where
         type Rs DisableRadius = DisableRadiusResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  DisableRadiusResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-ds/gen/Network/AWS/DirectoryService/DisableSSO.hs
+++ b/amazonka-ds/gen/Network/AWS/DirectoryService/DisableSSO.hs
@@ -95,7 +95,7 @@ instance AWSRequest DisableSSO where
         type Rs DisableSSO = DisableSSOResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  DisableSSOResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-ds/gen/Network/AWS/DirectoryService/EnableRadius.hs
+++ b/amazonka-ds/gen/Network/AWS/DirectoryService/EnableRadius.hs
@@ -78,7 +78,7 @@ instance AWSRequest EnableRadius where
         type Rs EnableRadius = EnableRadiusResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  EnableRadiusResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-ds/gen/Network/AWS/DirectoryService/EnableSSO.hs
+++ b/amazonka-ds/gen/Network/AWS/DirectoryService/EnableSSO.hs
@@ -95,7 +95,7 @@ instance AWSRequest EnableSSO where
         type Rs EnableSSO = EnableSSOResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  EnableSSOResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-ds/gen/Network/AWS/DirectoryService/RestoreFromSnapshot.hs
+++ b/amazonka-ds/gen/Network/AWS/DirectoryService/RestoreFromSnapshot.hs
@@ -77,7 +77,7 @@ instance AWSRequest RestoreFromSnapshot where
              RestoreFromSnapshotResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  RestoreFromSnapshotResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-ds/gen/Network/AWS/DirectoryService/UpdateRadius.hs
+++ b/amazonka-ds/gen/Network/AWS/DirectoryService/UpdateRadius.hs
@@ -79,7 +79,7 @@ instance AWSRequest UpdateRadius where
         type Rs UpdateRadius = UpdateRadiusResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  UpdateRadiusResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/CancelJob.hs
+++ b/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/CancelJob.hs
@@ -74,7 +74,7 @@ instance AWSRequest CancelJob where
         type Rs CancelJob = CancelJobResponse
         request = delete
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  CancelJobResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/DeletePipeline.hs
+++ b/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/DeletePipeline.hs
@@ -71,7 +71,7 @@ instance AWSRequest DeletePipeline where
         type Rs DeletePipeline = DeletePipelineResponse
         request = delete
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  DeletePipelineResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/DeletePreset.hs
+++ b/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/DeletePreset.hs
@@ -72,7 +72,7 @@ instance AWSRequest DeletePreset where
         type Rs DeletePreset = DeletePresetResponse
         request = delete
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  DeletePresetResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-emr/gen/Network/AWS/EMR/AddTags.hs
+++ b/amazonka-emr/gen/Network/AWS/EMR/AddTags.hs
@@ -83,7 +83,7 @@ instance AWSRequest AddTags where
         type Rs AddTags = AddTagsResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x -> AddTagsResponse' <$> (pure (fromEnum s)))
 
 instance ToHeaders AddTags where

--- a/amazonka-emr/gen/Network/AWS/EMR/RemoveTags.hs
+++ b/amazonka-emr/gen/Network/AWS/EMR/RemoveTags.hs
@@ -83,7 +83,7 @@ instance AWSRequest RemoveTags where
         type Rs RemoveTags = RemoveTagsResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  RemoveTagsResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-glacier/gen/Network/AWS/Glacier/CompleteMultipartUpload.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/CompleteMultipartUpload.hs
@@ -164,7 +164,8 @@ instance AWSRequest CompleteMultipartUpload where
         type Rs CompleteMultipartUpload =
              ArchiveCreationOutput
         request = postJSON
-        response = receiveJSON (\ s h x -> eitherParseJSON x)
+        response
+          = receiveEmpty (\ s h x -> eitherParseJSON x)
 
 instance ToHeaders CompleteMultipartUpload where
         toHeaders CompleteMultipartUpload'{..}

--- a/amazonka-glacier/gen/Network/AWS/Glacier/CreateVault.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/CreateVault.hs
@@ -107,7 +107,7 @@ instance AWSRequest CreateVault where
         type Rs CreateVault = CreateVaultResponse
         request = putJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  CreateVaultResponse' <$>
                    (h .#? "Location") <*> (pure (fromEnum s)))

--- a/amazonka-glacier/gen/Network/AWS/Glacier/InitiateJob.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/InitiateJob.hs
@@ -218,7 +218,7 @@ instance AWSRequest InitiateJob where
         type Rs InitiateJob = InitiateJobResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  InitiateJobResponse' <$>
                    (h .#? "x-amz-job-id") <*> (h .#? "Location") <*>

--- a/amazonka-glacier/gen/Network/AWS/Glacier/InitiateMultipartUpload.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/InitiateMultipartUpload.hs
@@ -144,7 +144,7 @@ instance AWSRequest InitiateMultipartUpload where
              InitiateMultipartUploadResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  InitiateMultipartUploadResponse' <$>
                    (h .#? "Location") <*>

--- a/amazonka-glacier/gen/Network/AWS/Glacier/InitiateVaultLock.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/InitiateVaultLock.hs
@@ -125,7 +125,7 @@ instance AWSRequest InitiateVaultLock where
         type Rs InitiateVaultLock = InitiateVaultLockResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  InitiateVaultLockResponse' <$>
                    (h .#? "x-amz-lock-id") <*> (pure (fromEnum s)))

--- a/amazonka-glacier/gen/Network/AWS/Glacier/UploadArchive.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/UploadArchive.hs
@@ -148,7 +148,8 @@ instance AWSRequest UploadArchive where
         type Sv UploadArchive = Glacier
         type Rs UploadArchive = ArchiveCreationOutput
         request = postBody
-        response = receiveJSON (\ s h x -> eitherParseJSON x)
+        response
+          = receiveEmpty (\ s h x -> eitherParseJSON x)
 
 instance ToBody UploadArchive where
         toBody = _uaBody

--- a/amazonka-glacier/gen/Network/AWS/Glacier/UploadMultipartPart.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/UploadMultipartPart.hs
@@ -169,7 +169,7 @@ instance AWSRequest UploadMultipartPart where
              UploadMultipartPartResponse
         request = putBody
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  UploadMultipartPartResponse' <$>
                    (h .#? "x-amz-sha256-tree-hash") <*>

--- a/amazonka-route53-domains/gen/Network/AWS/Route53Domains/DeleteTagsForDomain.hs
+++ b/amazonka-route53-domains/gen/Network/AWS/Route53Domains/DeleteTagsForDomain.hs
@@ -102,7 +102,7 @@ instance AWSRequest DeleteTagsForDomain where
              DeleteTagsForDomainResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  DeleteTagsForDomainResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-route53-domains/gen/Network/AWS/Route53Domains/DisableDomainAutoRenew.hs
+++ b/amazonka-route53-domains/gen/Network/AWS/Route53Domains/DisableDomainAutoRenew.hs
@@ -72,7 +72,7 @@ instance AWSRequest DisableDomainAutoRenew where
              DisableDomainAutoRenewResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  DisableDomainAutoRenewResponse' <$>
                    (pure (fromEnum s)))

--- a/amazonka-route53-domains/gen/Network/AWS/Route53Domains/EnableDomainAutoRenew.hs
+++ b/amazonka-route53-domains/gen/Network/AWS/Route53Domains/EnableDomainAutoRenew.hs
@@ -75,7 +75,7 @@ instance AWSRequest EnableDomainAutoRenew where
              EnableDomainAutoRenewResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  EnableDomainAutoRenewResponse' <$>
                    (pure (fromEnum s)))

--- a/amazonka-route53-domains/gen/Network/AWS/Route53Domains/UpdateTagsForDomain.hs
+++ b/amazonka-route53-domains/gen/Network/AWS/Route53Domains/UpdateTagsForDomain.hs
@@ -137,7 +137,7 @@ instance AWSRequest UpdateTagsForDomain where
              UpdateTagsForDomainResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  UpdateTagsForDomainResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-route53/gen/Network/AWS/Route53/ChangeTagsForResource.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/ChangeTagsForResource.hs
@@ -104,7 +104,7 @@ instance AWSRequest ChangeTagsForResource where
              ChangeTagsForResourceResponse
         request = postXML
         response
-          = receiveXML
+          = receiveEmpty
               (\ s h x ->
                  ChangeTagsForResourceResponse' <$>
                    (pure (fromEnum s)))

--- a/amazonka-route53/gen/Network/AWS/Route53/DeleteHealthCheck.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/DeleteHealthCheck.hs
@@ -78,7 +78,7 @@ instance AWSRequest DeleteHealthCheck where
         type Rs DeleteHealthCheck = DeleteHealthCheckResponse
         request = delete
         response
-          = receiveXML
+          = receiveEmpty
               (\ s h x ->
                  DeleteHealthCheckResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-route53/gen/Network/AWS/Route53/DeleteReusableDelegationSet.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/DeleteReusableDelegationSet.hs
@@ -77,7 +77,7 @@ instance AWSRequest DeleteReusableDelegationSet where
              DeleteReusableDelegationSetResponse
         request = delete
         response
-          = receiveXML
+          = receiveEmpty
               (\ s h x ->
                  DeleteReusableDelegationSetResponse' <$>
                    (pure (fromEnum s)))

--- a/amazonka-s3/gen/Network/AWS/S3/AbortMultipartUpload.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/AbortMultipartUpload.hs
@@ -98,7 +98,7 @@ instance AWSRequest AbortMultipartUpload where
              AbortMultipartUploadResponse
         request = delete
         response
-          = receiveXML
+          = receiveEmpty
               (\ s h x ->
                  AbortMultipartUploadResponse' <$>
                    (h .#? "x-amz-request-charged") <*>

--- a/amazonka-s3/gen/Network/AWS/S3/CreateBucket.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/CreateBucket.hs
@@ -131,7 +131,7 @@ instance AWSRequest CreateBucket where
         type Rs CreateBucket = CreateBucketResponse
         request = putXML
         response
-          = receiveXML
+          = receiveEmpty
               (\ s h x ->
                  CreateBucketResponse' <$>
                    (h .#? "Location") <*> (pure (fromEnum s)))

--- a/amazonka-s3/gen/Network/AWS/S3/DeleteObject.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/DeleteObject.hs
@@ -107,7 +107,7 @@ instance AWSRequest DeleteObject where
         type Rs DeleteObject = DeleteObjectResponse
         request = delete
         response
-          = receiveXML
+          = receiveEmpty
               (\ s h x ->
                  DeleteObjectResponse' <$>
                    (h .#? "x-amz-version-id") <*>

--- a/amazonka-s3/gen/Network/AWS/S3/HeadObject.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/HeadObject.hs
@@ -204,7 +204,7 @@ instance AWSRequest HeadObject where
         type Rs HeadObject = HeadObjectResponse
         request = head'
         response
-          = receiveXML
+          = receiveEmpty
               (\ s h x ->
                  HeadObjectResponse' <$>
                    (h .#? "x-amz-version-id") <*> (h .#? "ETag") <*>

--- a/amazonka-s3/gen/Network/AWS/S3/PutObject.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/PutObject.hs
@@ -307,7 +307,7 @@ instance AWSRequest PutObject where
         type Rs PutObject = PutObjectResponse
         request = putBody
         response
-          = receiveXML
+          = receiveEmpty
               (\ s h x ->
                  PutObjectResponse' <$>
                    (h .#? "x-amz-version-id") <*> (h .#? "ETag") <*>

--- a/amazonka-s3/gen/Network/AWS/S3/PutObjectACL.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/PutObjectACL.hs
@@ -159,7 +159,7 @@ instance AWSRequest PutObjectACL where
         type Rs PutObjectACL = PutObjectACLResponse
         request = putXML
         response
-          = receiveXML
+          = receiveEmpty
               (\ s h x ->
                  PutObjectACLResponse' <$>
                    (h .#? "x-amz-request-charged") <*>

--- a/amazonka-s3/gen/Network/AWS/S3/RestoreObject.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/RestoreObject.hs
@@ -102,7 +102,7 @@ instance AWSRequest RestoreObject where
         type Rs RestoreObject = RestoreObjectResponse
         request = postXML
         response
-          = receiveXML
+          = receiveEmpty
               (\ s h x ->
                  RestoreObjectResponse' <$>
                    (h .#? "x-amz-request-charged") <*>

--- a/amazonka-s3/gen/Network/AWS/S3/UploadPart.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/UploadPart.hs
@@ -178,7 +178,7 @@ instance AWSRequest UploadPart where
         type Rs UploadPart = UploadPartResponse
         request = putBody
         response
-          = receiveXML
+          = receiveEmpty
               (\ s h x ->
                  UploadPartResponse' <$>
                    (h .#? "ETag") <*> (h .#? "x-amz-request-charged")

--- a/amazonka-ssm/gen/Network/AWS/SSM/DeleteAssociation.hs
+++ b/amazonka-ssm/gen/Network/AWS/SSM/DeleteAssociation.hs
@@ -81,7 +81,7 @@ instance AWSRequest DeleteAssociation where
         type Rs DeleteAssociation = DeleteAssociationResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  DeleteAssociationResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-ssm/gen/Network/AWS/SSM/DeleteDocument.hs
+++ b/amazonka-ssm/gen/Network/AWS/SSM/DeleteDocument.hs
@@ -68,7 +68,7 @@ instance AWSRequest DeleteDocument where
         type Rs DeleteDocument = DeleteDocumentResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  DeleteDocumentResponse' <$> (pure (fromEnum s)))
 

--- a/amazonka-support/gen/Network/AWS/Support/RefreshTrustedAdvisorCheck.hs
+++ b/amazonka-support/gen/Network/AWS/Support/RefreshTrustedAdvisorCheck.hs
@@ -77,7 +77,7 @@ instance AWSRequest RefreshTrustedAdvisorCheck where
              RefreshTrustedAdvisorCheckResponse
         request = postJSON
         response
-          = receiveJSON
+          = receiveEmpty
               (\ s h x ->
                  RefreshTrustedAdvisorCheckResponse' <$>
                    (pure (fromEnum s)))

--- a/core/src/Network/AWS/Response.hs
+++ b/core/src/Network/AWS/Response.hs
@@ -43,6 +43,16 @@ receiveNull :: MonadResource m
 receiveNull rs _ = receive $ \_ _ x ->
     liftResourceT (x $$+- return (Right rs))
 
+receiveEmpty :: MonadResource m
+             => (Int -> ResponseHeaders -> Either String (Rs a))
+             -> Logger
+             -> Service s
+             -> Request a
+             -> ClientResponse
+             -> m (Response a)
+receiveEmpty f _ = receive $ \s h x ->
+    liftResourceT (x $$+- return (f s h))
+
 receiveXMLWrapper :: MonadResource m
                   => Text
                   -> (Int -> ResponseHeaders -> [Node] -> Either String (Rs a))
@@ -70,7 +80,6 @@ receiveJSON :: MonadResource m
             -> ClientResponse
             -> m (Response a)
 receiveJSON = deserialise eitherDecode'
-
 
 receiveBody :: MonadResource m
             => (Int -> ResponseHeaders -> RsBody -> Either String (Rs a))

--- a/core/src/Network/AWS/Response.hs
+++ b/core/src/Network/AWS/Response.hs
@@ -44,14 +44,14 @@ receiveNull rs _ = receive $ \_ _ x ->
     liftResourceT (x $$+- return (Right rs))
 
 receiveEmpty :: MonadResource m
-             => (Int -> ResponseHeaders -> Either String (Rs a))
+             => (Int -> ResponseHeaders -> () -> Either String (Rs a))
              -> Logger
              -> Service s
              -> Request a
              -> ClientResponse
              -> m (Response a)
 receiveEmpty f _ = receive $ \s h x ->
-    liftResourceT (x $$+- return (f s h))
+    liftResourceT (x $$+- return (f s h ()))
 
 receiveXMLWrapper :: MonadResource m
                   => Text

--- a/gen/src/Gen/AST/Data/Field.hs
+++ b/gen/src/Gen/AST/Data/Field.hs
@@ -137,6 +137,13 @@ fieldHelp = fromMaybe "Undocumented member."
 fieldLocation :: Field -> Maybe Location
 fieldLocation = view (fieldRef . refLocation)
 
+fieldBody :: Field -> Bool
+fieldBody x =
+    case fieldLocation x of
+        Just Body -> True
+        Nothing   -> True
+        _         -> fieldStream x
+
 fieldMaybe :: Field -> Bool
 fieldMaybe f =
     case typeOf f of

--- a/gen/src/Gen/AST/Data/Syntax.hs
+++ b/gen/src/Gen/AST/Data/Syntax.hs
@@ -638,6 +638,7 @@ responseF p r fs
     | null fs                         = var "receiveNull"
     | any fieldStream fs              = var "receiveBody"
     | Just x <- r ^. refResultWrapper = app (var (suf <> "Wrapper")) (str x)
+    | all (not . fieldBody) fs        = var "receiveEmpty"
     | otherwise                       = var suf
   where
     suf = "receive" <> Proto.suffix p


### PR DESCRIPTION
By checking during generation if a set of fields contains any elements that would be parsed from the body, we can selectively render `receiveEmpty`. This has the same arity as other `receive*` functions for generator convenience, but simply drains the response body without parsing.

Fixes #161.