### PR TITLE
Updating retryService to actually delay

### DIFF
--- a/amazonka/src/Network/AWS/Internal/HTTP.hs
+++ b/amazonka/src/Network/AWS/Internal/HTTP.hs
@@ -160,7 +160,7 @@ retryService :: Service -> RetryPolicy
 retryService s = limitRetries _retryAttempts <> RetryPolicy delay
   where
     delay n
-        | n > 0     = Just $ truncate (grow * 1000000)
+        | n >= 0    = Just $ truncate (grow * 1000000)
         | otherwise = Nothing
       where
         grow = _retryBase * (fromIntegral _retryGrowth ^^ (n - 1))


### PR DESCRIPTION
Previously this code incorrectly caused the very first
attempt to return Nothing (Control.Retry starts at 0).
Now it should capture the first attempt, so it returns
Just and actually retry.

Not really sure with the state of the tests, this could probably do with one. Here is a repl demonstrating the problem
```
>> :m + Control.Retry
>> let retry = limitRetries 5 <> (RetryPolicy $ \n -> if n > 0 then Just 2000000 else Nothing)
>> let action = putStrLn "action" >> return True
>> retrying retry (\_ b -> return b) action
action
True
>> let retry = limitRetries 5 <> (RetryPolicy $ \n -> if n >= 0 then Just 2000000 else Nothing)
>> retrying retry (\_ b -> return b) action
action
action
action
action
action
action
True
```
