### PR TITLE
Extending VolumeAttachmentState with an additional 'busy' constructor.

### DIFF
--- a/gen/annex/ec2.json
+++ b/gen/annex/ec2.json
@@ -11,6 +11,15 @@
                 "detached",
                 "busy"
             ]
+        },
+        "VolumeAttachmentState": {
+            "enum":[
+                "attaching",
+                "attached",
+                "detaching",
+                "detached",
+                "busy"
+            ]
         }
     },
     "waiters": {


### PR DESCRIPTION
Like `AttachmentStatus` (https://github.com/brendanhay/amazonka/commit/9b3959aad6541771e6274ffba47d771868fb20bb), `VolumeAttachmentState` can also read `busy`:

> `message = Failed reading: Failure parsing VolumeAttachmentState from value: 'busy'. Accepted values: attached, attaching, detached, detaching`

..so another override. `make -C gen gen format` yields:

```diff
diff --git a/amazonka-ec2/gen/Network/AWS/EC2/Types/Sum.hs b/amazonka-ec2/gen/Network/AWS/EC2/Types/Sum.hs
index 4c617b8..2088284 100644
--- a/amazonka-ec2/gen/Network/AWS/EC2/Types/Sum.hs
+++ b/amazonka-ec2/gen/Network/AWS/EC2/Types/Sum.hs
@@ -2322,6 +2322,7 @@ instance FromXML VirtualizationType where
 data VolumeAttachmentState
     = VASAttached
     | VASAttaching
+    | VASBusy
     | VASDetached
     | VASDetaching
     deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
@@ -2330,15 +2331,17 @@ instance FromText VolumeAttachmentState where
     parser = takeLowerText >>= \case
         "attached" -> pure VASAttached
         "attaching" -> pure VASAttaching
+        "busy" -> pure VASBusy
         "detached" -> pure VASDetached
         "detaching" -> pure VASDetaching
         e -> fromTextError $ "Failure parsing VolumeAttachmentState from value: '" <> e
-           <> "'. Accepted values: attached, attaching, detached, detaching"
+           <> "'. Accepted values: attached, attaching, busy, detached, detaching"
 
 instance ToText VolumeAttachmentState where
     toText = \case
         VASAttached -> "attached"
         VASAttaching -> "attaching"
+        VASBusy -> "busy"
         VASDetached -> "detached"
         VASDetaching -> "detaching"
 ```