### PR TITLE
Avoid emitting empty XML nodes for Nothing values

### DIFF
--- a/core/amazonka-core.cabal
+++ b/core/amazonka-core.cabal
@@ -115,6 +115,7 @@ test-suite tests
           Test.AWS.Arbitrary
         , Test.AWS.Data.Base64
         , Test.AWS.Data.List
+        , Test.AWS.Data.Maybe
         , Test.AWS.Data.Numeric
         , Test.AWS.Data.Time
         , Test.AWS.Sign.V4

--- a/core/src/Network/AWS/Data/XML.hs
+++ b/core/src/Network/AWS/Data/XML.hs
@@ -45,7 +45,10 @@ infixr 7 @=
 -- IsString instance for Name creates a qualified name with an empty ns.
 
 (@=) :: ToXML a => Text -> a -> XML
-n @= x = XOne . NodeElement $ mkElement (Name n Nothing Nothing) x
+n @= x =
+    case toXML x of
+        XNull -> XNull
+        xs    -> XOne . NodeElement $ mkElement (Name n Nothing Nothing) xs
 
 decodeXML :: FromXML a => LazyByteString -> Either String a
 decodeXML = either failure success . parseLBS def

--- a/core/test/Main.hs
+++ b/core/test/Main.hs
@@ -12,6 +12,7 @@ module Main (main) where
 
 import qualified Test.AWS.Data.Base64  as Base64
 import qualified Test.AWS.Data.List    as List
+import qualified Test.AWS.Data.Maybe   as Maybe
 import qualified Test.AWS.Data.Numeric as Numeric
 import qualified Test.AWS.Data.Time    as Time
 import qualified Test.AWS.Sign.V4      as V4
@@ -24,6 +25,7 @@ main = defaultMain $
             [ Numeric.tests
             , Time.tests
             , Base64.tests
+            , Maybe.tests
             ]
 
         , testGroup "collections"

--- a/core/test/Test/AWS/Data/List.hs
+++ b/core/test/Test/AWS/Data/List.hs
@@ -86,7 +86,7 @@ tests = testGroup "list"
         , testGroup "serialise"
             [ testGroup "non-flattened"
                 [ testToXML "absent"
-                    "<name>absent</name><itemSet/>"
+                    "<name>absent</name>"
                     (NonFlat "absent" absent)
 
                 , testToXML "primitive"

--- a/core/test/Test/AWS/Data/Maybe.hs
+++ b/core/test/Test/AWS/Data/Maybe.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module      : Test.AWS.Data.Maybe
+-- Copyright   : (c) 2013-2015 Brendan Hay
+-- License     : Mozilla Public License, v. 2.0.
+-- Maintainer  : Brendan Hay <brendan.g.hay@gmail.com>
+-- Stability   : experimental
+-- Portability : non-portable (GHC extensions)
+--
+module Test.AWS.Data.Maybe (tests) where
+
+import           Network.AWS.Prelude
+import           Test.AWS.Util
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+tests :: TestTree
+tests = testGroup "maybe"
+    [ testGroup "xml"
+        [ testGroup "serialise"
+            [ testCase "nothing" $
+                wrapXML "<Key>foo</Key>"
+                    @?= encodeXML (X (Item "foo" Nothing))
+
+            , testCase "just" $
+                wrapXML "<Key>bar</Key><Num>23</Num>"
+                    @?= encodeXML (X (Item "bar" (Just 23)))
+            ]
+        ]
+    ]
+
+data Item = Item Text (Maybe Int)
+    deriving (Eq, Show)
+
+instance ToXML Item where
+    toXML (Item x y) = mconcat
+        [ "Key" @= x
+        , "Num" @= y
+        ]

--- a/core/test/Test/AWS/Util.hs
+++ b/core/test/Test/AWS/Util.hs
@@ -72,15 +72,14 @@ testFromXML :: (FromXML a, Show a, Eq a)
             -> a
             -> TestTree
 testFromXML n bs x = testCase n $
-     Right (X x) @?= (decodeXML ("<x>" <> bs <> "</x>") >>= parseXML)
+     Right (X x) @?= (decodeXML (wrapXML bs) >>= parseXML)
 
 testToXML :: (ToXML a, Show a, Eq a)
           => TestName
           -> LazyByteString
           -> a
           -> TestTree
-testToXML n bs x = testCase n $
-    (declXML <> "<x>" <> bs <> "</x>") @?= encodeXML (X x)
+testToXML n bs x = testCase n $ wrapXML bs @?= encodeXML (X x)
 
 testFromJSON :: (FromJSON a, Show a, Eq a)
              => TestName
@@ -100,8 +99,9 @@ testToJSON n bs x = testCase n (bs @?= encode x)
 str :: LazyByteString -> LazyByteString
 str bs = "\"" <> bs <> "\""
 
-declXML :: LazyByteString
-declXML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+wrapXML :: LazyByteString -> LazyByteString
+wrapXML bs =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" <> "<x>" <> bs <> "</x>"
 
 maxInt :: Int
 maxInt = maxBound


### PR DESCRIPTION
This fixes the `Network.AWS.Data.XML.(@=)` pair serialisation operator erroneously emitting an empty XML element when no value (`XNull`) is present.

Fixes #160.