### PR TITLE
Top-level (as opposed to *With function) service configuration overrides

### DIFF
--- a/amazonka/amazonka.cabal
+++ b/amazonka/amazonka.cabal
@@ -63,6 +63,7 @@ library
         , exceptions          >= 0.6
         , http-client         >= 0.4.9
         , http-conduit        >= 2.1.4
+        , http-types          >= 0.8
         , ini                 >= 0.2
         , lens                >= 4.4
         , mmorph              >= 1

--- a/amazonka/src/Control/Monad/Trans/AWS.hs
+++ b/amazonka/src/Control/Monad/Trans/AWS.hs
@@ -66,6 +66,7 @@ module Control.Monad.Trans.AWS
     , within
     , once
     , timeout
+    , endpoint
 
     -- *** Per Request
     , sendWith

--- a/amazonka/src/Control/Monad/Trans/AWS.hs
+++ b/amazonka/src/Control/Monad/Trans/AWS.hs
@@ -62,17 +62,12 @@ module Control.Monad.Trans.AWS
     -- ** Overriding Service Configuration
     -- $service
 
-    -- *** Scoped Actions
     , within
     , once
+    , retries
     , timeout
     , endpoint
-
-    -- *** Per Request
-    , sendWith
-    , paginateWith
-    , awaitWith
-    , presignWith
+    , succeeds
 
     -- ** Streaming
     -- $streaming
@@ -163,6 +158,7 @@ import           Network.AWS.Internal.Logger
 import           Network.AWS.Pager            (AWSPager (..))
 import           Network.AWS.Prelude          as AWS
 import qualified Network.AWS.Presign          as Sign
+import           Network.AWS.Request          (requestURL)
 import           Network.AWS.Types            hiding (LogLevel (..))
 import           Network.AWS.Waiter           (Wait)
 
@@ -245,56 +241,27 @@ type AWSConstraint r m =
 -- | Send a request, returning the associated response if successful.
 --
 -- Throws 'Error'.
---
--- /See:/ 'sendWith'
 send :: (AWSConstraint r m, AWSRequest a)
      => a
      -> m (Rs a)
-send = sendWith id
-
--- | A variant of 'send' that allows modifying the default 'Service' definition
--- used to configure the request.
---
--- Throws 'Error'.
-sendWith :: (AWSConstraint r m, AWSSigner (Sg s), AWSRequest a)
-         => (Service (Sv a) -> Service s) -- ^ Modify the default service configuration.
-         -> a                             -- ^ Request.
-         -> m (Rs a)
-sendWith f x = do
+send x = do
     e <- view environment
-    r <- retrier e s rq (perform e s rq) >>= hoistError
-    return (snd r)
-  where
-    rq = request x
-    s  = f (serviceOf x)
+    r <- retrier e (configure e x) x
+    snd <$> hoistError r
 
 -- | Repeatedly send a request, automatically setting markers and
 -- paginating over multiple responses while available.
 --
 -- Throws 'Error'.
---
--- /See:/ 'paginateWith'
 paginate :: (AWSConstraint r m, AWSPager a)
          => a
          -> Source m (Rs a)
-paginate = paginateWith id
-
--- | A variant of 'paginate' that allows modifying the default 'Service' definition
--- used to configure the request.
---
--- Throws 'Error'.
-paginateWith :: (AWSConstraint r m, AWSSigner (Sg s), AWSPager a)
-             => (Service (Sv a) -> Service s) -- ^ Modify the default service configuration.
-             -> a                             -- ^ Initial request.
-             -> Source m (Rs a)
-paginateWith f = go
+paginate = go
   where
     go !x = do
-        !y <- sendWith f x
+        !y <- send x
         yield y
-        maybe (pure ())
-              go
-              (page x y)
+        maybe (pure ()) go (page x y)
 
 -- | Poll the API with the supplied request until a specific 'Wait' condition
 -- is fulfilled.
@@ -306,23 +273,10 @@ await :: (AWSConstraint r m, AWSRequest a)
       => Wait a
       -> a
       -> m ()
-await = awaitWith id
-
--- | A variant of 'await' that allows modifying the default 'Service' definition
--- used to configure the request.
---
--- Throws 'Error'.
-awaitWith :: (AWSConstraint r m, AWSSigner (Sg s), AWSRequest a)
-          => (Service (Sv a) -> Service s) -- ^ Modify the default service configuration.
-          -> Wait a                        -- ^ Polling, error and acceptance criteria.
-          -> a                             -- ^ Request to poll with.
-          -> m ()
-awaitWith f w x = do
+await w x = do
     e <- view environment
-    waiter e w rq (perform e s rq) >>= hoistError . maybe (Right ()) Left
-  where
-    rq = request x
-    s  = f (serviceOf x)
+    r <- waiter e (configure e x) w x
+    hoistError (maybe (Right ()) Left r)
 
 -- | Presign an URL that is valid from the specified time until the
 -- number of seconds expiry has elapsed.
@@ -338,15 +292,10 @@ presignURL :: ( MonadIO m
            -> Seconds     -- ^ Expiry time.
            -> a           -- ^ Request to presign.
            -> m ByteString
-presignURL ts ex x = do
-    a <- view envAuth
-    r <- view envRegion
-    Sign.presignURL a r ts ex x
+presignURL ts ex = liftM requestURL . presign ts ex
 
 -- | Presign an HTTP request that is valid from the specified time until the
 -- number of seconds expiry has elapsed.
---
--- /See:/ 'presignWith'
 presign :: ( MonadIO m
            , MonadReader r m
            , HasEnv r
@@ -357,25 +306,9 @@ presign :: ( MonadIO m
         -> Seconds     -- ^ Expiry time.
         -> a           -- ^ Request to presign.
         -> m ClientRequest
-presign = presignWith id
-
--- | A variant of 'presign' that allows specifying the 'Service' definition
--- used to configure the request.
-presignWith :: ( MonadIO m
-               , MonadReader r m
-               , HasEnv r
-               , AWSPresigner (Sg s)
-               , AWSRequest a
-               )
-            => (Service (Sv a) -> Service s) -- ^ Function to modify the service configuration.
-            -> UTCTime                       -- ^ Signing time.
-            -> Seconds                       -- ^ Expiry time.
-            -> a                             -- ^ Request to presign.
-            -> m ClientRequest
-presignWith f ts ex x = do
-    a <- view envAuth
-    g <- view envRegion
-    Sign.presignWith f a g ts ex x
+presign ts ex x = do
+    e <- view environment
+    Sign.presignWith (const $ configure e x) (_envAuth e) (_envRegion e) ts ex x
 
 -- | Test whether the underlying host is running on EC2.
 -- This is memoised and any external check occurs for the first invocation only.

--- a/amazonka/src/Network/AWS.hs
+++ b/amazonka/src/Network/AWS.hs
@@ -64,6 +64,7 @@ module Network.AWS
     , within
     , once
     , timeout
+    , endpoint
 
     -- ** Streaming
     -- $streaming
@@ -218,6 +219,11 @@ once = liftAWS . AWST.once
 -- | Scope an action such that any HTTP response will use this timeout value.
 timeout :: MonadAWS m => Seconds -> AWS a -> m a
 timeout s = liftAWS . AWST.timeout s
+
+-- | Scope an action such that any HTTP requests and signing logic used
+-- a modified endpoint.
+endpoint :: MonadAWS m => (Endpoint -> Endpoint) -> AWS a -> m a
+endpoint f = liftAWS . AWST.endpoint f
 
 -- | Send a request, returning the associated response if successful.
 --

--- a/amazonka/src/Network/AWS.hs
+++ b/amazonka/src/Network/AWS.hs
@@ -208,7 +208,7 @@ runAWS :: (MonadResource m, HasEnv r) => r -> AWS a -> m a
 runAWS e = liftResourceT . AWST.runAWST e
 
 -- | Scope an action within the specific 'Region'.
-within :: MonadAWS m => Region -> m a -> m a
+within :: MonadAWS m => Region -> AWS a -> m a
 within r = liftAWS . AWST.within r
 
 -- | Scope an action such that any retry logic for the 'Service' is

--- a/amazonka/src/Network/AWS.hs
+++ b/amazonka/src/Network/AWS.hs
@@ -208,7 +208,7 @@ runAWS :: (MonadResource m, HasEnv r) => r -> AWS a -> m a
 runAWS e = liftResourceT . AWST.runAWST e
 
 -- | Scope an action within the specific 'Region'.
-within :: MonadAWS m => Region -> AWS a -> m a
+within :: MonadAWS m => Region -> m a -> m a
 within r = liftAWS . AWST.within r
 
 -- | Scope an action such that any retry logic for the 'Service' is

--- a/amazonka/src/Network/AWS/Internal/HTTP.hs
+++ b/amazonka/src/Network/AWS/Internal/HTTP.hs
@@ -19,12 +19,12 @@ module Network.AWS.Internal.HTTP
     , waiter
     ) where
 
+import           Control.Arrow                (first)
 import           Control.Monad
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Resource
 import           Control.Retry
-import           Data.Bifunctor
 import           Data.List                    (intersperse)
 import           Data.Monoid
 import           Data.Time

--- a/amazonka/src/Network/AWS/Internal/HTTP.hs
+++ b/amazonka/src/Network/AWS/Internal/HTTP.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE ViewPatterns      #-}
 
 -- |
 -- Module      : Network.AWS.Internal.HTTP
@@ -14,8 +15,7 @@
 -- Portability : non-portable (GHC extensions)
 --
 module Network.AWS.Internal.HTTP
-    ( perform
-    , retrier
+    ( retrier
     , waiter
     ) where
 
@@ -24,6 +24,7 @@ import           Control.Monad.Catch
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Resource
 import           Control.Retry
+import           Data.Bifunctor
 import           Data.List                    (intersperse)
 import           Data.Monoid
 import           Data.Time
@@ -35,49 +36,14 @@ import           Network.HTTP.Conduit         hiding (Request, Response)
 
 import           Prelude
 
-perform :: (MonadCatch m, MonadResource m, AWSSigner (Sg s), AWSRequest a)
+retrier :: (MonadCatch m, MonadResource m, AWSSigner (Sg s), AWSRequest a)
         => Env
         -> Service s
-        -> Request a
+        -> a
         -> m (Either Error (Response a))
-perform e@Env{..} s x = catches go handlers
+retrier e@Env{..} s@Service{..} (request -> rq) =
+    retrying policy check (perform e s rq)
   where
-    go = do
-        t          <- liftIO getCurrentTime
-        Signed m r <- withAuth _envAuth $ \a ->
-            return (signed a _envRegion t svc x)
-
-        let rq = r { responseTimeout = timeoutFor e svc }
-
-        logTrace _envLogger m  -- trace:Signing:Meta
-        logDebug _envLogger rq -- debug:ClientRequest
-
-        rs         <- liftResourceT (http rq _envManager)
-
-        logDebug _envLogger rs -- debug:ClientResponse
-
-        Right <$>
-            response _envLogger svc x rs
-
-    handlers =
-        [ Handler $ return . Left
-        , Handler $ \er -> do
-            logError _envLogger er
-            return (Left (TransportError er))
-        ]
-
-    svc = apply _envOverride s
-
-retrier :: MonadIO m
-        => Env
-        -> Service s
-        -> Request a
-        -> m (Either Error (Response a))
-        -> m (Either Error (Response a))
-retrier Env{..} s rq =
-    retrying (fromMaybe policy _envRetryPolicy) check
-  where
-
     policy = limitRetries _retryAttempts
        <> RetryPolicy (const $ listToMaybe [0 | not stream])
        <> RetryPolicy delay
@@ -90,15 +56,13 @@ retrier Env{..} s rq =
           where
             grow = _retryBase * (fromIntegral _retryGrowth ^^ (n - 1))
 
-    check n = \case
-        Left (TransportError e) -> do
-            p <- liftIO (_envRetryCheck n e)
-            when p (msg "http_error" n) >> return p
+    check n (Left x)
+        | Just p <- x ^? transportErr n, p = msg "http_error" n >> return True
+        | Just m <- x ^? serviceErr        = msg m            n >> return True
+    check _ _                              = return False
 
-        Left e | Just x <- e ^? _ServiceError . to _retryCheck . _Just ->
-            msg x n >> return True
-
-        _ -> return False
+    transportErr n = _TransportError . to (_envRetryCheck n)
+    serviceErr     = _ServiceError . to _retryCheck . _Just
 
     msg x n = logDebug _envLogger
         . mconcat
@@ -111,32 +75,29 @@ retrier Env{..} s rq =
 
     Exponential{..} = _svcRetry
 
-    Service{..} = apply _envOverride s
-
-waiter :: MonadIO m
+waiter :: (MonadCatch m, MonadResource m, AWSSigner (Sg s), AWSRequest a)
        => Env
+       -> Service s
        -> Wait a
-       -> Request a
-       -> m (Either Error (Response a))
+       -> a
        -> m (Maybe Error)
-waiter Env{..} w@Wait{..} rq f = retrying policy check wait >>= exit
+waiter e@Env{..} s w@Wait{..} (request -> rq) =
+   retrying policy check (result <$> perform e s rq) >>= exit
   where
     policy = limitRetries _waitAttempts
           <> constantDelay (microseconds _waitDelay)
 
-    wait = do
-        e <- f
-        return (fromMaybe AcceptRetry (accept w rq e), e)
-
-    exit (AcceptSuccess, _)      = return Nothing
-    exit (_,             Left e) = return (Just e)
-    exit (_,             _)      = return Nothing
-
     check n (a, _) = msg n a >> return (retry a)
+      where
+        retry AcceptSuccess = False
+        retry AcceptFailure = False
+        retry AcceptRetry   = True
 
-    retry AcceptSuccess = False
-    retry AcceptFailure = False
-    retry AcceptRetry   = True
+    result = first (fromMaybe AcceptRetry . accept w rq) . join (,)
+
+    exit (AcceptSuccess, _) = return Nothing
+    exit (_,        Left x) = return (Just x)
+    exit (_,             _) = return Nothing
 
     msg n a = logDebug _envLogger
         . mconcat
@@ -148,7 +109,31 @@ waiter Env{..} w@Wait{..} rq f = retrying policy check wait >>= exit
           , "attempts."
           ]
 
--- | Returns the possible HTTP response timeout value in microseconds
--- given the timeout configuration sources.
-timeoutFor :: HasEnv a => a -> Service s -> Maybe Int
-timeoutFor e s = microseconds <$> _svcTimeout s
+perform :: (MonadCatch m, MonadResource m, AWSSigner (Sg s), AWSRequest a)
+        => Env
+        -> Service s
+        -> Request a
+        -> m (Either Error (Response a))
+perform Env{..} svc x = catches go handlers
+  where
+    go = do
+        t           <- liftIO getCurrentTime
+        Signed m rq <- withAuth _envAuth $ \a ->
+            return (signed a _envRegion t svc x)
+
+        logTrace _envLogger m  -- trace:Signing:Meta
+        logDebug _envLogger rq -- debug:ClientRequest
+
+        rs          <- liftResourceT (http rq _envManager)
+
+        logDebug _envLogger rs -- debug:ClientResponse
+
+        Right <$>
+            response _envLogger svc x rs
+
+    handlers =
+        [ Handler $ return . Left
+        , Handler $ \er -> do
+            logError _envLogger er
+            return (Left (TransportError er))
+        ]

--- a/amazonka/src/Network/AWS/Presign.hs
+++ b/amazonka/src/Network/AWS/Presign.hs
@@ -52,7 +52,7 @@ presign :: (MonadIO m, AWSPresigner (Sg (Sv a)), AWSRequest a)
         -> Seconds     -- ^ Expiry time.
         -> a           -- ^ Request to presign.
         -> m ClientRequest
-presign a r ts ex = presignWith id a r ts ex
+presign = presignWith id
 
 -- | A variant of 'presign' that allows specifying the 'Service' definition
 -- used to configure the request.

--- a/core/src/Network/AWS/Request.hs
+++ b/core/src/Network/AWS/Request.hs
@@ -141,19 +141,20 @@ requestHeaders :: Lens' Client.Request HTTP.RequestHeaders
 requestHeaders f x =
     f (Client.requestHeaders x) <&> \y -> x { Client.requestHeaders = y }
 
--- FIXME: Revist due to custom port numbers for endpoints.
 requestURL :: ClientRequest -> ByteString
-requestURL x =
-       scheme (Client.secure      x)
-    <> toBS   (Client.host        x)
-    <> port   (Client.port        x)
-    <> toBS   (Client.path        x)
-    <> toBS   (Client.queryString x)
+requestURL x = scheme
+    <> toBS (Client.host        x)
+    <> port (Client.port        x)
+    <> toBS (Client.path        x)
+    <> toBS (Client.queryString x)
   where
-    scheme True = "https://"
-    scheme _    = "http://"
+    scheme
+        | secure    = "https://"
+        | otherwise = "http://"
 
     port = \case
-        80  -> ""
-        443 -> ""
-        n   -> ":" <> toBS n
+        80           -> ""
+        443 | secure -> ""
+        n            -> ":" <> toBS n
+
+    secure = Client.secure x

--- a/core/src/Network/AWS/Sign/V2.hs
+++ b/core/src/Network/AWS/Sign/V2.hs
@@ -58,11 +58,8 @@ instance AWSSigner V2 where
       where
         meta = Meta t end signature
 
-        rq = clientRequest
+        rq = (clientRequest end _svcTimeout)
             { Client.method         = meth
-            , Client.host           = _endpointHost
-            , Client.secure         = _endpointSecure
-            , Client.port           = _endpointPort
             , Client.path           = path'
             , Client.queryString    = toBS authorised
             , Client.requestHeaders = headers

--- a/core/src/Network/AWS/Types.hs
+++ b/core/src/Network/AWS/Types.hs
@@ -167,16 +167,6 @@ type ClientResponse = Client.Response ResponseBody
 -- | A convenience alias encapsulating the common 'Response' body.
 type ResponseBody = ResumableSource (ResourceT IO) ByteString
 
--- | Construct a 'ClientRequest' using common parameters such as TLS and prevent
--- throwing errors when receiving erroneous status codes in respones.
-clientRequest :: ClientRequest
-clientRequest = def
-    { Client.secure        = True
-    , Client.port          = 443
-    , Client.redirectCount = 0
-    , Client.checkStatus   = \_ _ _ -> Nothing
-    }
-
 -- | Abbreviated service name.
 newtype Abbrev = Abbrev Text
     deriving (Eq, Ord, Show, IsString, FromXML, FromJSON, FromText, ToText, ToLog)
@@ -375,6 +365,17 @@ svcStatus = lens _svcStatus (\s a -> s { _svcStatus = a })
 
 svcRetry :: Lens' (Service s) Retry
 svcRetry = lens _svcRetry (\s a -> s { _svcRetry = a })
+
+-- | Construct a 'ClientRequest' using common parameters such as TLS and prevent
+-- throwing errors when receiving erroneous status codes in respones.
+clientRequest :: Endpoint -> Maybe Seconds -> ClientRequest
+clientRequest e t = def
+    { Client.secure          = _endpointSecure e
+    , Client.port            = _endpointPort   e
+    , Client.redirectCount   = 0
+    , Client.checkStatus     = \_ _ _ -> Nothing
+    , Client.responseTimeout = microseconds <$> t
+    }
 
 -- | An unsigned request.
 data Request a = Request

--- a/core/src/Network/AWS/Types.hs
+++ b/core/src/Network/AWS/Types.hs
@@ -49,6 +49,9 @@ module Network.AWS.Types
 
     -- * Retries
     , Retry          (..)
+    , exponentBase
+    , exponentGrowth
+    , retryAttempts
 
     -- * Signing
     , AWSSigner      (..)
@@ -339,6 +342,15 @@ data Retry = Exponential
       -- ^ Returns a descriptive name for logging
       -- if the request should be retried.
     }
+
+exponentBase :: Lens' Retry Double
+exponentBase = lens _retryBase (\s a -> s { _retryBase = a })
+
+exponentGrowth :: Lens' Retry Int
+exponentGrowth = lens _retryGrowth (\s a -> s { _retryGrowth = a })
+
+retryAttempts :: Lens' Retry Int
+retryAttempts = lens _retryAttempts (\s a -> s { _retryAttempts = a })
 
 -- | Attributes and functions specific to an AWS service.
 data Service s = Service


### PR DESCRIPTION
Removes the `*With` function variants in favour of exposing a consistent interface for modifying `Service` configuration. This modified configuration (including `Endpoint` facets) is now threaded through the lower levels of `amazonka-core` and fed directly into the `http-client.Request` construction such that any signing algorithm no longer needs to override the default port / SSL / host.

`override` can be used to modify the `Service` directly. (Uses `Reader.local`.) `endpoint`, `retries` and `succeeds` are built upon this.

The now redundant environment options such as `envTimeout` and `envRetryPolicy` are removed.

Additional lenses have been added to various types such as `Service`, `Retry` and `Endpoint` to make working with the above actions more succinct.

Naming of `succeeds` and `retries` subject to further bike-shedding.
