### PR TITLE
Case Sensitive MemberIds

### DIFF
--- a/amazonka-sns/gen/Network/AWS/SNS.hs
+++ b/amazonka-sns/gen/Network/AWS/SNS.hs
@@ -57,11 +57,11 @@ module Network.AWS.SNS
     -- ** InternalErrorException
     , _InternalErrorException
 
-    -- ** NotFoundException
-    , _NotFoundException
-
     -- ** InvalidParameterValueException
     , _InvalidParameterValueException
+
+    -- ** NotFoundException
+    , _NotFoundException
 
     -- ** TopicLimitExceededException
     , _TopicLimitExceededException
@@ -78,11 +78,17 @@ module Network.AWS.SNS
     -- ** RemovePermission
     , module Network.AWS.SNS.RemovePermission
 
-    -- ** SetPlatformApplicationAttributes
-    , module Network.AWS.SNS.SetPlatformApplicationAttributes
+    -- ** DeleteTopic
+    , module Network.AWS.SNS.DeleteTopic
+
+    -- ** ListTopics (Paginated)
+    , module Network.AWS.SNS.ListTopics
 
     -- ** CreatePlatformEndpoint
     , module Network.AWS.SNS.CreatePlatformEndpoint
+
+    -- ** SetPlatformApplicationAttributes
+    , module Network.AWS.SNS.SetPlatformApplicationAttributes
 
     -- ** ListSubscriptionsByTopic (Paginated)
     , module Network.AWS.SNS.ListSubscriptionsByTopic
@@ -90,20 +96,17 @@ module Network.AWS.SNS
     -- ** GetTopicAttributes
     , module Network.AWS.SNS.GetTopicAttributes
 
-    -- ** DeleteTopic
-    , module Network.AWS.SNS.DeleteTopic
-
-    -- ** ListTopics (Paginated)
-    , module Network.AWS.SNS.ListTopics
-
     -- ** CreatePlatformApplication
     , module Network.AWS.SNS.CreatePlatformApplication
+
+    -- ** GetPlatformApplicationAttributes
+    , module Network.AWS.SNS.GetPlatformApplicationAttributes
 
     -- ** ListEndpointsByPlatformApplication (Paginated)
     , module Network.AWS.SNS.ListEndpointsByPlatformApplication
 
-    -- ** GetPlatformApplicationAttributes
-    , module Network.AWS.SNS.GetPlatformApplicationAttributes
+    -- ** SetTopicAttributes
+    , module Network.AWS.SNS.SetTopicAttributes
 
     -- ** DeletePlatformApplication
     , module Network.AWS.SNS.DeletePlatformApplication
@@ -111,20 +114,17 @@ module Network.AWS.SNS
     -- ** ListPlatformApplications (Paginated)
     , module Network.AWS.SNS.ListPlatformApplications
 
-    -- ** SetTopicAttributes
-    , module Network.AWS.SNS.SetTopicAttributes
+    -- ** AddPermission
+    , module Network.AWS.SNS.AddPermission
 
     -- ** GetEndpointAttributes
     , module Network.AWS.SNS.GetEndpointAttributes
 
-    -- ** AddPermission
-    , module Network.AWS.SNS.AddPermission
+    -- ** ListSubscriptions (Paginated)
+    , module Network.AWS.SNS.ListSubscriptions
 
     -- ** GetSubscriptionAttributes
     , module Network.AWS.SNS.GetSubscriptionAttributes
-
-    -- ** ListSubscriptions (Paginated)
-    , module Network.AWS.SNS.ListSubscriptions
 
     -- ** CreateTopic
     , module Network.AWS.SNS.CreateTopic

--- a/amazonka-sns/gen/Network/AWS/SNS/Publish.hs
+++ b/amazonka-sns/gen/Network/AWS/SNS/Publish.hs
@@ -37,9 +37,9 @@ module Network.AWS.SNS.Publish
       publish
     , Publish
     -- * Request Lenses
-    , pMessageAttributes
-    , pTargetARN
     , pSubject
+    , pTargetARN
+    , pMessageAttributes
     , pTopicARN
     , pMessageStructure
     , pMessage
@@ -62,9 +62,9 @@ import           Network.AWS.SNS.Types.Product
 --
 -- /See:/ 'publish' smart constructor.
 data Publish = Publish'
-    { _pMessageAttributes :: !(Maybe (Map Text MessageAttributeValue))
+    { _pSubject           :: !(Maybe Text)
     , _pTargetARN         :: !(Maybe Text)
-    , _pSubject           :: !(Maybe Text)
+    , _pMessageAttributes :: !(Maybe (Map Text MessageAttributeValue))
     , _pTopicARN          :: !(Maybe Text)
     , _pMessageStructure  :: !(Maybe Text)
     , _pMessage           :: !Text
@@ -74,11 +74,11 @@ data Publish = Publish'
 --
 -- Use one of the following lenses to modify other fields as desired:
 --
--- * 'pMessageAttributes'
+-- * 'pSubject'
 --
 -- * 'pTargetARN'
 --
--- * 'pSubject'
+-- * 'pMessageAttributes'
 --
 -- * 'pTopicARN'
 --
@@ -90,21 +90,13 @@ publish
     -> Publish
 publish pMessage_ =
     Publish'
-    { _pMessageAttributes = Nothing
+    { _pSubject = Nothing
     , _pTargetARN = Nothing
-    , _pSubject = Nothing
+    , _pMessageAttributes = Nothing
     , _pTopicARN = Nothing
     , _pMessageStructure = Nothing
     , _pMessage = pMessage_
     }
-
--- | Message attributes for Publish action.
-pMessageAttributes :: Lens' Publish (HashMap Text MessageAttributeValue)
-pMessageAttributes = lens _pMessageAttributes (\ s a -> s{_pMessageAttributes = a}) . _Default . _Map;
-
--- | Either TopicArn or EndpointArn, but not both.
-pTargetARN :: Lens' Publish (Maybe Text)
-pTargetARN = lens _pTargetARN (\ s a -> s{_pTargetARN = a});
 
 -- | Optional parameter to be used as the \"Subject\" line when the message
 -- is delivered to email endpoints. This field will also be included, if
@@ -115,6 +107,14 @@ pTargetARN = lens _pTargetARN (\ s a -> s{_pTargetARN = a});
 -- characters; and must be less than 100 characters long.
 pSubject :: Lens' Publish (Maybe Text)
 pSubject = lens _pSubject (\ s a -> s{_pSubject = a});
+
+-- | Either TopicArn or EndpointArn, but not both.
+pTargetARN :: Lens' Publish (Maybe Text)
+pTargetARN = lens _pTargetARN (\ s a -> s{_pTargetARN = a});
+
+-- | Message attributes for Publish action.
+pMessageAttributes :: Lens' Publish (HashMap Text MessageAttributeValue)
+pMessageAttributes = lens _pMessageAttributes (\ s a -> s{_pMessageAttributes = a}) . _Default . _Map;
 
 -- | The topic you want to publish to.
 pTopicARN :: Lens' Publish (Maybe Text)
@@ -196,11 +196,11 @@ instance ToQuery Publish where
           = mconcat
               ["Action" =: ("Publish" :: ByteString),
                "Version" =: ("2010-03-31" :: ByteString),
+               "Subject" =: _pSubject, "TargetArn" =: _pTargetARN,
                "MessageAttributes" =:
                  toQuery
                    (toQueryMap "entry" "Name" "Value" <$>
                       _pMessageAttributes),
-               "TargetArn" =: _pTargetARN, "Subject" =: _pSubject,
                "TopicArn" =: _pTopicARN,
                "MessageStructure" =: _pMessageStructure,
                "Message" =: _pMessage]

--- a/amazonka-sns/gen/Network/AWS/SNS/Subscribe.hs
+++ b/amazonka-sns/gen/Network/AWS/SNS/Subscribe.hs
@@ -52,7 +52,7 @@ import           Network.AWS.SNS.Types.Product
 --
 -- /See:/ 'subscribe' smart constructor.
 data Subscribe = Subscribe'
-    { _subEndpoint :: !(Maybe Endpoint)
+    { _subEndpoint :: !(Maybe Text)
     , _subTopicARN :: !Text
     , _subProtocol :: !Text
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
@@ -92,7 +92,7 @@ subscribe pTopicARN_ pProtocol_ =
 --     queue
 -- -   For the 'application' protocol, the endpoint is the EndpointArn of a
 --     mobile app and device.
-subEndpoint :: Lens' Subscribe (Maybe Endpoint)
+subEndpoint :: Lens' Subscribe (Maybe Text)
 subEndpoint = lens _subEndpoint (\ s a -> s{_subEndpoint = a});
 
 -- | The ARN of the topic you want to subscribe to.

--- a/amazonka-sns/gen/Network/AWS/SNS/Types.hs
+++ b/amazonka-sns/gen/Network/AWS/SNS/Types.hs
@@ -22,8 +22,8 @@ module Network.AWS.SNS.Types
     , _SubscriptionLimitExceededException
     , _PlatformApplicationDisabledException
     , _InternalErrorException
-    , _NotFoundException
     , _InvalidParameterValueException
+    , _NotFoundException
     , _TopicLimitExceededException
 
     -- * Endpoint
@@ -129,15 +129,15 @@ _InternalErrorException :: AsError a => Getting (First ServiceError) a ServiceEr
 _InternalErrorException =
     _ServiceError . hasStatus 500 . hasCode "InternalError"
 
--- | Indicates that the requested resource does not exist.
-_NotFoundException :: AsError a => Getting (First ServiceError) a ServiceError
-_NotFoundException = _ServiceError . hasStatus 404 . hasCode "NotFound"
-
 -- | Indicates that a request parameter does not comply with the associated
 -- constraints.
 _InvalidParameterValueException :: AsError a => Getting (First ServiceError) a ServiceError
 _InvalidParameterValueException =
     _ServiceError . hasStatus 400 . hasCode "ParameterValueInvalid"
+
+-- | Indicates that the requested resource does not exist.
+_NotFoundException :: AsError a => Getting (First ServiceError) a ServiceError
+_NotFoundException = _ServiceError . hasStatus 404 . hasCode "NotFound"
 
 -- | Indicates that the customer already owns the maximum allowed number of
 -- topics.

--- a/amazonka-sns/gen/Network/AWS/SNS/Types/Product.hs
+++ b/amazonka-sns/gen/Network/AWS/SNS/Types/Product.hs
@@ -58,14 +58,6 @@ instance FromXML Endpoint where
                  may (parseXMLMap "entry" "key" "value"))
                 <*> (x .@? "EndpointArn")
 
-instance ToQuery Endpoint where
-        toQuery Endpoint'{..}
-          = mconcat
-              ["Attributes" =:
-                 toQuery
-                   (toQueryMap "entry" "key" "value" <$> _eAttributes),
-               "EndpointArn" =: _eEndpointARN]
-
 -- | The user-specified message attribute value. For string data types, the
 -- value attribute has the same restrictions on the content as the message
 -- body. For more information, see
@@ -179,7 +171,7 @@ data Subscription = Subscription'
     { _sProtocol        :: !(Maybe Text)
     , _sOwner           :: !(Maybe Text)
     , _sTopicARN        :: !(Maybe Text)
-    , _sEndpoint        :: !(Maybe Endpoint)
+    , _sEndpoint        :: !(Maybe Text)
     , _sSubscriptionARN :: !(Maybe Text)
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
@@ -220,7 +212,7 @@ sTopicARN :: Lens' Subscription (Maybe Text)
 sTopicARN = lens _sTopicARN (\ s a -> s{_sTopicARN = a});
 
 -- | The subscription\'s endpoint (format depends on the protocol).
-sEndpoint :: Lens' Subscription (Maybe Endpoint)
+sEndpoint :: Lens' Subscription (Maybe Text)
 sEndpoint = lens _sEndpoint (\ s a -> s{_sEndpoint = a});
 
 -- | The subscription\'s ARN.

--- a/amazonka-sns/test/Test/AWS/Gen/SNS.hs
+++ b/amazonka-sns/test/Test/AWS/Gen/SNS.hs
@@ -34,11 +34,17 @@ import Test.AWS.SNS.Internal
 --         , testRemovePermission $
 --             removePermission
 --
---         , testSetPlatformApplicationAttributes $
---             setPlatformApplicationAttributes
+--         , testDeleteTopic $
+--             deleteTopic
+--
+--         , testListTopics $
+--             listTopics
 --
 --         , testCreatePlatformEndpoint $
 --             createPlatformEndpoint
+--
+--         , testSetPlatformApplicationAttributes $
+--             setPlatformApplicationAttributes
 --
 --         , testListSubscriptionsByTopic $
 --             listSubscriptionsByTopic
@@ -46,20 +52,17 @@ import Test.AWS.SNS.Internal
 --         , testGetTopicAttributes $
 --             getTopicAttributes
 --
---         , testDeleteTopic $
---             deleteTopic
---
---         , testListTopics $
---             listTopics
---
 --         , testCreatePlatformApplication $
 --             createPlatformApplication
+--
+--         , testGetPlatformApplicationAttributes $
+--             getPlatformApplicationAttributes
 --
 --         , testListEndpointsByPlatformApplication $
 --             listEndpointsByPlatformApplication
 --
---         , testGetPlatformApplicationAttributes $
---             getPlatformApplicationAttributes
+--         , testSetTopicAttributes $
+--             setTopicAttributes
 --
 --         , testDeletePlatformApplication $
 --             deletePlatformApplication
@@ -67,20 +70,17 @@ import Test.AWS.SNS.Internal
 --         , testListPlatformApplications $
 --             listPlatformApplications
 --
---         , testSetTopicAttributes $
---             setTopicAttributes
+--         , testAddPermission $
+--             addPermission
 --
 --         , testGetEndpointAttributes $
 --             getEndpointAttributes
 --
---         , testAddPermission $
---             addPermission
+--         , testListSubscriptions $
+--             listSubscriptions
 --
 --         , testGetSubscriptionAttributes $
 --             getSubscriptionAttributes
---
---         , testListSubscriptions $
---             listSubscriptions
 --
 --         , testCreateTopic $
 --             createTopic
@@ -112,11 +112,17 @@ import Test.AWS.SNS.Internal
 --         , testRemovePermissionResponse $
 --             removePermissionResponse
 --
---         , testSetPlatformApplicationAttributesResponse $
---             setPlatformApplicationAttributesResponse
+--         , testDeleteTopicResponse $
+--             deleteTopicResponse
+--
+--         , testListTopicsResponse $
+--             listTopicsResponse
 --
 --         , testCreatePlatformEndpointResponse $
 --             createPlatformEndpointResponse
+--
+--         , testSetPlatformApplicationAttributesResponse $
+--             setPlatformApplicationAttributesResponse
 --
 --         , testListSubscriptionsByTopicResponse $
 --             listSubscriptionsByTopicResponse
@@ -124,20 +130,17 @@ import Test.AWS.SNS.Internal
 --         , testGetTopicAttributesResponse $
 --             getTopicAttributesResponse
 --
---         , testDeleteTopicResponse $
---             deleteTopicResponse
---
---         , testListTopicsResponse $
---             listTopicsResponse
---
 --         , testCreatePlatformApplicationResponse $
 --             createPlatformApplicationResponse
+--
+--         , testGetPlatformApplicationAttributesResponse $
+--             getPlatformApplicationAttributesResponse
 --
 --         , testListEndpointsByPlatformApplicationResponse $
 --             listEndpointsByPlatformApplicationResponse
 --
---         , testGetPlatformApplicationAttributesResponse $
---             getPlatformApplicationAttributesResponse
+--         , testSetTopicAttributesResponse $
+--             setTopicAttributesResponse
 --
 --         , testDeletePlatformApplicationResponse $
 --             deletePlatformApplicationResponse
@@ -145,20 +148,17 @@ import Test.AWS.SNS.Internal
 --         , testListPlatformApplicationsResponse $
 --             listPlatformApplicationsResponse
 --
---         , testSetTopicAttributesResponse $
---             setTopicAttributesResponse
+--         , testAddPermissionResponse $
+--             addPermissionResponse
 --
 --         , testGetEndpointAttributesResponse $
 --             getEndpointAttributesResponse
 --
---         , testAddPermissionResponse $
---             addPermissionResponse
+--         , testListSubscriptionsResponse $
+--             listSubscriptionsResponse
 --
 --         , testGetSubscriptionAttributesResponse $
 --             getSubscriptionAttributesResponse
---
---         , testListSubscriptionsResponse $
---             listSubscriptionsResponse
 --
 --         , testCreateTopicResponse $
 --             createTopicResponse
@@ -196,15 +196,25 @@ testRemovePermission = req
     "RemovePermission"
     "fixture/RemovePermission.yaml"
 
-testSetPlatformApplicationAttributes :: SetPlatformApplicationAttributes -> TestTree
-testSetPlatformApplicationAttributes = req
-    "SetPlatformApplicationAttributes"
-    "fixture/SetPlatformApplicationAttributes.yaml"
+testDeleteTopic :: DeleteTopic -> TestTree
+testDeleteTopic = req
+    "DeleteTopic"
+    "fixture/DeleteTopic.yaml"
+
+testListTopics :: ListTopics -> TestTree
+testListTopics = req
+    "ListTopics"
+    "fixture/ListTopics.yaml"
 
 testCreatePlatformEndpoint :: CreatePlatformEndpoint -> TestTree
 testCreatePlatformEndpoint = req
     "CreatePlatformEndpoint"
     "fixture/CreatePlatformEndpoint.yaml"
+
+testSetPlatformApplicationAttributes :: SetPlatformApplicationAttributes -> TestTree
+testSetPlatformApplicationAttributes = req
+    "SetPlatformApplicationAttributes"
+    "fixture/SetPlatformApplicationAttributes.yaml"
 
 testListSubscriptionsByTopic :: ListSubscriptionsByTopic -> TestTree
 testListSubscriptionsByTopic = req
@@ -216,30 +226,25 @@ testGetTopicAttributes = req
     "GetTopicAttributes"
     "fixture/GetTopicAttributes.yaml"
 
-testDeleteTopic :: DeleteTopic -> TestTree
-testDeleteTopic = req
-    "DeleteTopic"
-    "fixture/DeleteTopic.yaml"
-
-testListTopics :: ListTopics -> TestTree
-testListTopics = req
-    "ListTopics"
-    "fixture/ListTopics.yaml"
-
 testCreatePlatformApplication :: CreatePlatformApplication -> TestTree
 testCreatePlatformApplication = req
     "CreatePlatformApplication"
     "fixture/CreatePlatformApplication.yaml"
+
+testGetPlatformApplicationAttributes :: GetPlatformApplicationAttributes -> TestTree
+testGetPlatformApplicationAttributes = req
+    "GetPlatformApplicationAttributes"
+    "fixture/GetPlatformApplicationAttributes.yaml"
 
 testListEndpointsByPlatformApplication :: ListEndpointsByPlatformApplication -> TestTree
 testListEndpointsByPlatformApplication = req
     "ListEndpointsByPlatformApplication"
     "fixture/ListEndpointsByPlatformApplication.yaml"
 
-testGetPlatformApplicationAttributes :: GetPlatformApplicationAttributes -> TestTree
-testGetPlatformApplicationAttributes = req
-    "GetPlatformApplicationAttributes"
-    "fixture/GetPlatformApplicationAttributes.yaml"
+testSetTopicAttributes :: SetTopicAttributes -> TestTree
+testSetTopicAttributes = req
+    "SetTopicAttributes"
+    "fixture/SetTopicAttributes.yaml"
 
 testDeletePlatformApplication :: DeletePlatformApplication -> TestTree
 testDeletePlatformApplication = req
@@ -251,30 +256,25 @@ testListPlatformApplications = req
     "ListPlatformApplications"
     "fixture/ListPlatformApplications.yaml"
 
-testSetTopicAttributes :: SetTopicAttributes -> TestTree
-testSetTopicAttributes = req
-    "SetTopicAttributes"
-    "fixture/SetTopicAttributes.yaml"
+testAddPermission :: AddPermission -> TestTree
+testAddPermission = req
+    "AddPermission"
+    "fixture/AddPermission.yaml"
 
 testGetEndpointAttributes :: GetEndpointAttributes -> TestTree
 testGetEndpointAttributes = req
     "GetEndpointAttributes"
     "fixture/GetEndpointAttributes.yaml"
 
-testAddPermission :: AddPermission -> TestTree
-testAddPermission = req
-    "AddPermission"
-    "fixture/AddPermission.yaml"
+testListSubscriptions :: ListSubscriptions -> TestTree
+testListSubscriptions = req
+    "ListSubscriptions"
+    "fixture/ListSubscriptions.yaml"
 
 testGetSubscriptionAttributes :: GetSubscriptionAttributes -> TestTree
 testGetSubscriptionAttributes = req
     "GetSubscriptionAttributes"
     "fixture/GetSubscriptionAttributes.yaml"
-
-testListSubscriptions :: ListSubscriptions -> TestTree
-testListSubscriptions = req
-    "ListSubscriptions"
-    "fixture/ListSubscriptions.yaml"
 
 testCreateTopic :: CreateTopic -> TestTree
 testCreateTopic = req
@@ -327,12 +327,19 @@ testRemovePermissionResponse = res
     sNS
     (Proxy :: Proxy RemovePermission)
 
-testSetPlatformApplicationAttributesResponse :: SetPlatformApplicationAttributesResponse -> TestTree
-testSetPlatformApplicationAttributesResponse = res
-    "SetPlatformApplicationAttributesResponse"
-    "fixture/SetPlatformApplicationAttributesResponse.proto"
+testDeleteTopicResponse :: DeleteTopicResponse -> TestTree
+testDeleteTopicResponse = res
+    "DeleteTopicResponse"
+    "fixture/DeleteTopicResponse.proto"
     sNS
-    (Proxy :: Proxy SetPlatformApplicationAttributes)
+    (Proxy :: Proxy DeleteTopic)
+
+testListTopicsResponse :: ListTopicsResponse -> TestTree
+testListTopicsResponse = res
+    "ListTopicsResponse"
+    "fixture/ListTopicsResponse.proto"
+    sNS
+    (Proxy :: Proxy ListTopics)
 
 testCreatePlatformEndpointResponse :: CreatePlatformEndpointResponse -> TestTree
 testCreatePlatformEndpointResponse = res
@@ -340,6 +347,13 @@ testCreatePlatformEndpointResponse = res
     "fixture/CreatePlatformEndpointResponse.proto"
     sNS
     (Proxy :: Proxy CreatePlatformEndpoint)
+
+testSetPlatformApplicationAttributesResponse :: SetPlatformApplicationAttributesResponse -> TestTree
+testSetPlatformApplicationAttributesResponse = res
+    "SetPlatformApplicationAttributesResponse"
+    "fixture/SetPlatformApplicationAttributesResponse.proto"
+    sNS
+    (Proxy :: Proxy SetPlatformApplicationAttributes)
 
 testListSubscriptionsByTopicResponse :: ListSubscriptionsByTopicResponse -> TestTree
 testListSubscriptionsByTopicResponse = res
@@ -355,26 +369,19 @@ testGetTopicAttributesResponse = res
     sNS
     (Proxy :: Proxy GetTopicAttributes)
 
-testDeleteTopicResponse :: DeleteTopicResponse -> TestTree
-testDeleteTopicResponse = res
-    "DeleteTopicResponse"
-    "fixture/DeleteTopicResponse.proto"
-    sNS
-    (Proxy :: Proxy DeleteTopic)
-
-testListTopicsResponse :: ListTopicsResponse -> TestTree
-testListTopicsResponse = res
-    "ListTopicsResponse"
-    "fixture/ListTopicsResponse.proto"
-    sNS
-    (Proxy :: Proxy ListTopics)
-
 testCreatePlatformApplicationResponse :: CreatePlatformApplicationResponse -> TestTree
 testCreatePlatformApplicationResponse = res
     "CreatePlatformApplicationResponse"
     "fixture/CreatePlatformApplicationResponse.proto"
     sNS
     (Proxy :: Proxy CreatePlatformApplication)
+
+testGetPlatformApplicationAttributesResponse :: GetPlatformApplicationAttributesResponse -> TestTree
+testGetPlatformApplicationAttributesResponse = res
+    "GetPlatformApplicationAttributesResponse"
+    "fixture/GetPlatformApplicationAttributesResponse.proto"
+    sNS
+    (Proxy :: Proxy GetPlatformApplicationAttributes)
 
 testListEndpointsByPlatformApplicationResponse :: ListEndpointsByPlatformApplicationResponse -> TestTree
 testListEndpointsByPlatformApplicationResponse = res
@@ -383,12 +390,12 @@ testListEndpointsByPlatformApplicationResponse = res
     sNS
     (Proxy :: Proxy ListEndpointsByPlatformApplication)
 
-testGetPlatformApplicationAttributesResponse :: GetPlatformApplicationAttributesResponse -> TestTree
-testGetPlatformApplicationAttributesResponse = res
-    "GetPlatformApplicationAttributesResponse"
-    "fixture/GetPlatformApplicationAttributesResponse.proto"
+testSetTopicAttributesResponse :: SetTopicAttributesResponse -> TestTree
+testSetTopicAttributesResponse = res
+    "SetTopicAttributesResponse"
+    "fixture/SetTopicAttributesResponse.proto"
     sNS
-    (Proxy :: Proxy GetPlatformApplicationAttributes)
+    (Proxy :: Proxy SetTopicAttributes)
 
 testDeletePlatformApplicationResponse :: DeletePlatformApplicationResponse -> TestTree
 testDeletePlatformApplicationResponse = res
@@ -404,12 +411,12 @@ testListPlatformApplicationsResponse = res
     sNS
     (Proxy :: Proxy ListPlatformApplications)
 
-testSetTopicAttributesResponse :: SetTopicAttributesResponse -> TestTree
-testSetTopicAttributesResponse = res
-    "SetTopicAttributesResponse"
-    "fixture/SetTopicAttributesResponse.proto"
+testAddPermissionResponse :: AddPermissionResponse -> TestTree
+testAddPermissionResponse = res
+    "AddPermissionResponse"
+    "fixture/AddPermissionResponse.proto"
     sNS
-    (Proxy :: Proxy SetTopicAttributes)
+    (Proxy :: Proxy AddPermission)
 
 testGetEndpointAttributesResponse :: GetEndpointAttributesResponse -> TestTree
 testGetEndpointAttributesResponse = res
@@ -418,12 +425,12 @@ testGetEndpointAttributesResponse = res
     sNS
     (Proxy :: Proxy GetEndpointAttributes)
 
-testAddPermissionResponse :: AddPermissionResponse -> TestTree
-testAddPermissionResponse = res
-    "AddPermissionResponse"
-    "fixture/AddPermissionResponse.proto"
+testListSubscriptionsResponse :: ListSubscriptionsResponse -> TestTree
+testListSubscriptionsResponse = res
+    "ListSubscriptionsResponse"
+    "fixture/ListSubscriptionsResponse.proto"
     sNS
-    (Proxy :: Proxy AddPermission)
+    (Proxy :: Proxy ListSubscriptions)
 
 testGetSubscriptionAttributesResponse :: GetSubscriptionAttributesResponse -> TestTree
 testGetSubscriptionAttributesResponse = res
@@ -431,13 +438,6 @@ testGetSubscriptionAttributesResponse = res
     "fixture/GetSubscriptionAttributesResponse.proto"
     sNS
     (Proxy :: Proxy GetSubscriptionAttributes)
-
-testListSubscriptionsResponse :: ListSubscriptionsResponse -> TestTree
-testListSubscriptionsResponse = res
-    "ListSubscriptionsResponse"
-    "fixture/ListSubscriptionsResponse.proto"
-    sNS
-    (Proxy :: Proxy ListSubscriptions)
 
 testCreateTopicResponse :: CreateTopicResponse -> TestTree
 testCreateTopicResponse = res

--- a/gen/src/Gen/Types/Id.hs
+++ b/gen/src/Gen/Types/Id.hs
@@ -39,8 +39,6 @@ import           Control.Comonad
 import           Control.Comonad.Cofree
 import           Control.Lens
 import           Data.Aeson
-import           Data.CaseInsensitive   (CI)
-import qualified Data.CaseInsensitive   as CI
 import           Data.Hashable
 import           Data.Text              (Text)
 import qualified Data.Text              as Text
@@ -59,7 +57,7 @@ instance (Functor f, HasId a) => HasId (Cofree f a) where
 
 -- | A type where the actual identifier is immutable,
 -- but the usable representation can be appended/modified.
-data Id = Id (CI Text) Text
+data Id = Id Text Text
     deriving (Show)
 
 instance Eq Id where
@@ -75,7 +73,7 @@ instance ToJSON Id where
     toJSON = toJSON . view representation
 
 mkId :: Text -> Id
-mkId t = Id (CI.mk t) (format t)
+mkId t = Id t (format t)
 
 format :: Text -> Text
 format = upperHead . upperAcronym
@@ -86,7 +84,7 @@ representation =
          (\(Id x _) t -> Id x (format t))
 
 memberId :: Id -> Text
-memberId (Id x _) = CI.original x
+memberId (Id x _) = x
 
 typeId :: Id -> Text
 typeId = view representation


### PR DESCRIPTION
Since SNS has case sensitive shapes (`Endpoint` vs `endpoint`), the internal `CI` wrapper is causing one of the disparate types to clobber the other, leading to incorrect serialisation behaviour.

This PR removes the internal `CI` wrapper. The ordering (due to updated `Hashable` instances) of all exports/record declarations is impacted by this change.

Fixes #209.