### PR TITLE
Ensure nested ToXML instance fields receive a namespace if none specified

### DIFF
--- a/amazonka-s3/fixture/DeleteObjects
+++ b/amazonka-s3/fixture/DeleteObjects
@@ -4,8 +4,8 @@ path:   /bucketname
 query:  ?delete=
 headers:
   Host: s3.amazonaws.com
-  Authorization: AWS4-HMAC-SHA256 Credential=access/20091028/us-east-1/s3/aws4_request, SignedHeaders=content-md5;host;x-amz-content-sha256;x-amz-date, Signature=444663bb6a12513999d350ae5d1e6fcf7b2a0893ea22582c6db4922edbb9c83b
-  Content-MD5: PdWUHsgAuOlP59d4mBjdGg==
-  X-Amz-Content-SHA256: 593bd30fd702e1eae6fd7d828b80ccdf3283194ef2632440511115e70cdf4ccc
+  Authorization: AWS4-HMAC-SHA256 Credential=access/20091028/us-east-1/s3/aws4_request, SignedHeaders=content-md5;host;x-amz-content-sha256;x-amz-date, Signature=8395d88802592a49a30ca19ee1e0a819a663542eddc9bfe6482e314f6ce09b58
+  Content-MD5: Baa58yLrqn+8X+KF6MwPug==
+  X-Amz-Content-SHA256: 3be5f080da935ef26665db14539913f2a45d0219d47414df168777f155b30070
   X-Amz-Date: 20091028T223200Z
-body: <?xml version="1.0" encoding="UTF-8"?><Delete xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Object xmlns=""><Key>sample1.text</Key></Object><Object xmlns=""><Key>sample2.text</Key></Object></Delete>
+body: <?xml version="1.0" encoding="UTF-8"?><Delete xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Object><Key>sample1.text</Key></Object><Object><Key>sample2.text</Key></Object></Delete>

--- a/core/amazonka-core.cabal
+++ b/core/amazonka-core.cabal
@@ -90,6 +90,7 @@ library
         , transformers-compat  >= 0.3
         , unordered-containers >= 0.2.5
         , xml-conduit          >= 1.2
+        , xml-types            >= 0.3.4
 
     if !impl(ghc>=7.9)
         build-depends:

--- a/gen/src/Gen/AST/Data/Instance.hs
+++ b/gen/src/Gen/AST/Data/Instance.hs
@@ -116,7 +116,7 @@ requestInsts m h r fs = do
                 Just (ToQuery zs) -> ToQuery (ys <> zs)
                 _                 -> ToQuery ys
 
-        f ToQuery {} = True
+        f s ToQuery {} = True
         f _          = False
 
     replaceXML :: [Inst] -> Either Error [Inst]


### PR DESCRIPTION
By previously using either the `IsString Name` instance or constructing a name with `Nothing` for the XML namespace, the namespace would be rendered as `xmlns=""` thus generating invalid AWS XML.

This PR adds a some what performant fix during rendering of the XML document to ensure names have the root element's namespace, if none was specified.

Fixes #166.