### PR TITLE
Do not forget to set 'host' parameter

### DIFF
--- a/core/src/Network/AWS/Sign/V4.hs
+++ b/core/src/Network/AWS/Sign/V4.hs
@@ -158,6 +158,7 @@ finalise m@Meta{..} authorise = Signed m (authorise rq)
   where
     rq = (clientRequest metaEndpoint metaTimeout)
         { Client.method         = toBS metaMethod
+        , Client.host           = metaEndpoint ^. endpointHost
         , Client.path           = toBS metaPath
         , Client.queryString    = qry
         , Client.requestHeaders = metaHeaders


### PR DESCRIPTION
Looks like `Request.host` is not being set so the `host == "localhost"`.