### PR TITLE
Add independent type for S3 BucketLocationConstraint values

### DIFF
--- a/amazonka-s3/gen/Network/AWS/S3/GetBucketLocation.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/GetBucketLocation.hs
@@ -87,7 +87,7 @@ instance ToQuery GetBucketLocation where
 -- | /See:/ 'getBucketLocationResponse' smart constructor.
 data GetBucketLocationResponse = GetBucketLocationResponse'
     { _grsResponseStatus     :: !Int
-    , _grsLocationConstraint :: !Region
+    , _grsLocationConstraint :: !LocationConstraint
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
 -- | Creates a value of 'GetBucketLocationResponse' with the minimum fields required to make a request.
@@ -99,7 +99,7 @@ data GetBucketLocationResponse = GetBucketLocationResponse'
 -- * 'grsLocationConstraint'
 getBucketLocationResponse
     :: Int -- ^ 'grsResponseStatus'
-    -> Region -- ^ 'grsLocationConstraint'
+    -> LocationConstraint -- ^ 'grsLocationConstraint'
     -> GetBucketLocationResponse
 getBucketLocationResponse pResponseStatus_ pLocationConstraint_ =
     GetBucketLocationResponse'
@@ -112,5 +112,5 @@ grsResponseStatus :: Lens' GetBucketLocationResponse Int
 grsResponseStatus = lens _grsResponseStatus (\ s a -> s{_grsResponseStatus = a});
 
 -- | Undocumented member.
-grsLocationConstraint :: Lens' GetBucketLocationResponse Region
+grsLocationConstraint :: Lens' GetBucketLocationResponse LocationConstraint
 grsLocationConstraint = lens _grsLocationConstraint (\ s a -> s{_grsLocationConstraint = a});

--- a/amazonka-s3/gen/Network/AWS/S3/Types/Product.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/Types/Product.hs
@@ -454,7 +454,7 @@ instance FromXML CopyPartResult where
 
 -- | /See:/ 'createBucketConfiguration' smart constructor.
 newtype CreateBucketConfiguration = CreateBucketConfiguration'
-    { _cbcLocationConstraint :: Maybe Region
+    { _cbcLocationConstraint :: Maybe LocationConstraint
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
 -- | Creates a value of 'CreateBucketConfiguration' with the minimum fields required to make a request.
@@ -471,7 +471,7 @@ createBucketConfiguration =
 
 -- | Specifies the region where the bucket will be created. If you don\'t
 -- specify a region, the bucket will be created in US Standard.
-cbcLocationConstraint :: Lens' CreateBucketConfiguration (Maybe Region)
+cbcLocationConstraint :: Lens' CreateBucketConfiguration (Maybe LocationConstraint)
 cbcLocationConstraint = lens _cbcLocationConstraint (\ s a -> s{_cbcLocationConstraint = a});
 
 instance ToXML CreateBucketConfiguration where

--- a/amazonka-s3/src/Network/AWS/S3/Internal.hs
+++ b/amazonka-s3/src/Network/AWS/S3/Internal.hs
@@ -3,7 +3,9 @@
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE MultiWayIf                 #-}
+{-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE RankNTypes                 #-}
 
 -- |
@@ -15,12 +17,18 @@
 -- Portability : non-portable (GHC extensions)
 --
 module Network.AWS.S3.Internal
-    ( Region          (..)
-    , BucketName      (..)
-    , ETag            (..)
-    , ObjectVersionId (..)
+    ( Region             (..)
+    , BucketName         (..)
+    , ETag               (..)
+    , ObjectVersionId    (..)
+
+    -- * Bucket Location
+    , LocationConstraint (..)
+    , _LocationConstraint
+
+    -- * Object Key
     , Delimiter
-    , ObjectKey       (..)
+    , ObjectKey          (..)
     , _ObjectKey
     , keyPrefix
     , keyName
@@ -92,6 +100,42 @@ newtype ObjectVersionId = ObjectVersionId Text
         , ToQuery
         , ToLog
         )
+
+newtype LocationConstraint = LocationConstraint { location :: Region }
+    deriving
+        ( Eq
+        , Ord
+        , Read
+        , Show
+        , Data
+        , Typeable
+        , Generic
+        , ToText
+        , ToByteString
+        , ToLog
+        )
+
+_LocationConstraint :: Iso' LocationConstraint Region
+_LocationConstraint = iso location LocationConstraint
+
+instance FromText LocationConstraint where
+    parser = LocationConstraint <$> (parser <|> go)
+      where
+        go = takeLowerText >>= \case
+            ""   -> pure NorthVirginia
+            "eu" -> pure Ireland
+            e    -> fromTextError $
+                "Failure parsing LocationConstraint from " <> e
+
+instance FromXML LocationConstraint where
+    parseXML = \case
+        [] -> pure (LocationConstraint NorthVirginia)
+        ns -> parseXMLText "LocationConstraint" ns
+
+instance ToXML LocationConstraint where
+    toXML = \case
+        LocationConstraint NorthVirginia -> XNull
+        LocationConstraint r             -> toXMLText r
 
 newtype ObjectKey = ObjectKey Text
     deriving

--- a/amazonka-s3/src/Network/AWS/S3/Internal.hs
+++ b/amazonka-s3/src/Network/AWS/S3/Internal.hs
@@ -101,7 +101,7 @@ newtype ObjectVersionId = ObjectVersionId Text
         , ToLog
         )
 
-newtype LocationConstraint = LocationConstraint { location :: Region }
+newtype LocationConstraint = LocationConstraint { constraintRegion :: Region }
     deriving
         ( Eq
         , Ord
@@ -116,7 +116,7 @@ newtype LocationConstraint = LocationConstraint { location :: Region }
         )
 
 _LocationConstraint :: Iso' LocationConstraint Region
-_LocationConstraint = iso location LocationConstraint
+_LocationConstraint = iso constraintRegion LocationConstraint
 
 instance FromText LocationConstraint where
     parser = LocationConstraint <$> (parser <|> go)

--- a/gen/config/s3.json
+++ b/gen/config/s3.json
@@ -48,7 +48,7 @@
         },
         "BucketLocationConstraint": {
             "replacedBy": {
-                "name": "Region",
+                "name": "LocationConstraint",
                 "deriving": []
             }
         },

--- a/gen/stack.yaml
+++ b/gen/stack.yaml
@@ -1,5 +1,6 @@
-resolver: nightly-2015-08-06
+resolver: nightly-2015-11-17
 flags:    {}
-packages: ['.']
 extra-deps:
-  - text-regex-replace-0.1.0.1
+  - text-regex-replace-0.1.1.1
+packages:
+  - '.'


### PR DESCRIPTION
Deserialisation of BucketLocationConstraint was previously not correctly handling  `"EU"` (`eu-west-1`) and `""` (`us-east-1`) values.

Now, deserialising an empty `<LocationConstraint/>`:

```haskell
λ: decodeXML "<LocationConstraint xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"/>"
    :: Either String LocationConstraint 
Right (LocationConstraint {location = NorthVirginia})
```

Returning EU:

```haskell
λ: decodeXML "<LocationConstraint xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">EU</LocationConstraint>"
    :: Either String LocationConstraint 
Right (LocationConstraint {location = Ireland})
```

Serialisation is also changed, specifically by discarding the value `NorthVirginia` per the [documentation](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUT.html#RESTBucketPUT-requests-request-elements):

```haskell
λ: let cfg = createBucketConfiguration & cbcLocationConstraint ?~ LocationConstraint NorthVirginia
λ: let bkt = createBucket "Foo" & cbCreateBucketConfiguration ?~ cfg
λ: encodeXML bkt
"<?xml version=\"1.0\" encoding=\"UTF-8\"?><CreateBucketConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"/>"
```

> What has not been changed due to ambiguity, is serialising `Ireland` -> `"EU"`. The documentation is not clear here, it appears to accept `eu-west-1`, but the example shows `EU`.

Fixes #249.