### PR TITLE
Retry HttpExceptions Consisting of Transport/Connection Failures by Default

### DIFF
--- a/amazonka/src/Network/AWS/Internal/HTTP.hs
+++ b/amazonka/src/Network/AWS/Internal/HTTP.hs
@@ -98,9 +98,9 @@ waiter w@Wait{..} x = do
 
     result rq = first (fromMaybe AcceptRetry . accept w rq) . join (,)
 
-    exit (AcceptSuccess, _) = return $ Right AcceptSuccess
-    exit (_,        Left e) = return $ Left e
-    exit (accept,        _) = return $ Right accept
+    exit (AcceptSuccess, _) = return (Right AcceptSuccess)
+    exit (_,        Left e) = return (Left e)
+    exit (a,        _)      = return (Right a)
 
     msg l n a = logDebug l
         . mconcat


### PR DESCRIPTION
.. up to 3 times by default. This can be reset or have the limit increased by:

```haskell
-- Retry 'many' times ..
e <- newEnv Rotorua Discover <&> envRetryCheck .~ retryConnectionFailure maxBound
...

-- Retry no HttpExceptions (1.3.5 and earlier behaviour):
e <- newEnv Ruatoria Discover <&> envRetryCheck .~ (\_ _ -> False)
...
```

This is a partial fix for #230. The `StatusCodeException == status500` check has not been included - since whether to include this as the default or not is (imo) subjective and specific to S3 in the mentioned issue. I may introduce a more composeable mechanism for adding `HttpException` retries in the future, such as combining with the `ServiceError` check and use of `Control.Retry`.

The hope is that this change combined with the addition of the `100-continue` header introduced in #235 provide sufficient to address the concerns in #230.

cc @nhibberd 