### PR TITLE
Ensure trailing slashes in paths are preserved

### DIFF
--- a/core/src/Network/AWS/Data/Path.hs
+++ b/core/src/Network/AWS/Data/Path.hs
@@ -72,7 +72,10 @@ instance Monoid RawPath where
 
 instance ToByteString EscapedPath where
     toBS (Encoded [] _) = slash
-    toBS (Encoded xs t) = slash <> BS8.intercalate slash (xs <> [slash | t])
+    toBS (Encoded xs t) = trail (slash <> BS8.intercalate slash xs)
+      where
+        trail | t         = flip BS8.snoc sep
+              | otherwise = id
 
 escapePath :: Path a -> EscapedPath
 escapePath (Raw     xs t) = Encoded (map (urlEncode True) xs) t

--- a/core/src/Network/AWS/Data/Path.hs
+++ b/core/src/Network/AWS/Data/Path.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE DataKinds          #-}
-{-# LANGUAGE DefaultSignatures  #-}
 {-# LANGUAGE FlexibleInstances  #-}
 {-# LANGUAGE GADTs              #-}
 {-# LANGUAGE KindSignatures     #-}
 {-# LANGUAGE LambdaCase         #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE ViewPatterns       #-}
 
 -- |
 -- Module      : Network.AWS.Data.Path
@@ -30,6 +30,7 @@ module Network.AWS.Data.Path
     , collapsePath
     ) where
 
+import qualified Data.ByteString             as BS
 import qualified Data.ByteString.Char8       as BS8
 import           Data.Monoid
 import           Network.AWS.Data.ByteString
@@ -48,14 +49,16 @@ instance ToPath Text where
     toPath = toBS
 
 rawPath :: ToPath a => a -> Path 'NoEncoding
-rawPath = Raw . filter (not . BS8.null) . BS8.split sep . toPath
+rawPath (toPath -> x) = Raw (filter (not . BS8.null) (BS8.split sep x)) trail
+  where
+    trail = not (BS.null x || BS8.last x /= sep)
 
 data Encoding = NoEncoding | Percent
     deriving (Eq, Show)
 
 data Path :: Encoding -> * where
-    Raw     :: [ByteString] -> Path 'NoEncoding
-    Encoded :: [ByteString] -> Path 'Percent
+    Raw     :: [ByteString] -> Bool -> Path 'NoEncoding
+    Encoded :: [ByteString] -> Bool -> Path 'Percent
 
 deriving instance Show (Path a)
 deriving instance Eq   (Path a)
@@ -64,21 +67,21 @@ type RawPath     = Path 'NoEncoding
 type EscapedPath = Path 'Percent
 
 instance Monoid RawPath where
-    mempty                    = Raw []
-    mappend (Raw xs) (Raw ys) = Raw (xs ++ ys)
+    mempty                        = Raw [] False
+    mappend (Raw xs _) (Raw ys t) = Raw (xs ++ ys) t
 
 instance ToByteString EscapedPath where
-    toBS (Encoded []) = slash
-    toBS (Encoded xs) = slash <> BS8.intercalate slash xs
+    toBS (Encoded [] _) = slash
+    toBS (Encoded xs t) = slash <> BS8.intercalate slash (xs <> [slash | t])
 
 escapePath :: Path a -> EscapedPath
-escapePath (Raw     xs) = Encoded (map (urlEncode True) xs)
-escapePath (Encoded xs) = Encoded xs
+escapePath (Raw     xs t) = Encoded (map (urlEncode True) xs) t
+escapePath (Encoded xs t) = Encoded xs t
 
 collapsePath :: Path a -> Path a
 collapsePath = \case
-    Raw     xs -> Raw     (go xs)
-    Encoded xs -> Encoded (go xs)
+    Raw     xs t -> Raw     (go xs) t
+    Encoded xs t -> Encoded (go xs) t
   where
     go = reverse . f . reverse
 

--- a/core/src/Network/AWS/Types.hs
+++ b/core/src/Network/AWS/Types.hs
@@ -112,7 +112,6 @@ module Network.AWS.Types
 
     -- ** Seconds
     , Seconds         (..)
-    , _Seconds
     , seconds
     , microseconds
 
@@ -604,17 +603,16 @@ newtype Seconds = Seconds Int
         , ToText
         )
 
-_Seconds :: Iso' Seconds Int
-_Seconds = iso seconds Seconds
-
 instance ToLog Seconds where
-    build (Seconds n) = build n <> "s"
+    build s = build (seconds s) <> "s"
 
 seconds :: Seconds -> Int
-seconds (Seconds n) = n
+seconds (Seconds n)
+    | n < 0     = 0
+    | otherwise = n
 
 microseconds :: Seconds -> Int
-microseconds (Seconds n) = n * 1000000
+microseconds =  (1000000 *) . seconds
 
 _Coerce :: (Coercible a b, Coercible b a) => Iso' a b
 _Coerce = iso coerce coerce

--- a/core/test/Main.hs
+++ b/core/test/Main.hs
@@ -14,6 +14,7 @@ import qualified Test.AWS.Data.Base64  as Base64
 import qualified Test.AWS.Data.List    as List
 import qualified Test.AWS.Data.Maybe   as Maybe
 import qualified Test.AWS.Data.Numeric as Numeric
+import qualified Test.AWS.Data.Path    as Path
 import qualified Test.AWS.Data.Time    as Time
 import qualified Test.AWS.Error        as Error
 import qualified Test.AWS.Sign.V4      as V4
@@ -27,6 +28,10 @@ main = defaultMain $
             , Time.tests
             , Base64.tests
             , Maybe.tests
+            ]
+
+        , testGroup "paths"
+            [ Path.tests
             ]
 
         , testGroup "collections"

--- a/core/test/Test/AWS/Data/Path.hs
+++ b/core/test/Test/AWS/Data/Path.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module      : Test.AWS.Data.Path
+-- Copyright   : (c) 2013-2015 Brendan Hay
+-- License     : Mozilla Public License, v. 2.0.
+-- Maintainer  : Brendan Hay <brendan.g.hay@gmail.com>
+-- Stability   : experimental
+-- Portability : non-portable (GHC extensions)
+--
+module Test.AWS.Data.Path (tests) where
+
+import           Network.AWS.Prelude
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+tests :: TestTree
+tests = testGroup "path"
+    [ testGroup "encode"
+        [ testCase "doesn't append trailing slash" $
+            let x = "/path/without/trailing/slash" in encode x @?= x
+
+        , testCase "preserves trailing slash" $
+            let x = "/some/path/with/trailing/slash/" in encode x @?= x
+
+        , testCase "removes adjacent slashes" $
+            let x = "/path//with/adjacent///slahes/"
+                y = "/path/with/adjacent/slahes/"
+             in encode x @?= y
+        ]
+    ]
+
+encode :: ByteString -> ByteString
+encode = toBS . escapePath . rawPath


### PR DESCRIPTION
Ensures erroneous paths are corrected, but trailing slashes are retained: `/foo///bar/` becomes `/foo/bar/`.

Fixes #195.