### PR TITLE
Adding support for credentials file consistent with official AWS SDKs

### DIFF
--- a/amazonka/amazonka.cabal
+++ b/amazonka/amazonka.cabal
@@ -71,10 +71,12 @@ library
         , bytestring          >= 0.9
         , conduit             >= 1.1
         , conduit-extra       >= 1.1
+        , directory           >= 1.2
         , exceptions          >= 0.6
         , free                >= 4.5
         , http-client         >= 0.4.9
         , http-conduit        >= 2.1.4
+        , ini                 >= 0.2
         , lens                >= 4.4
         , mmorph              >= 1
         , monad-control       >= 1


### PR DESCRIPTION
Adds support for credentials retrieval consistent with the official SDKs.

This means reading an INI formatted `~/.aws/credentials` file described [here](http://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs) if present, and support for reading the optional `AWS_SESSION_TOKEN` environment variable.

The location of the file defaults to whatever `System.Directory` considers home on Windows, rather than the `%USERPROFILE%` path mentioned in the above article. I'll revisit this at some point. 

Dependent on #164.