### PR TITLE
Ensure literal/primitive response bodies are correctly handled

### DIFF
--- a/amazonka-glacier/gen/Network/AWS/Glacier/GetVaultAccessPolicy.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/GetVaultAccessPolicy.hs
@@ -95,7 +95,7 @@ instance AWSRequest GetVaultAccessPolicy where
           = receiveJSON
               (\ s h x ->
                  GetVaultAccessPolicyResponse' <$>
-                   (x .?> "policy") <*> (pure (fromEnum s)))
+                   (eitherParseJSON x) <*> (pure (fromEnum s)))
 
 instance ToHeaders GetVaultAccessPolicy where
         toHeaders = const mempty

--- a/amazonka-glacier/gen/Network/AWS/Glacier/GetVaultNotifications.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/GetVaultNotifications.hs
@@ -109,8 +109,7 @@ instance AWSRequest GetVaultNotifications where
           = receiveJSON
               (\ s h x ->
                  GetVaultNotificationsResponse' <$>
-                   (x .?> "vaultNotificationConfig") <*>
-                     (pure (fromEnum s)))
+                   (eitherParseJSON x) <*> (pure (fromEnum s)))
 
 instance ToHeaders GetVaultNotifications where
         toHeaders = const mempty

--- a/amazonka-lambda/gen/Network/AWS/Lambda/Invoke.hs
+++ b/amazonka-lambda/gen/Network/AWS/Lambda/Invoke.hs
@@ -31,10 +31,10 @@ module Network.AWS.Lambda.Invoke
     , Invoke
     -- * Request Lenses
     , iInvocationType
-    , iPayload
     , iLogType
     , iClientContext
     , iFunctionName
+    , iPayload
 
     -- * Destructuring the Response
     , invokeResponse
@@ -55,10 +55,10 @@ import           Network.AWS.Response
 -- | /See:/ 'invoke' smart constructor.
 data Invoke = Invoke'
     { _iInvocationType :: !(Maybe InvocationType)
-    , _iPayload        :: !(Maybe (HashMap Text Value))
     , _iLogType        :: !(Maybe LogType)
     , _iClientContext  :: !(Maybe Text)
     , _iFunctionName   :: !Text
+    , _iPayload        :: !(HashMap Text Value)
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
 -- | Creates a value of 'Invoke' with the minimum fields required to make a request.
@@ -67,23 +67,24 @@ data Invoke = Invoke'
 --
 -- * 'iInvocationType'
 --
--- * 'iPayload'
---
 -- * 'iLogType'
 --
 -- * 'iClientContext'
 --
 -- * 'iFunctionName'
+--
+-- * 'iPayload'
 invoke
     :: Text -- ^ 'iFunctionName'
+    -> HashMap Text Value -- ^ 'iPayload'
     -> Invoke
-invoke pFunctionName_ =
+invoke pFunctionName_ pPayload_ =
     Invoke'
     { _iInvocationType = Nothing
-    , _iPayload = Nothing
     , _iLogType = Nothing
     , _iClientContext = Nothing
     , _iFunctionName = pFunctionName_
+    , _iPayload = pPayload_
     }
 
 -- | By default, the 'Invoke' API assumes \"RequestResponse\" invocation
@@ -96,10 +97,6 @@ invoke pFunctionName_ =
 -- want to verify access to a function without running it.
 iInvocationType :: Lens' Invoke (Maybe InvocationType)
 iInvocationType = lens _iInvocationType (\ s a -> s{_iInvocationType = a});
-
--- | JSON that you want to provide to your Lambda function as input.
-iPayload :: Lens' Invoke (Maybe (HashMap Text Value))
-iPayload = lens _iPayload (\ s a -> s{_iPayload = a});
 
 -- | You can set this optional parameter to \"Tail\" in the request only if
 -- you specify the 'InvocationType' parameter with value
@@ -132,6 +129,10 @@ iClientContext = lens _iClientContext (\ s a -> s{_iClientContext = a});
 -- character in length.
 iFunctionName :: Lens' Invoke Text
 iFunctionName = lens _iFunctionName (\ s a -> s{_iFunctionName = a});
+
+-- | JSON that you want to provide to your Lambda function as input.
+iPayload :: Lens' Invoke (HashMap Text Value)
+iPayload = lens _iPayload (\ s a -> s{_iPayload = a});
 
 instance AWSRequest Invoke where
         type Rs Invoke = InvokeResponse

--- a/amazonka-lambda/gen/Network/AWS/Lambda/Invoke.hs
+++ b/amazonka-lambda/gen/Network/AWS/Lambda/Invoke.hs
@@ -59,7 +59,7 @@ data Invoke = Invoke'
     , _iClientContext  :: !(Maybe Text)
     , _iFunctionName   :: !Text
     , _iPayload        :: !(HashMap Text Value)
-    } deriving (Eq,Read,Show,Data,Typeable,Generic)
+    } deriving (Eq,Show,Data,Typeable,Generic)
 
 -- | Creates a value of 'Invoke' with the minimum fields required to make a request.
 --
@@ -173,7 +173,7 @@ data InvokeResponse = InvokeResponse'
     , _irsLogResult     :: !(Maybe Text)
     , _irsPayload       :: !(Maybe (HashMap Text Value))
     , _irsStatusCode    :: !Int
-    } deriving (Eq,Read,Show,Data,Typeable,Generic)
+    } deriving (Eq,Show,Data,Typeable,Generic)
 
 -- | Creates a value of 'InvokeResponse' with the minimum fields required to make a request.
 --

--- a/amazonka-s3-encryption/src/Network/AWS/S3/Encryption/Envelope.hs
+++ b/amazonka-s3-encryption/src/Network/AWS/S3/Encryption/Envelope.hs
@@ -127,7 +127,7 @@ decodeV2 xs m e = do
     rs  <- runAWS e . send $
         KMS.decrypt raw
             & dEncryptionContext .~ fromDescription (m <> d)
-            -- ^ Left-associative merge for material description,
+            -- Left-associative merge for material description,
             -- keys in the supplied description override those
             -- on the envelope.
 

--- a/amazonka-s3/gen/Network/AWS/S3/GetBucketPolicy.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/GetBucketPolicy.hs
@@ -88,7 +88,7 @@ instance ToQuery GetBucketPolicy where
 data GetBucketPolicyResponse = GetBucketPolicyResponse'
     { _gbprsResponseStatus :: !Int
     , _gbprsPolicy         :: !(HashMap Text Value)
-    } deriving (Eq,Read,Show,Data,Typeable,Generic)
+    } deriving (Eq,Show,Data,Typeable,Generic)
 
 -- | Creates a value of 'GetBucketPolicyResponse' with the minimum fields required to make a request.
 --

--- a/amazonka-s3/gen/Network/AWS/S3/GetBucketPolicy.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/GetBucketPolicy.hs
@@ -33,8 +33,8 @@ module Network.AWS.S3.GetBucketPolicy
     , getBucketPolicyResponse
     , GetBucketPolicyResponse
     -- * Response Lenses
-    , gbprsPolicy
     , gbprsResponseStatus
+    , gbprsPolicy
     ) where
 
 import           Network.AWS.Prelude
@@ -69,10 +69,10 @@ instance AWSRequest GetBucketPolicy where
         type Rs GetBucketPolicy = GetBucketPolicyResponse
         request = get s3
         response
-          = receiveXML
+          = receiveJSON
               (\ s h x ->
                  GetBucketPolicyResponse' <$>
-                   (parseXML x) <*> (pure (fromEnum s)))
+                   (pure (fromEnum s)) <*> (pure x))
 
 instance ToHeaders GetBucketPolicy where
         toHeaders = const mempty
@@ -86,30 +86,31 @@ instance ToQuery GetBucketPolicy where
 
 -- | /See:/ 'getBucketPolicyResponse' smart constructor.
 data GetBucketPolicyResponse = GetBucketPolicyResponse'
-    { _gbprsPolicy         :: !(Maybe Text)
-    , _gbprsResponseStatus :: !Int
+    { _gbprsResponseStatus :: !Int
+    , _gbprsPolicy         :: !(HashMap Text Value)
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
 -- | Creates a value of 'GetBucketPolicyResponse' with the minimum fields required to make a request.
 --
 -- Use one of the following lenses to modify other fields as desired:
 --
--- * 'gbprsPolicy'
---
 -- * 'gbprsResponseStatus'
+--
+-- * 'gbprsPolicy'
 getBucketPolicyResponse
     :: Int -- ^ 'gbprsResponseStatus'
+    -> HashMap Text Value -- ^ 'gbprsPolicy'
     -> GetBucketPolicyResponse
-getBucketPolicyResponse pResponseStatus_ =
+getBucketPolicyResponse pResponseStatus_ pPolicy_ =
     GetBucketPolicyResponse'
-    { _gbprsPolicy = Nothing
-    , _gbprsResponseStatus = pResponseStatus_
+    { _gbprsResponseStatus = pResponseStatus_
+    , _gbprsPolicy = pPolicy_
     }
-
--- | The bucket policy as a JSON document.
-gbprsPolicy :: Lens' GetBucketPolicyResponse (Maybe Text)
-gbprsPolicy = lens _gbprsPolicy (\ s a -> s{_gbprsPolicy = a});
 
 -- | The response status code.
 gbprsResponseStatus :: Lens' GetBucketPolicyResponse Int
 gbprsResponseStatus = lens _gbprsResponseStatus (\ s a -> s{_gbprsResponseStatus = a});
+
+-- | The bucket policy as a JSON document.
+gbprsPolicy :: Lens' GetBucketPolicyResponse (HashMap Text Value)
+gbprsPolicy = lens _gbprsPolicy (\ s a -> s{_gbprsPolicy = a});

--- a/amazonka-s3/gen/Network/AWS/S3/PutBucketPolicy.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/PutBucketPolicy.hs
@@ -47,7 +47,7 @@ import           Network.AWS.S3.Types.Product
 data PutBucketPolicy = PutBucketPolicy'
     { _pbpContentMD5 :: !(Maybe Text)
     , _pbpBucket     :: !BucketName
-    , _pbpPolicy     :: !Text
+    , _pbpPolicy     :: !(HashMap Text Value)
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
 -- | Creates a value of 'PutBucketPolicy' with the minimum fields required to make a request.
@@ -61,7 +61,7 @@ data PutBucketPolicy = PutBucketPolicy'
 -- * 'pbpPolicy'
 putBucketPolicy
     :: BucketName -- ^ 'pbpBucket'
-    -> Text -- ^ 'pbpPolicy'
+    -> HashMap Text Value -- ^ 'pbpPolicy'
     -> PutBucketPolicy
 putBucketPolicy pBucket_ pPolicy_ =
     PutBucketPolicy'
@@ -79,16 +79,16 @@ pbpBucket :: Lens' PutBucketPolicy BucketName
 pbpBucket = lens _pbpBucket (\ s a -> s{_pbpBucket = a});
 
 -- | The bucket policy as a JSON document.
-pbpPolicy :: Lens' PutBucketPolicy Text
+pbpPolicy :: Lens' PutBucketPolicy (HashMap Text Value)
 pbpPolicy = lens _pbpPolicy (\ s a -> s{_pbpPolicy = a});
 
 instance AWSRequest PutBucketPolicy where
         type Rs PutBucketPolicy = PutBucketPolicyResponse
-        request = contentMD5 . putXML s3
+        request = contentMD5 . putBody s3
         response = receiveNull PutBucketPolicyResponse'
 
-instance ToElement PutBucketPolicy where
-        toElement = mkElement "Policy" . _pbpPolicy
+instance ToBody PutBucketPolicy where
+        toBody = toBody . _pbpPolicy
 
 instance ToHeaders PutBucketPolicy where
         toHeaders PutBucketPolicy'{..}

--- a/amazonka-s3/gen/Network/AWS/S3/PutBucketPolicy.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/PutBucketPolicy.hs
@@ -48,7 +48,7 @@ data PutBucketPolicy = PutBucketPolicy'
     { _pbpContentMD5 :: !(Maybe Text)
     , _pbpBucket     :: !BucketName
     , _pbpPolicy     :: !(HashMap Text Value)
-    } deriving (Eq,Read,Show,Data,Typeable,Generic)
+    } deriving (Eq,Show,Data,Typeable,Generic)
 
 -- | Creates a value of 'PutBucketPolicy' with the minimum fields required to make a request.
 --

--- a/core/src/Network/AWS/Data/Body.hs
+++ b/core/src/Network/AWS/Data/Body.hs
@@ -29,7 +29,7 @@ import qualified Data.ByteString.Char8        as BS8
 import qualified Data.ByteString.Lazy         as LBS
 import qualified Data.ByteString.Lazy.Char8   as LBS8
 import           Data.Conduit
-import qualified Data.Conduit.List            as CL
+import           Data.HashMap.Strict          (HashMap)
 import           Data.Monoid
 import           Data.String
 import           Data.Text                    (Text)
@@ -197,6 +197,9 @@ instance ToHashedBody Value          where toHashed = toHashed . encode
 instance ToHashedBody Element        where toHashed = toHashed . encodeXML
 instance ToHashedBody QueryString    where toHashed = toHashed . toBS
 
+instance ToHashedBody (HashMap Text Value) where
+    toHashed = toHashed . Object
+
 -- | Anything that can be converted to a streaming request 'Body'.
 class ToBody a where
     -- | Convert a value to a request body.
@@ -214,6 +217,7 @@ instance ToBody LBS.ByteString
 instance ToBody ByteString
 instance ToBody Text
 instance ToBody LText.Text
+instance ToBody (HashMap Text Value)
 instance ToBody Value
 instance ToBody Element
 instance ToBody QueryString

--- a/gen/annex/lambda.json
+++ b/gen/annex/lambda.json
@@ -1,5 +1,24 @@
 {
     "metadata": {
         "serviceAbbreviation": "Lambda"
+    },
+    "shapes": {
+        "InvocationResponse": {
+            "members": {
+                "Payload": {
+                    "shape": "JsonPayload"
+                }
+            }
+        },
+        "InvocationRequest": {
+            "members": {
+                "Payload": {
+                    "shape": "JsonPayload"
+                }
+            }
+        },
+        "JsonPayload": {
+            "type": "json"
+        }
     }
 }

--- a/gen/annex/s3.json
+++ b/gen/annex/s3.json
@@ -4,6 +4,9 @@
     },
     "documentation": "Amazon Simple Storage Service is storage for the Internet. Amazon S3 has a simple web services interface that you can use to store and retrieve any amount of data, at any time, from anywhere on the web. It gives any developer access to the same highly scalable, reliable, fast, inexpensive data storage infrastructure that Amazon uses to run its own global network of web sites. The service aims to maximize benefits of scale and to pass those benefits on to developers.",
     "shapes": {
+        "Policy": {
+            "type": "json"
+        },
         "CompletedPartList": {
             "min": 1
         }

--- a/gen/config/lambda.json
+++ b/gen/config/lambda.json
@@ -3,9 +3,9 @@
     "operationUrl": "http://docs.aws.amazon.com/lambda/latest/dg/API_",
     "libraryName": "amazonka-lambda",
     "typeOverrides": {
-        "InvokeAsyncResponse": {
+        "InvocationRequest": {
             "requiredFields": [
-                "Status"
+                "Payload"
             ]
         }
     }

--- a/gen/config/s3.json
+++ b/gen/config/s3.json
@@ -17,6 +17,11 @@
         "Network.AWS.S3.Internal"
     ],
     "typeOverrides": {
+        "GetBucketPolicyOutput": {
+            "requiredFields": [
+                "Policy"
+            ]
+        },
         "Error": {
             "renamedTo": "S3ServiceError"
         },

--- a/gen/config/s3.json
+++ b/gen/config/s3.json
@@ -20,11 +20,6 @@
         "Error": {
             "renamedTo": "S3ServiceError"
         },
-        "ListObjectsResponse": {
-            "requiredFields": [
-                "Name"
-            ]
-        },
         "Bucket": {
             "requiredFields": [
                 "CreationDate",

--- a/gen/src/Gen/AST/Data/Field.hs
+++ b/gen/src/Gen/AST/Data/Field.hs
@@ -152,12 +152,23 @@ fieldHelp f =
 fieldLocation :: Field -> Maybe Location
 fieldLocation = view (fieldRef . refLocation)
 
+-- | Is the field reference or its parent annotation streaming?
+fieldStream :: Field -> Bool
+fieldStream x =
+       x ^. fieldRef . refStreaming
+    || x ^. fieldAnn . infoStreaming
+
+-- | Does the field have its location set to 'Body'?
 fieldBody :: Field -> Bool
 fieldBody x =
     case fieldLocation x of
         Just Body -> True
         Nothing   -> True
         _         -> fieldStream x
+
+-- | Is this primitive field set as the payload in the parent shape?
+fieldLitPayload :: Field -> Bool
+fieldLitPayload x = _fieldPayload x && fieldLit x
 
 fieldMaybe :: Field -> Bool
 fieldMaybe f =
@@ -168,12 +179,8 @@ fieldMaybe f =
 fieldMonoid :: Field -> Bool
 fieldMonoid = elem DMonoid . derivingOf . view fieldAnn
 
-fieldStream :: Field -> Bool
-fieldStream x =
-       x ^. fieldRef . refStreaming
-    || x ^. fieldAnn . infoStreaming
-
-fieldList1, fieldList, fieldMap :: Field -> Bool
+fieldList1, fieldList, fieldMap, fieldLit :: Field -> Bool
 fieldList1 f = fieldList f && nonEmpty f
 fieldList    = not . isn't _List . unwrap . view fieldAnn
 fieldMap     = not . isn't _Map  . unwrap . view fieldAnn
+fieldLit     = not . isn't _Lit  . unwrap . view fieldAnn

--- a/gen/src/Gen/AST/Data/Instance.hs
+++ b/gen/src/Gen/AST/Data/Instance.hs
@@ -102,7 +102,7 @@ requestInsts m h r fs = do
     toPath = ToPath <$> uriFields h uriPath id fs
 
     toBody :: Maybe Inst
-    toBody = ToBody <$> stream
+    toBody = ToBody <$> (stream <|> payload)
 
     concatQuery :: [Inst] -> Either Error [Inst]
     concatQuery is = do
@@ -174,6 +174,8 @@ requestInsts m h r fs = do
         body = isJust toBody
 
     (listToMaybe -> stream, fields) = partition fieldStream notLocated
+
+    payload = find fieldLitPayload fields
 
     notLocated :: [Field]
     notLocated = satisfy (\l -> isNothing l || Just Body == l) fs

--- a/gen/src/Gen/AST/TypeOf.hs
+++ b/gen/src/Gen/AST/TypeOf.hs
@@ -112,7 +112,7 @@ derivingOf = uniq . typ . typeOf
         Blob   -> base
         Time   -> DOrd : base
         Bool   -> enum <> base
-        Json   -> base
+        Json   -> [DEq, DShow, DData, DTypeable, DGeneric]
 
 stream, string, num, frac, monoid, enum, base :: [Derive]
 stream = [DShow, DGeneric]

--- a/gen/src/Gen/AST/TypeOf.hs
+++ b/gen/src/Gen/AST/TypeOf.hs
@@ -112,6 +112,7 @@ derivingOf = uniq . typ . typeOf
         Blob   -> base
         Time   -> DOrd : base
         Bool   -> enum <> base
+        Json   -> base
 
 stream, string, num, frac, monoid, enum, base :: [Derive]
 stream = [DShow, DGeneric]

--- a/gen/src/Gen/Types/Ann.hs
+++ b/gen/src/Gen/Types/Ann.hs
@@ -111,6 +111,7 @@ data Lit
     | Blob
     | Time
     | Bool
+    | Json
       deriving (Show)
 
 data TType

--- a/gen/src/Gen/Types/Service.hs
+++ b/gen/src/Gen/Types/Service.hs
@@ -349,6 +349,7 @@ instance FromJSON (ShapeF ()) where
             "blob"      -> pure (Lit i Blob)
             "boolean"   -> pure (Lit i Bool)
             "timestamp" -> pure (Lit i Time)
+            "json"      -> pure (Lit i Json)
             "string"    -> pure (maybe (Lit i Text) f m)
               where
                 f = Enum i . Map.fromList . map (first mkId . renameBranch)


### PR DESCRIPTION
Extends `amazonka-gen` with a `json` literal type, that can be added via `annex` / `config` overrides. This allows for fixes with S3's `GetObjectPolicy`, Lambda, and Glacier operations that return non-streaming response bodies that are in factor opaque JSON documents.

Fixes #224.