### PR TITLE
Add runResourceT to usage example in Network.AWS

### DIFF
--- a/amazonka/src/Network/AWS.hs
+++ b/amazonka/src/Network/AWS.hs
@@ -328,7 +328,7 @@ example = do
     b <- sourceFileIO "local\/path\/to\/object-payload"
 
     -- We now run the AWS computation with the overriden logger, performing the PutObject request:
-    runAWS (e & envLogger .~ l) $
+    runResourceT . runAWS (e & envLogger .~ l) $
         send (putObject "bucket-name" "object-key" b)
 @
 -}


### PR DESCRIPTION
The usage example seems to be wrong. It caused the confusion in #232