### PR TITLE
Demonstration of incorrect/unintentional exception semantics

### DIFF
--- a/amazonka/src/Control/Monad/Trans/AWS.hs
+++ b/amazonka/src/Control/Monad/Trans/AWS.hs
@@ -156,6 +156,7 @@ import           Control.Monad.Trans.Free        (FreeF (Pure), FreeT (..))
 import           Control.Monad.Trans.Free.Church
 import           Control.Monad.Trans.Resource
 import           Control.Monad.Writer.Class
+import           Data.Bifunctor
 import           Data.IORef
 import           Network.AWS.Auth
 import qualified Network.AWS.EC2.Metadata        as EC2
@@ -232,18 +233,16 @@ instance MonadWriter w m => MonadWriter w (AWST m) where
 --
 -- /See:/ 'runResourceT'.
 runAWST :: (MonadCatch m, MonadResource m, HasEnv r) => r -> AWST m a -> m a
-runAWST = execAWST hoistError
+runAWST = execAWST
 
 -- | Run an 'AWST' action with configurable 'Error' handling.
 --
 -- Does not explictly throw 'Error's and instead uses the supplied lift function.
 execAWST :: (MonadCatch m, MonadResource m, HasEnv r)
-         => (forall a. Either Error a -> m a)
-            -- ^ Lift an 'Error' into the base Monad.
-         -> r
+         => r
          -> AWST m b
          -> m b
-execAWST f = innerAWST go
+execAWST = innerAWST go
   where
     go (CheckF k) = do
         io <- view envEC2
@@ -252,42 +251,42 @@ execAWST f = innerAWST go
             Just p  -> k p
             Nothing -> do
                 m  <- view envManager
-                !r <- lift . f =<< tryT (EC2.isEC2 m)
+                !r <- EC2.isEC2 m
                 liftIO (atomicWriteIORef io (Just r))
                 k r
 
-    go (DynF x k) = do
-        m <- view envManager
-        r <- lift . f =<< tryT (EC2.dynamic m x)
-        k r
+--     go (DynF x k) = do
+--         m <- view envManager
+--         r <- lift . f =<< tryT (EC2.dynamic m x)
+--         k r
 
-    go (MetaF x k) = do
-        m <- view envManager
-        r <- lift . f =<< tryT (EC2.metadata m x)
-        k r
+--     go (MetaF x k) = do
+--         m <- view envManager
+--         r <- lift . f =<< tryT (EC2.metadata m x)
+--         k r
 
-    go (UserF k) = do
-        m <- view envManager
-        r <- lift . f =<< tryT (EC2.userdata m)
-        k r
+--     go (UserF k) = do
+--         m <- view envManager
+--         r <- lift . f =<< tryT (EC2.userdata m)
+--         k r
 
-    go (SignF s ts ex x k) = do
-        a <- view envAuth
-        g <- view envRegion
-        r <- Sign.presignWith (const s) a g ts ex x
-        k r
+--     go (SignF s ts ex x k) = do
+--         a <- view envAuth
+--         g <- view envRegion
+--         r <- Sign.presignWith (const s) a g ts ex x
+--         k r
 
     go (SendF s (request -> x) k) = do
         e <- view environment
-        r <- lift . f =<< retrier e s x (perform e s x)
-        k (snd r)
+        r <- retrier e s x (perform e s x)
+        k (second snd r)
 
     go (AwaitF s w (request -> x) k) = do
         e <- view environment
-        lift . f . maybe (Right ()) Left =<< waiter e w x (perform e s x)
-        k
+        r <- waiter e w x (perform e s x)
+        k r
 
-    tryT m = either (Left . TransportError) Right <$> try m
+--    tryT m = either (Left . TransportError) Right <$> try m
 
 innerAWST :: (Monad m, HasEnv r)
           => (Command (ReaderT Env m a) -> ReaderT Env m a)
@@ -302,8 +301,8 @@ hoistAWST :: (Monad m, Monad n)
           -> AWST n b
 hoistAWST nat = AWST . hoistFT (hoist nat) . unAWST
 
-hoistError :: MonadThrow m => Either Error a -> m a
-hoistError = either (throwingM _Error) return
+-- hoistError :: MonadThrow m => Either Error a -> m a
+-- hoistError = either (throwingM _Error) return
 
 {- $discovery
 AuthN/AuthZ information is handled similarly to other AWS SDKs. You can read

--- a/examples/amazonka-examples.cabal
+++ b/examples/amazonka-examples.cabal
@@ -24,6 +24,7 @@ library
 
     build-depends:
           amazonka      == 1.0.1.*
+        , amazonka-dynamodb
         , amazonka-ec2
         , amazonka-s3
         , amazonka-sqs
@@ -31,6 +32,8 @@ library
         , bytestring
         , conduit
         , conduit-extra
+        , exceptions
         , lens
+        , semigroups
         , transformers
         , text

--- a/examples/amazonka-examples.cabal
+++ b/examples/amazonka-examples.cabal
@@ -19,6 +19,7 @@ library
 
     exposed-modules:
           Example.EC2
+        , Example.ExceptionSemantics
         , Example.S3
         , Example.SQS
 

--- a/examples/src/Example/EC2.hs
+++ b/examples/src/Example/EC2.hs
@@ -11,12 +11,11 @@
 module Example.EC2 where
 
 import           Control.Lens
-
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.AWS
 import           Data.ByteString.Builder (hPutBuilder)
 import           Data.Conduit
-import qualified Data.Conduit.List       as Conduit
+import qualified Data.Conduit.List       as CL
 import           Data.Monoid
 import           Network.AWS.Data
 import           Network.AWS.EC2
@@ -37,6 +36,6 @@ instanceOverview r = do
 
     runResourceT . runAWST env $
         paginate describeInstances
-            =$= Conduit.concatMap (view dirsReservations)
-            =$= Conduit.concatMap (view rInstances)
-             $$ Conduit.mapM_ (liftIO . hPutBuilder stdout . pp)
+            =$= CL.concatMap (view dirsReservations)
+            =$= CL.concatMap (view rInstances)
+             $$ CL.mapM_ (liftIO . hPutBuilder stdout . pp)

--- a/examples/src/Example/ExceptionSemantics.hs
+++ b/examples/src/Example/ExceptionSemantics.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module      : Example.ExceptionSemantics
+-- Copyright   : (c) 2013-2015 Brendan Hay
+-- License     : Mozilla Public License, v. 2.0.
+-- Maintainer  : Brendan Hay <brendan.g.hay@gmail.com>
+-- Stability   : provisional
+-- Portability : non-portable (GHC extensions)
+--
+module Example.ExceptionSemantics where
+
+import           Control.Exception.Lens
+import           Control.Lens
+import           Control.Monad.Catch
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.AWS
+import           Data.Conduit
+import qualified Data.Conduit.List       as CL
+import           Data.List.NonEmpty      (NonEmpty (..))
+import           Data.Monoid
+import           Data.Text               (Text)
+import qualified Data.Text               as Text
+import qualified Data.Text.IO            as Text
+import           Network.AWS.Data
+import           Network.AWS.DynamoDB
+import           System.IO
+
+exceptions :: Region -- ^ Region to operate in.
+           -> Text   -- ^ DynamoDB table name, shouldn't exist.
+           -> IO ()
+exceptions r n = do
+    lgr <- newLogger Info stdout
+    env <- newEnv r Discover <&> envLogger .~ lgr
+
+    let str :: Show a => a -> Text
+        str = Text.pack . show
+
+    let say :: MonadIO m => Text -> m ()
+        say = liftIO . Text.putStrLn
+
+    runResourceT $ do
+        runAWST env $ do
+            say $ "Listing all tables in region " <> toText r
+            paginate listTables
+                =$= CL.concatMap (view ltrsTableNames)
+                 $$ CL.mapM_ (say . mappend "Table: ")
+
+            say "Throwing deliberate IOError"
+            Left u <- trying _IOException $
+                throwM (userError "deliberate!")
+
+            say $ "Performing table scan of " <> n
+            p <- try $
+                paginate (scan n & sAttributesToGet ?~ "foo" :| [])
+                    $$ CL.consume
+
+            say "Displaying error caught while scanning:"
+            case p of
+                Left  e -> say $ str (e :: SomeException)
+                Right x -> say $ "No error! " <> str x
+
+        say "Exited AWST scope."
+    say "Exited ResourceT scope."
+

--- a/examples/src/Example/ExceptionSemantics.hs
+++ b/examples/src/Example/ExceptionSemantics.hs
@@ -61,8 +61,8 @@ exceptions r n = do
             say "Displaying error while scanning using 'paginate': "
             display p
 
-        say "Exited AWST scope."
-    say "Exited ResourceT scope."
+        sayLn "Exited AWST scope."
+    sayLn "Exited ResourceT scope."
 
 display :: (MonadIO m, Show a) => Either SomeException a -> m ()
 display = sayLn . either str (mappend "No error! " . str)


### PR DESCRIPTION
To run, from the project root:

```
$ stack ghci amazonka-examples
```

And then, in GHCi:

```
λ: import Example.ExceptionSemantics
λ: exceptions Frankfurt "non-existent-dynamo-table"
Listing all tables in region eu-central-1
Throwing deliberate IOError
Caught: user error (deliberate!)
Performing table scan of foo
*** Exception: ServiceError (ServiceError' {_serviceAbbrev = Abbrev "DynamoDB", _serviceStatus = Status {statusCode = 400, statusMessage = "Bad Request"}, _serviceHeaders = [("x-amzn-RequestId","..."),("x-amz-crc32","..."),("Content-Type","application/x-amz-json-1.0"),("Content-Length","112"),("Date","Thu, 20 Aug 2015 08:39:28 GMT")], _serviceCode = ErrorCode "ResourceNotFoundException", _serviceMessage = Just (ErrorMessage "Requested resource not found"), _serviceRequestId = Just (RequestId "...")})
```

The `examples/src/Example/ExceptionSemantics.hs` should perform the following:

* List all DynamoDB tables in the supplied region.
* Throw a deliberate `IOError` and catch it, continuing.
* Perform a table scan of the supplied table name, using `send` and `try` to catch `SomeException`.
* Perform a table scan of the supplied table name, using `paginate` and `try` to catch `SomeException`.
* Print the caught error, which should be a `ResourceNotFoundException`.
* Print when the `AWST` is unwrapped.
* Print when the `ResourceT` is unwrapped.

From the GHCi example above, this is not the case. The `ResourceNotFoundException is never caught and the example exits after the first `send Scan` attempt.
