### PR TITLE
Indicate in "await" responses whether requests were fulfilled.

### DIFF
--- a/amazonka/src/Control/Monad/Trans/AWS.hs
+++ b/amazonka/src/Control/Monad/Trans/AWS.hs
@@ -176,7 +176,7 @@ import           Network.AWS.Prelude          as AWS
 import qualified Network.AWS.Presign          as Sign
 import           Network.AWS.Request          (requestURL)
 import           Network.AWS.Types            hiding (LogLevel (..))
-import           Network.AWS.Waiter           (Wait)
+import           Network.AWS.Waiter           (Accept, Wait)
 
 type AWST = AWST' Env
 
@@ -287,8 +287,8 @@ paginate = go
 await :: (AWSConstraint r m, AWSRequest a)
       => Wait a
       -> a
-      -> m ()
-await w = waiter w >=> hoistError . maybe (Right ()) Left
+      -> m Accept
+await w = waiter w >=> hoistError
 
 -- | Presign an URL that is valid from the specified time until the
 -- number of seconds expiry has elapsed.

--- a/amazonka/src/Network/AWS.hs
+++ b/amazonka/src/Network/AWS.hs
@@ -260,7 +260,7 @@ paginate = hoist liftAWS . AWST.paginate
 
 -- | Poll the API with the supplied request until a specific 'Wait' condition
 -- is fulfilled.
-await :: (MonadAWS m, AWSRequest a) => Wait a -> a -> m ()
+await :: (MonadAWS m, AWSRequest a) => Wait a -> a -> m AWST.Accept
 await w = liftAWS . AWST.await w
 
 -- | Presign an URL that is valid from the specified time until the

--- a/amazonka/src/Network/AWS/Internal/HTTP.hs
+++ b/amazonka/src/Network/AWS/Internal/HTTP.hs
@@ -81,7 +81,7 @@ waiter :: ( MonadCatch m
           )
        => Wait a
        -> a
-       -> m (Maybe Error)
+       -> m (Either Error Accept)
 waiter w@Wait{..} x = do
    e@Env{..} <- view environment
    rq        <- configured x
@@ -98,9 +98,9 @@ waiter w@Wait{..} x = do
 
     result rq = first (fromMaybe AcceptRetry . accept w rq) . join (,)
 
-    exit (AcceptSuccess, _) = return Nothing
-    exit (_,        Left e) = return (Just e)
-    exit (_,             _) = return Nothing
+    exit (AcceptSuccess, _) = return $ Right AcceptSuccess
+    exit (_,        Left e) = return $ Left e
+    exit (accept,        _) = return $ Right accept
 
     msg l n a = logDebug l
         . mconcat


### PR DESCRIPTION
Presently there doesn't seem to be much indication whether a waiter met success before `_waitAttempts`; service errors encountered in terminal waits are lifted and thrown (unless that wait happened to somehow succeed in spite of it), but it is not revealed whether valid and terminal requests met `AcceptSuccess`, `AcceptFailure`, or `AcceptRetry`. This patch has that missing result provided as the return type of `await`.

Motivating example; on `develop`, with `i-deadbeef` substituted for some running instance, this exits without anything being thrown, and no indication that the waiter never succeeded:

```haskell
module Main where

import Control.Lens  (set)
import Control.Monad.Trans.AWS
import Network.AWS.EC2 
import Network.AWS.Waiter (_waitAttempts)

waiter = instanceTerminated { _waitAttempts = 1 } 
 `await` set diiInstanceIds ["i-deadbeef"] describeInstances 

main :: IO ()
main = newEnv Singapore Discover
   >>= runResourceT . flip runAWST waiter
```