### PR TITLE
ISO8601 timezone formatted incorrectly for amazon

### DIFF
--- a/amazonka-s3/fixture/CopyObjectResponse.proto
+++ b/amazonka-s3/fixture/CopyObjectResponse.proto
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CopyObjectResult>
-  <LastModified>2009-10-28T22:32:00</LastModified>
+  <LastModified>2009-10-28T22:32:00Z</LastModified>
   <ETag>"9b2cf535f27731c974343645a3985328"</ETag>
 </CopyObjectResult>

--- a/core/test/Test/AWS/Data/Time.hs
+++ b/core/test/Test/AWS/Data/Time.hs
@@ -48,7 +48,7 @@ tests = testGroup "time"
                 "Fri, 07 Nov 2014 04:42:13 GMT" (time :: RFC822)
 
             , testToText "iso8601"
-                "2014-11-07T04:42:13UTC" (time :: ISO8601)
+                "2014-11-07T04:42:13Z" (time :: ISO8601)
 
             , testToText "aws"
                 "20141107T044213Z" (time :: AWSTime)
@@ -64,7 +64,7 @@ tests = testGroup "time"
                 "x=Fri%2C%2007%20Nov%202014%2004%3A42%3A13%20GMT" (time :: RFC822)
 
             , testToQuery "iso8601"
-                "x=2014-11-07T04%3A42%3A13UTC" (time :: ISO8601)
+                "x=2014-11-07T04%3A42%3A13Z" (time :: ISO8601)
 
             , testToQuery "aws"
                 "x=20141107T044213Z" (time :: AWSTime)
@@ -99,7 +99,7 @@ tests = testGroup "time"
                 "Fri, 07 Nov 2014 04:42:13 GMT" (time :: RFC822)
 
             , testToXML "iso8601"
-                "2014-11-07T04:42:13UTC" (time :: ISO8601)
+                "2014-11-07T04:42:13Z" (time :: ISO8601)
 
             , testToXML "aws"
                 "20141107T044213Z" (time :: AWSTime)
@@ -137,7 +137,7 @@ tests = testGroup "time"
                 (str "Fri, 07 Nov 2014 04:42:13 GMT") (time :: RFC822)
 
             , testToJSON "iso8601"
-                (str "2014-11-07T04:42:13UTC") (time :: ISO8601)
+                (str "2014-11-07T04:42:13Z") (time :: ISO8601)
 
             , testToJSON "aws"
                 (str "20141107T044213Z") (time :: AWSTime)


### PR DESCRIPTION
`_serviceCode = ErrorCode "MalformedInput", _serviceMessage = Just (ErrorMessage "timestamp must follow ISO8601")`

This only seems to affect sending dates to amazon, the parsing itself works fine (otherwise I suspect this would have been hit ages ago):

```
> fromText "2014-11-07T04:42:13Z" :: Either String ISO8601
Right (Time 2014-11-07 04:42:13 UTC)
```