### PR TITLE
Use standard AWS environment variables

### DIFF
--- a/amazonka/src/Network/AWS/Auth.hs
+++ b/amazonka/src/Network/AWS/Auth.hs
@@ -67,12 +67,12 @@ import           System.Mem.Weak
 import           Prelude
 
 -- | Default access key environment variable.
-accessKey :: Text -- ^ 'AWS_ACCESS_KEY'
-accessKey = "AWS_ACCESS_KEY"
+accessKey :: Text -- ^ 'AWS_ACCESS_KEY_ID'
+accessKey = "AWS_ACCESS_KEY_ID"
 
 -- | Default secret key environment variable.
-secretKey :: Text -- ^ 'AWS_SECRET_KEY'
-secretKey = "AWS_SECRET_KEY"
+secretKey :: Text -- ^ 'AWS_SECRET_ACCESS_KEY'
+secretKey = "AWS_SECRET_ACCESS_KEY"
 
 {- $credentials
 'getAuth' is implemented using the following @from*@-styled functions below.


### PR DESCRIPTION
All SDKs now seems to use these variables: http://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs

There might be a good reason to use something different. If so would you accept a PR that tries both sets of environment variables?