### PR TITLE
Release 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 [![Gitter Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/brendanhay/amazonka?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 * [Description](#description)
-* [Organisation](#organisation)
 * [Documentation](#documentation)
+* [Organisation](#organisation)
+* [Change Log](#change-log)
 * [Contribute](#contribute)
 * [Licence](#licence)
 
@@ -44,6 +45,11 @@ This repository is organised into the following directory structure:
 * [`script`](script): CI scripts to manage the release lifecycle of the service libraries.
 * [`share`](share): Makefile plumbing common to all service libraries
 * [`test`](test): The `amazonka-test` library containing common test functionality.
+
+
+## Change Log
+
+A change log can be found at [`amazonka/CHANGELOG.md`](amazonka/CHANGELOG.md).
 
 
 ## Contribute

--- a/amazonka-autoscaling/README.md
+++ b/amazonka-autoscaling/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-autoscaling/amazonka-autoscaling.cabal
+++ b/amazonka-autoscaling/amazonka-autoscaling.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-autoscaling
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Auto Scaling SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -102,7 +102,7 @@ library
         , Network.AWS.AutoScaling.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-autoscaling-test
@@ -122,9 +122,9 @@ test-suite amazonka-autoscaling-test
         , Test.AWS.AutoScaling.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-autoscaling == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-autoscaling == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-cloudformation/README.md
+++ b/amazonka-cloudformation/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-cloudformation/amazonka-cloudformation.cabal
+++ b/amazonka-cloudformation/amazonka-cloudformation.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-cloudformation
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon CloudFormation SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -87,7 +87,7 @@ library
         , Network.AWS.CloudFormation.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-cloudformation-test
@@ -107,9 +107,9 @@ test-suite amazonka-cloudformation-test
         , Test.AWS.CloudFormation.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-cloudformation == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-cloudformation == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-cloudfront/README.md
+++ b/amazonka-cloudfront/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-cloudfront/amazonka-cloudfront.cabal
+++ b/amazonka-cloudfront/amazonka-cloudfront.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-cloudfront
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon CloudFront SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -80,7 +80,7 @@ library
         , Network.AWS.CloudFront.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-cloudfront-test
@@ -100,9 +100,9 @@ test-suite amazonka-cloudfront-test
         , Test.AWS.CloudFront.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-cloudfront == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-cloudfront == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-cloudhsm/README.md
+++ b/amazonka-cloudhsm/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-cloudhsm/amazonka-cloudhsm.cabal
+++ b/amazonka-cloudhsm/amazonka-cloudhsm.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-cloudhsm
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon CloudHSM SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -66,7 +66,7 @@ library
         , Network.AWS.CloudHSM.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-cloudhsm-test
@@ -86,9 +86,9 @@ test-suite amazonka-cloudhsm-test
         , Test.AWS.CloudHSM.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-cloudhsm == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-cloudhsm == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-cloudsearch-domains/README.md
+++ b/amazonka-cloudsearch-domains/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-cloudsearch-domains/amazonka-cloudsearch-domains.cabal
+++ b/amazonka-cloudsearch-domains/amazonka-cloudsearch-domains.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-cloudsearch-domains
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon CloudSearch Domain SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -63,7 +63,7 @@ library
         , Network.AWS.CloudSearchDomains.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-cloudsearch-domains-test
@@ -83,9 +83,9 @@ test-suite amazonka-cloudsearch-domains-test
         , Test.AWS.CloudSearchDomains.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-cloudsearch-domains == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-cloudsearch-domains == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-cloudsearch/README.md
+++ b/amazonka-cloudsearch/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-cloudsearch/amazonka-cloudsearch.cabal
+++ b/amazonka-cloudsearch/amazonka-cloudsearch.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-cloudsearch
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon CloudSearch SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -85,7 +85,7 @@ library
         , Network.AWS.CloudSearch.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-cloudsearch-test
@@ -105,9 +105,9 @@ test-suite amazonka-cloudsearch-test
         , Test.AWS.CloudSearch.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-cloudsearch == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-cloudsearch == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-cloudtrail/README.md
+++ b/amazonka-cloudtrail/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-cloudtrail/amazonka-cloudtrail.cabal
+++ b/amazonka-cloudtrail/amazonka-cloudtrail.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-cloudtrail
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon CloudTrail SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -79,7 +79,7 @@ library
         , Network.AWS.CloudTrail.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-cloudtrail-test
@@ -99,9 +99,9 @@ test-suite amazonka-cloudtrail-test
         , Test.AWS.CloudTrail.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-cloudtrail == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-cloudtrail == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-cloudwatch-logs/README.md
+++ b/amazonka-cloudwatch-logs/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-cloudwatch-logs/amazonka-cloudwatch-logs.cabal
+++ b/amazonka-cloudwatch-logs/amazonka-cloudwatch-logs.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-cloudwatch-logs
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon CloudWatch Logs SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -111,7 +111,7 @@ library
         , Network.AWS.CloudWatchLogs.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-cloudwatch-logs-test
@@ -131,9 +131,9 @@ test-suite amazonka-cloudwatch-logs-test
         , Test.AWS.CloudWatchLogs.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-cloudwatch-logs == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-cloudwatch-logs == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-cloudwatch/README.md
+++ b/amazonka-cloudwatch/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-cloudwatch/amazonka-cloudwatch.cabal
+++ b/amazonka-cloudwatch/amazonka-cloudwatch.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-cloudwatch
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon CloudWatch SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -109,7 +109,7 @@ library
         , Network.AWS.CloudWatch.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-cloudwatch-test
@@ -129,9 +129,9 @@ test-suite amazonka-cloudwatch-test
         , Test.AWS.CloudWatch.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-cloudwatch == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-cloudwatch == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-codecommit/README.md
+++ b/amazonka-codecommit/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-codecommit/amazonka-codecommit.cabal
+++ b/amazonka-codecommit/amazonka-codecommit.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-codecommit
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon CodeCommit SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -72,7 +72,7 @@ library
         , Network.AWS.CodeCommit.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-codecommit-test
@@ -92,9 +92,9 @@ test-suite amazonka-codecommit-test
         , Test.AWS.CodeCommit.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-codecommit == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-codecommit == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-codedeploy/README.md
+++ b/amazonka-codedeploy/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-codedeploy/amazonka-codedeploy.cabal
+++ b/amazonka-codedeploy/amazonka-codedeploy.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-codedeploy
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon CodeDeploy SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -140,7 +140,7 @@ library
         , Network.AWS.CodeDeploy.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-codedeploy-test
@@ -160,9 +160,9 @@ test-suite amazonka-codedeploy-test
         , Test.AWS.CodeDeploy.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-codedeploy == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-codedeploy == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-codepipeline/README.md
+++ b/amazonka-codepipeline/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-codepipeline/amazonka-codepipeline.cabal
+++ b/amazonka-codepipeline/amazonka-codepipeline.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-codepipeline
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon CodePipeline SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -167,7 +167,7 @@ library
         , Network.AWS.CodePipeline.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-codepipeline-test
@@ -187,9 +187,9 @@ test-suite amazonka-codepipeline-test
         , Test.AWS.CodePipeline.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-codepipeline == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-codepipeline == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-cognito-identity/README.md
+++ b/amazonka-cognito-identity/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-cognito-identity/amazonka-cognito-identity.cabal
+++ b/amazonka-cognito-identity/amazonka-cognito-identity.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-cognito-identity
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Cognito Identity SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -103,7 +103,7 @@ library
         , Network.AWS.CognitoIdentity.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-cognito-identity-test
@@ -123,9 +123,9 @@ test-suite amazonka-cognito-identity-test
         , Test.AWS.CognitoIdentity.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-cognito-identity == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-cognito-identity == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-cognito-sync/README.md
+++ b/amazonka-cognito-sync/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-cognito-sync/amazonka-cognito-sync.cabal
+++ b/amazonka-cognito-sync/amazonka-cognito-sync.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-cognito-sync
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Cognito Sync SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -89,7 +89,7 @@ library
         , Network.AWS.CognitoSync.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-cognito-sync-test
@@ -109,9 +109,9 @@ test-suite amazonka-cognito-sync-test
         , Test.AWS.CognitoSync.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-cognito-sync == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-cognito-sync == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-config/README.md
+++ b/amazonka-config/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-config/amazonka-config.cabal
+++ b/amazonka-config/amazonka-config.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-config
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Config SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -89,7 +89,7 @@ library
         , Network.AWS.Config.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-config-test
@@ -109,9 +109,9 @@ test-suite amazonka-config-test
         , Test.AWS.Config.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-config == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-config == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-datapipeline/README.md
+++ b/amazonka-datapipeline/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-datapipeline/amazonka-datapipeline.cabal
+++ b/amazonka-datapipeline/amazonka-datapipeline.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-datapipeline
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Data Pipeline SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -90,7 +90,7 @@ library
         , Network.AWS.DataPipeline.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-datapipeline-test
@@ -110,9 +110,9 @@ test-suite amazonka-datapipeline-test
         , Test.AWS.DataPipeline.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-datapipeline == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-datapipeline == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-devicefarm/README.md
+++ b/amazonka-devicefarm/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-devicefarm/amazonka-devicefarm.cabal
+++ b/amazonka-devicefarm/amazonka-devicefarm.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-devicefarm
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Device Farm SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -76,7 +76,7 @@ library
         , Network.AWS.DeviceFarm.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-devicefarm-test
@@ -96,9 +96,9 @@ test-suite amazonka-devicefarm-test
         , Test.AWS.DeviceFarm.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-devicefarm == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-devicefarm == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-directconnect/README.md
+++ b/amazonka-directconnect/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-directconnect/amazonka-directconnect.cabal
+++ b/amazonka-directconnect/amazonka-directconnect.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-directconnect
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Direct Connect SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -88,7 +88,7 @@ library
         , Network.AWS.DirectConnect.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-directconnect-test
@@ -108,9 +108,9 @@ test-suite amazonka-directconnect-test
         , Test.AWS.DirectConnect.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-directconnect == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-directconnect == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-ds/README.md
+++ b/amazonka-ds/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-ds/amazonka-ds.cabal
+++ b/amazonka-ds/amazonka-ds.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-ds
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Directory Service SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -70,7 +70,7 @@ library
         , Network.AWS.DirectoryService.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-ds-test
@@ -90,9 +90,9 @@ test-suite amazonka-ds-test
         , Test.AWS.DirectoryService.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-ds == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-ds == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-dynamodb-streams/README.md
+++ b/amazonka-dynamodb-streams/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-dynamodb-streams/amazonka-dynamodb-streams.cabal
+++ b/amazonka-dynamodb-streams/amazonka-dynamodb-streams.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-dynamodb-streams
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon DynamoDB Streams SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -80,7 +80,7 @@ library
         , Network.AWS.DynamoDBStreams.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-dynamodb-streams-test
@@ -100,9 +100,9 @@ test-suite amazonka-dynamodb-streams-test
         , Test.AWS.DynamoDBStreams.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-dynamodb-streams == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-dynamodb-streams == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-dynamodb/README.md
+++ b/amazonka-dynamodb/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-dynamodb/amazonka-dynamodb.cabal
+++ b/amazonka-dynamodb/amazonka-dynamodb.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-dynamodb
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon DynamoDB SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -176,7 +176,7 @@ library
         , Network.AWS.DynamoDB.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-dynamodb-test
@@ -196,9 +196,9 @@ test-suite amazonka-dynamodb-test
         , Test.AWS.DynamoDB.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-dynamodb == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-dynamodb == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-ec2/README.md
+++ b/amazonka-ec2/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-ec2/amazonka-ec2.cabal
+++ b/amazonka-ec2/amazonka-ec2.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-ec2
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Elastic Compute Cloud SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -236,7 +236,7 @@ library
         , Network.AWS.EC2.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-ec2-test
@@ -256,9 +256,9 @@ test-suite amazonka-ec2-test
         , Test.AWS.EC2.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-ec2 == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-ec2 == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-ecs/README.md
+++ b/amazonka-ecs/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-ecs/amazonka-ecs.cabal
+++ b/amazonka-ecs/amazonka-ecs.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-ecs
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon EC2 Container Service SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -89,7 +89,7 @@ library
         , Network.AWS.ECS.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-ecs-test
@@ -109,9 +109,9 @@ test-suite amazonka-ecs-test
         , Test.AWS.ECS.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-ecs == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-ecs == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-efs/README.md
+++ b/amazonka-efs/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-efs/amazonka-efs.cabal
+++ b/amazonka-efs/amazonka-efs.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-efs
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Elastic File System SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -60,7 +60,7 @@ library
         , Network.AWS.EFS.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-efs-test
@@ -80,9 +80,9 @@ test-suite amazonka-efs-test
         , Test.AWS.EFS.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-efs == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-efs == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-elasticache/README.md
+++ b/amazonka-elasticache/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-elasticache/amazonka-elasticache.cabal
+++ b/amazonka-elasticache/amazonka-elasticache.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-elasticache
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon ElastiCache SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -99,7 +99,7 @@ library
         , Network.AWS.ElastiCache.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-elasticache-test
@@ -119,9 +119,9 @@ test-suite amazonka-elasticache-test
         , Test.AWS.ElastiCache.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-elasticache == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-elasticache == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-elasticbeanstalk/README.md
+++ b/amazonka-elasticbeanstalk/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-elasticbeanstalk/amazonka-elasticbeanstalk.cabal
+++ b/amazonka-elasticbeanstalk/amazonka-elasticbeanstalk.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-elasticbeanstalk
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Elastic Beanstalk SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -105,7 +105,7 @@ library
         , Network.AWS.ElasticBeanstalk.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-elasticbeanstalk-test
@@ -125,9 +125,9 @@ test-suite amazonka-elasticbeanstalk-test
         , Test.AWS.ElasticBeanstalk.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-elasticbeanstalk == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-elasticbeanstalk == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-elastictranscoder/README.md
+++ b/amazonka-elastictranscoder/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-elastictranscoder/amazonka-elastictranscoder.cabal
+++ b/amazonka-elastictranscoder/amazonka-elastictranscoder.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-elastictranscoder
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Elastic Transcoder SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -68,7 +68,7 @@ library
         , Network.AWS.ElasticTranscoder.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-elastictranscoder-test
@@ -88,9 +88,9 @@ test-suite amazonka-elastictranscoder-test
         , Test.AWS.ElasticTranscoder.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-elastictranscoder == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-elastictranscoder == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-elb/README.md
+++ b/amazonka-elb/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-elb/amazonka-elb.cabal
+++ b/amazonka-elb/amazonka-elb.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-elb
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Elastic Load Balancing SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -93,7 +93,7 @@ library
         , Network.AWS.ELB.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-elb-test
@@ -113,9 +113,9 @@ test-suite amazonka-elb-test
         , Test.AWS.ELB.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-elb == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-elb == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-emr/README.md
+++ b/amazonka-emr/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-emr/amazonka-emr.cabal
+++ b/amazonka-emr/amazonka-emr.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-emr
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Elastic MapReduce SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -69,7 +69,7 @@ library
         , Network.AWS.EMR.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-emr-test
@@ -89,9 +89,9 @@ test-suite amazonka-emr-test
         , Test.AWS.EMR.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-emr == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-emr == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-glacier/README.md
+++ b/amazonka-glacier/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-glacier/amazonka-glacier.cabal
+++ b/amazonka-glacier/amazonka-glacier.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-glacier
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Glacier SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -113,7 +113,7 @@ library
         , Network.AWS.Glacier.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-glacier-test
@@ -133,9 +133,9 @@ test-suite amazonka-glacier-test
         , Test.AWS.Glacier.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-glacier == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-glacier == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-iam/README.md
+++ b/amazonka-iam/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-iam/amazonka-iam.cabal
+++ b/amazonka-iam/amazonka-iam.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-iam
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Identity and Access Management SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -218,7 +218,7 @@ library
         , Network.AWS.IAM.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-iam-test
@@ -238,9 +238,9 @@ test-suite amazonka-iam-test
         , Test.AWS.IAM.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-iam == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-iam == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-importexport/README.md
+++ b/amazonka-importexport/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-importexport/amazonka-importexport.cabal
+++ b/amazonka-importexport/amazonka-importexport.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-importexport
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Import/Export SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -61,7 +61,7 @@ library
         , Network.AWS.ImportExport.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-importexport-test
@@ -81,9 +81,9 @@ test-suite amazonka-importexport-test
         , Test.AWS.ImportExport.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-importexport == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-importexport == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-kinesis/README.md
+++ b/amazonka-kinesis/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-kinesis/amazonka-kinesis.cabal
+++ b/amazonka-kinesis/amazonka-kinesis.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-kinesis
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Kinesis SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -65,7 +65,7 @@ library
         , Network.AWS.Kinesis.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-kinesis-test
@@ -85,9 +85,9 @@ test-suite amazonka-kinesis-test
         , Test.AWS.Kinesis.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-kinesis == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-kinesis == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-kms/README.md
+++ b/amazonka-kms/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-kms/amazonka-kms.cabal
+++ b/amazonka-kms/amazonka-kms.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-kms
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Key Management Service SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -147,7 +147,7 @@ library
         , Network.AWS.KMS.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-kms-test
@@ -167,9 +167,9 @@ test-suite amazonka-kms-test
         , Test.AWS.KMS.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-kms == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-kms == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-lambda/README.md
+++ b/amazonka-lambda/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-lambda/amazonka-lambda.cabal
+++ b/amazonka-lambda/amazonka-lambda.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-lambda
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Lambda SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -74,7 +74,7 @@ library
         , Network.AWS.Lambda.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-lambda-test
@@ -94,9 +94,9 @@ test-suite amazonka-lambda-test
         , Test.AWS.Lambda.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-lambda == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-lambda == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-ml/README.md
+++ b/amazonka-ml/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-ml/amazonka-ml.cabal
+++ b/amazonka-ml/amazonka-ml.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-ml
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Machine Learning SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -74,7 +74,7 @@ library
         , Network.AWS.MachineLearning.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-ml-test
@@ -94,9 +94,9 @@ test-suite amazonka-ml-test
         , Test.AWS.MachineLearning.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-ml == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-ml == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-opsworks/README.md
+++ b/amazonka-opsworks/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-opsworks/amazonka-opsworks.cabal
+++ b/amazonka-opsworks/amazonka-opsworks.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-opsworks
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon OpsWorks SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -164,7 +164,7 @@ library
         , Network.AWS.OpsWorks.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-opsworks-test
@@ -184,9 +184,9 @@ test-suite amazonka-opsworks-test
         , Test.AWS.OpsWorks.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-opsworks == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-opsworks == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-rds/README.md
+++ b/amazonka-rds/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-rds/amazonka-rds.cabal
+++ b/amazonka-rds/amazonka-rds.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-rds
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Relational Database Service SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -152,7 +152,7 @@ library
         , Network.AWS.RDS.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-rds-test
@@ -172,9 +172,9 @@ test-suite amazonka-rds-test
         , Test.AWS.RDS.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-rds == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-rds == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-redshift/README.md
+++ b/amazonka-redshift/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-redshift/amazonka-redshift.cabal
+++ b/amazonka-redshift/amazonka-redshift.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-redshift
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Redshift SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -134,7 +134,7 @@ library
         , Network.AWS.Redshift.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-redshift-test
@@ -154,9 +154,9 @@ test-suite amazonka-redshift-test
         , Test.AWS.Redshift.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-redshift == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-redshift == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-route53-domains/README.md
+++ b/amazonka-route53-domains/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-route53-domains/amazonka-route53-domains.cabal
+++ b/amazonka-route53-domains/amazonka-route53-domains.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-route53-domains
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Route 53 Domains SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -67,7 +67,7 @@ library
         , Network.AWS.Route53Domains.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-route53-domains-test
@@ -87,9 +87,9 @@ test-suite amazonka-route53-domains-test
         , Test.AWS.Route53Domains.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-route53-domains == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-route53-domains == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-route53/README.md
+++ b/amazonka-route53/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-route53/amazonka-route53.cabal
+++ b/amazonka-route53/amazonka-route53.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-route53
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Route 53 SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -85,7 +85,7 @@ library
         , Network.AWS.Route53.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-route53-test
@@ -105,9 +105,9 @@ test-suite amazonka-route53-test
         , Test.AWS.Route53.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-route53 == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-route53 == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-s3/README.md
+++ b/amazonka-s3/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-s3/amazonka-s3.cabal
+++ b/amazonka-s3/amazonka-s3.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-s3
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Simple Storage Service SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -108,7 +108,7 @@ library
         , Network.AWS.S3.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
         , lens >= 4.4
         , text >= 1.1
@@ -130,9 +130,9 @@ test-suite amazonka-s3-test
         , Test.AWS.S3.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-s3 == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-s3 == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-sdb/README.md
+++ b/amazonka-sdb/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-sdb/amazonka-sdb.cabal
+++ b/amazonka-sdb/amazonka-sdb.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-sdb
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon SimpleDB SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -75,7 +75,7 @@ library
         , Network.AWS.SDB.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-sdb-test
@@ -95,9 +95,9 @@ test-suite amazonka-sdb-test
         , Test.AWS.SDB.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-sdb == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-sdb == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-ses/README.md
+++ b/amazonka-ses/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-ses/amazonka-ses.cabal
+++ b/amazonka-ses/amazonka-ses.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-ses
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Simple Email Service SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -79,7 +79,7 @@ library
         , Network.AWS.SES.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-ses-test
@@ -99,9 +99,9 @@ test-suite amazonka-ses-test
         , Test.AWS.SES.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-ses == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-ses == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-sns/README.md
+++ b/amazonka-sns/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-sns/amazonka-sns.cabal
+++ b/amazonka-sns/amazonka-sns.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-sns
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Simple Notification Service SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -91,7 +91,7 @@ library
         , Network.AWS.SNS.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-sns-test
@@ -111,9 +111,9 @@ test-suite amazonka-sns-test
         , Test.AWS.SNS.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-sns == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-sns == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-sqs/README.md
+++ b/amazonka-sqs/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-sqs/amazonka-sqs.cabal
+++ b/amazonka-sqs/amazonka-sqs.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-sqs
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Simple Queue Service SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -94,7 +94,7 @@ library
         , Network.AWS.SQS.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-sqs-test
@@ -114,9 +114,9 @@ test-suite amazonka-sqs-test
         , Test.AWS.SQS.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-sqs == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-sqs == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-ssm/README.md
+++ b/amazonka-ssm/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-ssm/amazonka-ssm.cabal
+++ b/amazonka-ssm/amazonka-ssm.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-ssm
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Simple Systems Management Service SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -75,7 +75,7 @@ library
         , Network.AWS.SSM.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-ssm-test
@@ -95,9 +95,9 @@ test-suite amazonka-ssm-test
         , Test.AWS.SSM.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-ssm == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-ssm == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-storagegateway/README.md
+++ b/amazonka-storagegateway/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-storagegateway/amazonka-storagegateway.cabal
+++ b/amazonka-storagegateway/amazonka-storagegateway.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-storagegateway
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Storage Gateway SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -125,7 +125,7 @@ library
         , Network.AWS.StorageGateway.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-storagegateway-test
@@ -145,9 +145,9 @@ test-suite amazonka-storagegateway-test
         , Test.AWS.StorageGateway.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-storagegateway == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-storagegateway == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-sts/README.md
+++ b/amazonka-sts/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-sts/amazonka-sts.cabal
+++ b/amazonka-sts/amazonka-sts.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-sts
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Security Token Service SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -110,7 +110,7 @@ library
         , Network.AWS.STS.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-sts-test
@@ -130,9 +130,9 @@ test-suite amazonka-sts-test
         , Test.AWS.STS.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-sts == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-sts == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-support/README.md
+++ b/amazonka-support/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-support/amazonka-support.cabal
+++ b/amazonka-support/amazonka-support.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-support
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Support SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -115,7 +115,7 @@ library
         , Network.AWS.Support.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-support-test
@@ -135,9 +135,9 @@ test-suite amazonka-support-test
         , Test.AWS.Support.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-support == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-support == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-swf/README.md
+++ b/amazonka-swf/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-swf/amazonka-swf.cabal
+++ b/amazonka-swf/amazonka-swf.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-swf
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon Simple Workflow Service SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -96,7 +96,7 @@ library
         , Network.AWS.SWF.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-swf-test
@@ -116,9 +116,9 @@ test-suite amazonka-swf-test
         , Test.AWS.SWF.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-swf == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-swf == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka-workspaces/README.md
+++ b/amazonka-workspaces/README.md
@@ -8,7 +8,7 @@
 
 ## Version
 
-`1.2.0.2`
+`1.3.0`
 
 
 ## Description

--- a/amazonka-workspaces/amazonka-workspaces.cabal
+++ b/amazonka-workspaces/amazonka-workspaces.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-workspaces
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazon WorkSpaces SDK.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -60,7 +60,7 @@ library
         , Network.AWS.WorkSpaces.Types.Sum
 
     build-depends:
-          amazonka-core == 1.2.0.*
+          amazonka-core == 1.3.0.*
         , base          >= 4.7     && < 5
 
 test-suite amazonka-workspaces-test
@@ -80,9 +80,9 @@ test-suite amazonka-workspaces-test
         , Test.AWS.WorkSpaces.Internal
 
     build-depends:
-          amazonka-core == 1.2.0.*
-        , amazonka-test == 1.2.0.*
-        , amazonka-workspaces == 1.2.0.*
+          amazonka-core == 1.3.0.*
+        , amazonka-test == 1.3.0.*
+        , amazonka-workspaces == 1.3.0.*
         , base
         , bytestring
         , lens

--- a/amazonka/CHANGELOG.md
+++ b/amazonka/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## [1.3.0](https://github.com/brendanhay/amazonka/tree/1.3.0)
-Released: **03 September, 2015**, Commits: [1.2.0.2](https://github.com/brendanhay/amazonka/compare/1.2.0.2...1.3.0)
+Released: **03 September, 2015**, Compare: [1.2.0.2](https://github.com/brendanhay/amazonka/compare/1.2.0.2...1.3.0)
 
 ### Changed
 
@@ -16,24 +16,24 @@ Released: **03 September, 2015**, Commits: [1.2.0.2](https://github.com/brendanh
 
 
 ## [1.2.0.2](https://github.com/brendanhay/amazonka/tree/1.2.0.2)
-Released: **29 August, 2015**, Commits: [1.2.0.2](https://github.com/brendanhay/amazonka/compare/1.2.0.1...1.2.0.2)
+Released: **29 August, 2015**, Compare: [1.2.0.1](https://github.com/brendanhay/amazonka/compare/1.2.0.1...1.2.0.2)
 
 
 ## [1.2.0.1](https://github.com/brendanhay/amazonka/tree/1.2.0.1)
-Released: **28 August, 2015**, Commits: [1.2.0.1](https://github.com/brendanhay/amazonka/compare/1.2.0...1.2.0.1)
+Released: **28 August, 2015**, Compare: [1.2.0](https://github.com/brendanhay/amazonka/compare/1.2.0...1.2.0.1)
 
 
 ## [1.2.0](https://github.com/brendanhay/amazonka/tree/1.2.0)
-Released: **27 August, 2015**, Commits: [1.2.0](https://github.com/brendanhay/amazonka/compare/1.1.0...1.2.0)
+Released: **27 August, 2015**, Compare: [1.1.0](https://github.com/brendanhay/amazonka/compare/1.1.0...1.2.0)
 
 
 ## [1.1.0](https://github.com/brendanhay/amazonka/tree/1.1.0)
-Released: **21 August, 2015**, Commits: [1.1.0](https://github.com/brendanhay/amazonka/compare/1.0.1...1.1.0)
+Released: **21 August, 2015**, Compare: [1.0.1](https://github.com/brendanhay/amazonka/compare/1.0.1...1.1.0)
 
 
 ## [1.0.1](https://github.com/brendanhay/amazonka/tree/1.0.1)
-Released: **18 August, 2015**, Commits: [1.0.0](https://github.com/brendanhay/amazonka/compare/1.0.0...1.0.1)
+Released: **18 August, 2015**, Compare: [1.0.0](https://github.com/brendanhay/amazonka/compare/1.0.0...1.0.1)
 
 
 ## [1.0.0](https://github.com/brendanhay/amazonka/tree/1.0.0)
-Released: **16 August, 2015**, Commits: [0.3.6](https://github.com/brendanhay/amazonka/compare/0.3.6...1.0.0)
+Released: **16 August, 2015**, Compare: [0.3.6](https://github.com/brendanhay/amazonka/compare/0.3.6...1.0.0)

--- a/amazonka/CHANGELOG.md
+++ b/amazonka/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Change Log
+
+## [1.3.0](https://github.com/brendanhay/amazonka/tree/1.3.0)
+Released: **03 September, 2015**, Commits: [1.2.0.2](https://github.com/brendanhay/amazonka/compare/1.2.0.2...1.3.0)
+
+### Changed
+
+- Renamed all HTTP status code response lenses from `*Status` to `*ResponseStatus`.
+
+### Fixed
+
+- Fix malformed SNS Subscribe request. [\#209](https://github.com/brendanhay/amazonka/issues/209)
+- Fix `amazonka-core` cabal build error due to lax `vector` constraints. [\#208](https://github.com/brendanhay/amazonka/issues/208)
+- Override SQS message attribute type, `QueueAttributeName` -> `MessageAttributeName`. [\#199](https://github.com/brendanhay/amazonka/issues/199)
+- Re-enable stackage test builds for all service libraries. [\#170](https://github.com/brendanhay/amazonka/issues/170)
+
+
+## [1.2.0.2](https://github.com/brendanhay/amazonka/tree/1.2.0.2)
+Released: **29 August, 2015**, Commits: [1.2.0.2](https://github.com/brendanhay/amazonka/compare/1.2.0.1...1.2.0.2)
+
+
+## [1.2.0.1](https://github.com/brendanhay/amazonka/tree/1.2.0.1)
+Released: **28 August, 2015**, Commits: [1.2.0.1](https://github.com/brendanhay/amazonka/compare/1.2.0...1.2.0.1)
+
+
+## [1.2.0](https://github.com/brendanhay/amazonka/tree/1.2.0)
+Released: **27 August, 2015**, Commits: [1.2.0](https://github.com/brendanhay/amazonka/compare/1.1.0...1.2.0)
+
+
+## [1.1.0](https://github.com/brendanhay/amazonka/tree/1.1.0)
+Released: **21 August, 2015**, Commits: [1.1.0](https://github.com/brendanhay/amazonka/compare/1.0.1...1.1.0)
+
+
+## [1.0.1](https://github.com/brendanhay/amazonka/tree/1.0.1)
+Released: **18 August, 2015**, Commits: [1.0.0](https://github.com/brendanhay/amazonka/compare/1.0.0...1.0.1)
+
+
+## [1.0.0](https://github.com/brendanhay/amazonka/tree/1.0.0)
+Released: **16 August, 2015**, Commits: [0.3.6](https://github.com/brendanhay/amazonka/compare/0.3.6...1.0.0)

--- a/amazonka/amazonka.cabal
+++ b/amazonka/amazonka.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Comprehensive Amazon Web Services SDK
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -55,7 +55,7 @@ library
         , Network.AWS.Internal.Logger
 
     build-depends:
-          amazonka-core       == 1.2.0.*
+          amazonka-core       == 1.3.0.*
         , base                >= 4.7     && < 5
         , bytestring          >= 0.9
         , conduit             >= 1.1

--- a/amazonka/amazonka.cabal
+++ b/amazonka/amazonka.cabal
@@ -10,7 +10,7 @@ maintainer:            Brendan Hay <brendan.g.hay@gmail.com>
 copyright:             Copyright (c) 2013-2015 Brendan Hay
 category:              Network, AWS, Cloud, Distributed Computing
 build-type:            Simple
-extra-source-files:    README.md
+extra-source-files:    README.md CHANGELOG.md
 cabal-version:         >= 1.10
 
 description:

--- a/core/amazonka-core.cabal
+++ b/core/amazonka-core.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-core
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Core data types and functionality for Amazonka libraries.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues

--- a/examples/amazonka-examples.cabal
+++ b/examples/amazonka-examples.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-examples
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Basic examples for various amazonka libraries.
 homepage:              https://github.com/brendanhay/amazonka
 license:               OtherLicense
@@ -25,7 +25,7 @@ library
         , Example.SQS
 
     build-depends:
-          amazonka      == 1.2.0.*
+          amazonka      == 1.3.0.*
         , amazonka-core
         , amazonka-dynamodb
         , amazonka-ec2

--- a/gen/amazonka-gen.cabal
+++ b/gen/amazonka-gen.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-gen
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Amazonka Code Generator
 homepage:              https://github.com/brendanhay/amazonka
 license:               OtherLicense

--- a/test/amazonka-test.cabal
+++ b/test/amazonka-test.cabal
@@ -1,5 +1,5 @@
 name:                  amazonka-test
-version:               1.2.0.2
+version:               1.3.0
 synopsis:              Common functionality for Amazonka library test-suites.
 homepage:              https://github.com/brendanhay/amazonka
 bug-reports:           https://github.com/brendanhay/amazonka/issues
@@ -37,7 +37,7 @@ library
 
     build-depends:
           aeson                >= 0.8
-        , amazonka-core        == 1.2.0.*
+        , amazonka-core        == 1.3.0.*
         , base                 >= 4.7     && < 5
         , bifunctors           >= 4.1
         , bytestring           >= 0.9


### PR DESCRIPTION
* Contains fixes for #199, #208, and #209.
* Renames responses status code lenses from `*Status` -> `*ResponseStatus`.
* Regeneration from updated service definitions.

Adds a bloody `CHANGELOG.md`.