### PR TITLE
Temporary fix for SQS's ReceiveMessage using incorrect enumeration values

### DIFF
--- a/amazonka-sqs/gen/Network/AWS/SQS.hs
+++ b/amazonka-sqs/gen/Network/AWS/SQS.hs
@@ -157,6 +157,9 @@ module Network.AWS.SQS
 
     -- * Types
 
+    -- ** MessageAttribute
+    , MessageAttribute (..)
+
     -- ** QueueAttributeName
     , QueueAttributeName (..)
 

--- a/amazonka-sqs/gen/Network/AWS/SQS/ReceiveMessage.hs
+++ b/amazonka-sqs/gen/Network/AWS/SQS/ReceiveMessage.hs
@@ -97,7 +97,7 @@ data ReceiveMessage = ReceiveMessage'
     { _rmVisibilityTimeout     :: !(Maybe Int)
     , _rmMessageAttributeNames :: !(Maybe [Text])
     , _rmWaitTimeSeconds       :: !(Maybe Int)
-    , _rmAttributeNames        :: !(Maybe [QueueAttributeName])
+    , _rmAttributeNames        :: !(Maybe [MessageAttribute])
     , _rmMaxNumberOfMessages   :: !(Maybe Int)
     , _rmQueueURL              :: !Text
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
@@ -173,7 +173,7 @@ rmWaitTimeSeconds = lens _rmWaitTimeSeconds (\ s a -> s{_rmWaitTimeSeconds = a})
 --     anonymous access is allowed) of the sender.
 -- -   'SentTimestamp' - returns the time when the message was sent to the
 --     queue (epoch time in milliseconds).
-rmAttributeNames :: Lens' ReceiveMessage [QueueAttributeName]
+rmAttributeNames :: Lens' ReceiveMessage [MessageAttribute]
 rmAttributeNames = lens _rmAttributeNames (\ s a -> s{_rmAttributeNames = a}) . _Default . _Coerce;
 
 -- | The maximum number of messages to return. Amazon SQS never returns more

--- a/amazonka-sqs/gen/Network/AWS/SQS/Types.hs
+++ b/amazonka-sqs/gen/Network/AWS/SQS/Types.hs
@@ -33,6 +33,9 @@ module Network.AWS.SQS.Types
     , _MessageNotInflight
     , _BatchEntryIdsNotDistinct
 
+    -- * MessageAttribute
+    , MessageAttribute (..)
+
     -- * QueueAttributeName
     , QueueAttributeName (..)
 

--- a/amazonka-sqs/gen/Network/AWS/SQS/Types/Sum.hs
+++ b/amazonka-sqs/gen/Network/AWS/SQS/Types/Sum.hs
@@ -19,6 +19,37 @@ module Network.AWS.SQS.Types.Sum where
 
 import           Network.AWS.Prelude
 
+data MessageAttribute
+    = All
+    | ApproximateFirstReceiveTimestamp
+    | ApproximateReceiveCount
+    | SenderId
+    | SentTimestamp
+    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+
+instance FromText MessageAttribute where
+    parser = takeLowerText >>= \case
+        "all" -> pure All
+        "approximatefirstreceivetimestamp" -> pure ApproximateFirstReceiveTimestamp
+        "approximatereceivecount" -> pure ApproximateReceiveCount
+        "senderid" -> pure SenderId
+        "senttimestamp" -> pure SentTimestamp
+        e -> fromTextError $ "Failure parsing MessageAttribute from value: '" <> e
+           <> "'. Accepted values: All, ApproximateFirstReceiveTimestamp, ApproximateReceiveCount, SenderId, SentTimestamp"
+
+instance ToText MessageAttribute where
+    toText = \case
+        All -> "All"
+        ApproximateFirstReceiveTimestamp -> "ApproximateFirstReceiveTimestamp"
+        ApproximateReceiveCount -> "ApproximateReceiveCount"
+        SenderId -> "SenderId"
+        SentTimestamp -> "SentTimestamp"
+
+instance Hashable     MessageAttribute
+instance ToByteString MessageAttribute
+instance ToQuery      MessageAttribute
+instance ToHeader     MessageAttribute
+
 data QueueAttributeName
     = ApproximateNumberOfMessages
     | ApproximateNumberOfMessagesDelayed

--- a/gen/annex/sqs.json
+++ b/gen/annex/sqs.json
@@ -1,5 +1,32 @@
 {
     "metadata": {
         "serviceAbbreviation": "SQS"
+    },
+    "shapes": {
+        "MessageAttributeList": {
+            "type": "list",
+            "member": {
+                "shape": "MessageAttribute",
+                "locationName": "AttributeName"
+            },
+            "flattened": true
+        },
+        "ReceiveMessageRequest": {
+            "members": {
+                "AttributeNames": {
+                    "shape": "MessageAttributeList"
+                }
+            }
+        },
+        "MessageAttribute": {
+            "type": "string",
+            "enum": [
+                "All",
+                "ApproximateFirstReceiveTimestamp",
+                "ApproximateReceiveCount",
+                "SenderId",
+                "SentTimestamp"
+            ]
+        }
     }
 }


### PR DESCRIPTION
Overrides the SQS service definition for `ReceiveMessage` by substituting in a fresh shape, in turn referencing a fresh enumeration with the correct values.

Fixes #199. In reference to boto/botocore#602.