### PR TITLE
Discard await response, in favour of intelligently returning errors

### DIFF
--- a/amazonka/src/Control/Monad/Trans/AWS.hs
+++ b/amazonka/src/Control/Monad/Trans/AWS.hs
@@ -284,8 +284,8 @@ execAWST f = innerAWST go
 
     go (AwaitF s w (request -> x) k) = do
         e <- view environment
-        r <- lift . f =<< waiter e w x (perform e s x)
-        k (snd r)
+        lift . f . maybe (Right ()) Left =<< waiter e w x (perform e s x)
+        k
 
     tryT m = either (Left . TransportError) Right <$> try m
 

--- a/amazonka/src/Network/AWS.hs
+++ b/amazonka/src/Network/AWS.hs
@@ -249,7 +249,7 @@ paginate = hoist liftAWS . AWST.paginate
 -- is fulfilled.
 --
 -- /See:/ 'AWST.awaitWith'
-await :: (MonadAWS m, AWSRequest a) => Wait a -> a -> m (Rs a)
+await :: (MonadAWS m, AWSRequest a) => Wait a -> a -> m ()
 await w = liftAWS . AWST.await w
 
 -- | Presign an URL that is valid from the specified time until the

--- a/amazonka/src/Network/AWS/Internal/HTTP.hs
+++ b/amazonka/src/Network/AWS/Internal/HTTP.hs
@@ -113,15 +113,21 @@ waiter :: MonadIO m
        -> Wait a
        -> Request a
        -> m (Either Error (Response a))
-       -> m (Either Error (Response a))
-waiter Env{..} w@Wait{..} rq = retrying policy check
+       -> m (Maybe Error)
+waiter Env{..} w@Wait{..} rq f = retrying policy check wait >>= exit
   where
     policy = limitRetries _waitAttempts
           <> constantDelay (microseconds _waitDelay)
 
-    check n rs = do
-        let a = fromMaybe AcceptRetry (accept w rq rs)
-        msg n a >> return (retry a)
+    wait = do
+        e <- f
+        return (fromMaybe AcceptRetry (accept w rq e), e)
+
+    exit (AcceptSuccess, _)      = return Nothing
+    exit (_,             Left e) = return (Just e)
+    exit (_,             _)      = return Nothing
+
+    check n (a, _) = msg n a >> return (retry a)
 
     retry AcceptSuccess = False
     retry AcceptFailure = False


### PR DESCRIPTION
By discarding the `Rs a` response for the last succeeding request in an `await` call, the error can optionally be returned, that is, suppressed if there was an `AcceptSuccess` match for a raised `Error`.

The reason for having to return `()` instead of `Rs a`, is if `AcceptSuccess == Error` .. there is no `Rs a` to return.

Fixes #178