### PR TITLE
Add Bounded Instances for Enumeration Types

### DIFF
--- a/amazonka-apigateway/gen/Network/AWS/APIGateway/Types/Sum.hs
+++ b/amazonka-apigateway/gen/Network/AWS/APIGateway/Types/Sum.hs
@@ -29,7 +29,7 @@ data CacheClusterSize
     | D28_4
     | D58_2
     | D6_1
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText CacheClusterSize where
     parser = takeLowerText >>= \case
@@ -73,7 +73,7 @@ data CacheClusterStatus
     | DeleteInProgress
     | FlushInProgress
     | NotAvailable
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText CacheClusterStatus where
     parser = takeLowerText >>= \case
@@ -106,7 +106,7 @@ data IntegrationType
     = AWS
     | HTTP
     | Mock
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText IntegrationType where
     parser = takeLowerText >>= \case
@@ -140,7 +140,7 @@ data Op
     | Remove
     | Replace
     | Test
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText Op where
     parser = takeLowerText >>= \case

--- a/amazonka-autoscaling/gen/Network/AWS/AutoScaling/Types/Sum.hs
+++ b/amazonka-autoscaling/gen/Network/AWS/AutoScaling/Types/Sum.hs
@@ -33,7 +33,7 @@ data LifecycleState
     | Terminating
     | TerminatingProceed
     | TerminatingWait
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText LifecycleState where
     parser = takeLowerText >>= \case
@@ -89,7 +89,7 @@ data ScalingActivityStatusCode
     | WaitingForInstanceWarmup
     | WaitingForSpotInstanceId
     | WaitingForSpotInstanceRequestId
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ScalingActivityStatusCode where
     parser = takeLowerText >>= \case

--- a/amazonka-cloudformation/gen/Network/AWS/CloudFormation/Types/Sum.hs
+++ b/amazonka-cloudformation/gen/Network/AWS/CloudFormation/Types/Sum.hs
@@ -21,7 +21,7 @@ import           Network.AWS.Prelude
 
 data Capability =
     CapabilityIAM
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText Capability where
     parser = takeLowerText >>= \case
@@ -45,7 +45,7 @@ data OnFailure
     = Delete
     | DoNothing
     | Rollback
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText OnFailure where
     parser = takeLowerText >>= \case
@@ -69,7 +69,7 @@ instance ToHeader     OnFailure
 data ResourceSignalStatus
     = Failure
     | Success
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ResourceSignalStatus where
     parser = takeLowerText >>= \case
@@ -99,7 +99,7 @@ data ResourceStatus
     | UpdateComplete
     | UpdateFailed
     | UpdateInProgress
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ResourceStatus where
     parser = takeLowerText >>= \case
@@ -154,7 +154,7 @@ data StackStatus
     | SSUpdateRollbackCompleteCleanupInProgress
     | SSUpdateRollbackFailed
     | SSUpdateRollbackInProgress
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText StackStatus where
     parser = takeLowerText >>= \case

--- a/amazonka-cloudfront/gen/Network/AWS/CloudFront/Types/Sum.hs
+++ b/amazonka-cloudfront/gen/Network/AWS/CloudFront/Types/Sum.hs
@@ -23,7 +23,7 @@ data GeoRestrictionType
     = Blacklist
     | None
     | Whitelist
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText GeoRestrictionType where
     parser = takeLowerText >>= \case
@@ -54,7 +54,7 @@ data ItemSelection
     = ISAll
     | ISNone
     | ISWhitelist
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ItemSelection where
     parser = takeLowerText >>= \case
@@ -89,7 +89,7 @@ data Method
     | Patch
     | Post
     | Put
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText Method where
     parser = takeLowerText >>= \case
@@ -127,7 +127,7 @@ instance ToXML Method where
 data MinimumProtocolVersion
     = SSLV3
     | TLSV1
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText MinimumProtocolVersion where
     parser = takeLowerText >>= \case
@@ -155,7 +155,7 @@ instance ToXML MinimumProtocolVersion where
 data OriginProtocolPolicy
     = HTTPOnly
     | MatchViewer
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText OriginProtocolPolicy where
     parser = takeLowerText >>= \case
@@ -184,7 +184,7 @@ data PriceClass
     = PriceClass100
     | PriceClass200
     | PriceClassAll
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText PriceClass where
     parser = takeLowerText >>= \case
@@ -214,7 +214,7 @@ instance ToXML PriceClass where
 data SSLSupportMethod
     = SNIOnly
     | VIP
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText SSLSupportMethod where
     parser = takeLowerText >>= \case
@@ -243,7 +243,7 @@ data ViewerProtocolPolicy
     = AllowAll
     | HTTPSOnly
     | RedirectToHTTPS
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ViewerProtocolPolicy where
     parser = takeLowerText >>= \case

--- a/amazonka-cloudhsm/gen/Network/AWS/CloudHSM/Types/Sum.hs
+++ b/amazonka-cloudhsm/gen/Network/AWS/CloudHSM/Types/Sum.hs
@@ -22,7 +22,7 @@ import           Network.AWS.Prelude
 data ClientVersion
     = VD5_1
     | VD5_3
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ClientVersion where
     parser = takeLowerText >>= \case
@@ -48,7 +48,7 @@ data CloudHSMObjectState
     = Degraded
     | Ready
     | Updating
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText CloudHSMObjectState where
     parser = takeLowerText >>= \case
@@ -80,7 +80,7 @@ data HSMStatus
     | HSTerminated
     | HSTerminating
     | HSUpdating
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText HSMStatus where
     parser = takeLowerText >>= \case
@@ -114,7 +114,7 @@ instance FromJSON HSMStatus where
 
 data SubscriptionType =
     Production
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText SubscriptionType where
     parser = takeLowerText >>= \case

--- a/amazonka-cloudsearch-domains/gen/Network/AWS/CloudSearchDomains/Types/Sum.hs
+++ b/amazonka-cloudsearch-domains/gen/Network/AWS/CloudSearchDomains/Types/Sum.hs
@@ -22,7 +22,7 @@ import           Network.AWS.Prelude
 data ContentType
     = ApplicationJSON
     | ApplicationXML
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ContentType where
     parser = takeLowerText >>= \case
@@ -49,7 +49,7 @@ data QueryParser
     | Lucene
     | Simple
     | Structured
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText QueryParser where
     parser = takeLowerText >>= \case

--- a/amazonka-cloudsearch/gen/Network/AWS/CloudSearch/Types/Sum.hs
+++ b/amazonka-cloudsearch/gen/Network/AWS/CloudSearch/Types/Sum.hs
@@ -24,7 +24,7 @@ data AlgorithmicStemming
     | ASLight
     | ASMinimal
     | ASNone
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText AlgorithmicStemming where
     parser = takeLowerText >>= \case
@@ -88,7 +88,7 @@ data AnalysisSchemeLanguage
     | TR
     | ZhHans
     | ZhHant
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText AnalysisSchemeLanguage where
     parser = takeLowerText >>= \case
@@ -192,7 +192,7 @@ data IndexFieldType
     | LiteralArray
     | Text
     | TextArray
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText IndexFieldType where
     parser = takeLowerText >>= \case
@@ -249,7 +249,7 @@ data OptionState
     | FailedToValidate
     | Processing
     | RequiresIndexDocuments
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText OptionState where
     parser = takeLowerText >>= \case
@@ -286,7 +286,7 @@ data PartitionInstanceType
     | Search_M3_Large
     | Search_M3_Medium
     | Search_M3_XLarge
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText PartitionInstanceType where
     parser = takeLowerText >>= \case
@@ -324,7 +324,7 @@ data SuggesterFuzzyMatching
     = High
     | Low
     | None
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText SuggesterFuzzyMatching where
     parser = takeLowerText >>= \case

--- a/amazonka-cloudtrail/gen/Network/AWS/CloudTrail/Types/Sum.hs
+++ b/amazonka-cloudtrail/gen/Network/AWS/CloudTrail/Types/Sum.hs
@@ -25,7 +25,7 @@ data LookupAttributeKey
     | ResourceName
     | ResourceType
     | Username
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText LookupAttributeKey where
     parser = takeLowerText >>= \case

--- a/amazonka-cloudwatch-logs/gen/Network/AWS/CloudWatchLogs/Types/Sum.hs
+++ b/amazonka-cloudwatch-logs/gen/Network/AWS/CloudWatchLogs/Types/Sum.hs
@@ -26,7 +26,7 @@ data ExportTaskStatusCode
     | Pending
     | PendingCancel
     | Running
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ExportTaskStatusCode where
     parser = takeLowerText >>= \case
@@ -62,7 +62,7 @@ instance FromJSON ExportTaskStatusCode where
 data OrderBy
     = LastEventTime
     | LogStreamName
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText OrderBy where
     parser = takeLowerText >>= \case

--- a/amazonka-cloudwatch/gen/Network/AWS/CloudWatch/Types/Sum.hs
+++ b/amazonka-cloudwatch/gen/Network/AWS/CloudWatch/Types/Sum.hs
@@ -24,7 +24,7 @@ data ComparisonOperator
     | GreaterThanThreshold
     | LessThanOrEqualToThreshold
     | LessThanThreshold
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ComparisonOperator where
     parser = takeLowerText >>= \case
@@ -54,7 +54,7 @@ data HistoryItemType
     = Action
     | ConfigurationUpdate
     | StateUpdate
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText HistoryItemType where
     parser = takeLowerText >>= \case
@@ -106,7 +106,7 @@ data StandardUnit
     | TerabitsSecond
     | Terabytes
     | TerabytesSecond
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText StandardUnit where
     parser = takeLowerText >>= \case
@@ -182,7 +182,7 @@ data StateValue
     = Alarm
     | InsufficientData
     | OK
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText StateValue where
     parser = takeLowerText >>= \case
@@ -212,7 +212,7 @@ data Statistic
     | Minimum
     | SampleCount
     | Sum
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText Statistic where
     parser = takeLowerText >>= \case

--- a/amazonka-codecommit/gen/Network/AWS/CodeCommit/Types/Sum.hs
+++ b/amazonka-codecommit/gen/Network/AWS/CodeCommit/Types/Sum.hs
@@ -22,7 +22,7 @@ import           Network.AWS.Prelude
 data OrderEnum
     = Ascending
     | Descending
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText OrderEnum where
     parser = takeLowerText >>= \case
@@ -47,7 +47,7 @@ instance ToJSON OrderEnum where
 data SortByEnum
     = LastModifiedDate
     | RepositoryName
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText SortByEnum where
     parser = takeLowerText >>= \case

--- a/amazonka-codedeploy/gen/Network/AWS/CodeDeploy/Types/Sum.hs
+++ b/amazonka-codedeploy/gen/Network/AWS/CodeDeploy/Types/Sum.hs
@@ -23,7 +23,7 @@ data ApplicationRevisionSortBy
     = FirstUsedTime
     | LastUsedTime
     | RegisterTime
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ApplicationRevisionSortBy where
     parser = takeLowerText >>= \case
@@ -51,7 +51,7 @@ data BundleType
     = TAR
     | TGZ
     | Zip
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText BundleType where
     parser = takeLowerText >>= \case
@@ -92,7 +92,7 @@ data DeployErrorCode
     | RevisionMissing
     | Throttled
     | Timeout
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DeployErrorCode where
     parser = takeLowerText >>= \case
@@ -139,7 +139,7 @@ instance FromJSON DeployErrorCode where
 data DeploymentCreator
     = Autoscaling
     | User
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DeploymentCreator where
     parser = takeLowerText >>= \case
@@ -168,7 +168,7 @@ data DeploymentStatus
     | Queued
     | Stopped
     | Succeeded
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DeploymentStatus where
     parser = takeLowerText >>= \case
@@ -205,7 +205,7 @@ data EC2TagFilterType
     = KeyAndValue
     | KeyOnly
     | ValueOnly
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText EC2TagFilterType where
     parser = takeLowerText >>= \case
@@ -239,7 +239,7 @@ data InstanceStatus
     | ISSkipped
     | ISSucceeded
     | ISUnknown
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText InstanceStatus where
     parser = takeLowerText >>= \case
@@ -279,7 +279,7 @@ data LifecycleErrorCode
     | ScriptTimedOut
     | Success
     | UnknownError
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText LifecycleErrorCode where
     parser = takeLowerText >>= \case
@@ -316,7 +316,7 @@ data LifecycleEventStatus
     | LESSkipped
     | LESSucceeded
     | LESUnknown
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText LifecycleEventStatus where
     parser = takeLowerText >>= \case
@@ -350,7 +350,7 @@ data ListStateFilterAction
     = Exclude
     | Ignore
     | Include
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ListStateFilterAction where
     parser = takeLowerText >>= \case
@@ -377,7 +377,7 @@ instance ToJSON ListStateFilterAction where
 data MinimumHealthyHostsType
     = FleetPercent
     | HostCount
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText MinimumHealthyHostsType where
     parser = takeLowerText >>= \case
@@ -405,7 +405,7 @@ instance FromJSON MinimumHealthyHostsType where
 data RegistrationStatus
     = Deregistered
     | Registered
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText RegistrationStatus where
     parser = takeLowerText >>= \case
@@ -430,7 +430,7 @@ instance ToJSON RegistrationStatus where
 data RevisionLocationType
     = GitHub
     | S3
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText RevisionLocationType where
     parser = takeLowerText >>= \case
@@ -458,7 +458,7 @@ instance FromJSON RevisionLocationType where
 data SortOrder
     = Ascending
     | Descending
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText SortOrder where
     parser = takeLowerText >>= \case
@@ -483,7 +483,7 @@ instance ToJSON SortOrder where
 data StopStatus
     = SSPending
     | SSSucceeded
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText StopStatus where
     parser = takeLowerText >>= \case
@@ -509,7 +509,7 @@ data TagFilterType
     = TFTKeyAndValue
     | TFTKeyOnly
     | TFTValueOnly
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText TagFilterType where
     parser = takeLowerText >>= \case

--- a/amazonka-codepipeline/gen/Network/AWS/CodePipeline/Types/Sum.hs
+++ b/amazonka-codepipeline/gen/Network/AWS/CodePipeline/Types/Sum.hs
@@ -25,7 +25,7 @@ data ActionCategory
     | Invoke
     | Source
     | Test
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ActionCategory where
     parser = takeLowerText >>= \case
@@ -60,7 +60,7 @@ data ActionConfigurationPropertyType
     = Boolean
     | Number
     | String
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ActionConfigurationPropertyType where
     parser = takeLowerText >>= \case
@@ -91,7 +91,7 @@ data ActionExecutionStatus
     = Failed
     | InProgress
     | Succeeded
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ActionExecutionStatus where
     parser = takeLowerText >>= \case
@@ -119,7 +119,7 @@ data ActionOwner
     = AWS
     | Custom
     | ThirdParty
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ActionOwner where
     parser = takeLowerText >>= \case
@@ -148,7 +148,7 @@ instance FromJSON ActionOwner where
 
 data ArtifactLocationType =
     ALTS3
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ArtifactLocationType where
     parser = takeLowerText >>= \case
@@ -170,7 +170,7 @@ instance FromJSON ArtifactLocationType where
 
 data ArtifactStoreType =
     S3
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ArtifactStoreType where
     parser = takeLowerText >>= \case
@@ -195,7 +195,7 @@ instance FromJSON ArtifactStoreType where
 
 data BlockerType =
     Schedule
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText BlockerType where
     parser = takeLowerText >>= \case
@@ -220,7 +220,7 @@ instance FromJSON BlockerType where
 
 data EncryptionKeyType =
     KMS
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText EncryptionKeyType where
     parser = takeLowerText >>= \case
@@ -250,7 +250,7 @@ data FailureType
     | RevisionOutOfSync
     | RevisionUnavailable
     | SystemUnavailable
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText FailureType where
     parser = takeLowerText >>= \case
@@ -288,7 +288,7 @@ data JobStatus
     | JSQueued
     | JSSucceeded
     | JSTimedOut
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText JobStatus where
     parser = takeLowerText >>= \case
@@ -323,7 +323,7 @@ instance FromJSON JobStatus where
 data StageTransitionType
     = Inbound
     | Outbound
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText StageTransitionType where
     parser = takeLowerText >>= \case

--- a/amazonka-cognito-identity/gen/Network/AWS/CognitoIdentity/Types/Sum.hs
+++ b/amazonka-cognito-identity/gen/Network/AWS/CognitoIdentity/Types/Sum.hs
@@ -22,7 +22,7 @@ import           Network.AWS.Prelude
 data CognitoErrorCode
     = AccessDenied
     | InternalServerError
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText CognitoErrorCode where
     parser = takeLowerText >>= \case

--- a/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/Types/Sum.hs
+++ b/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/Types/Sum.hs
@@ -24,7 +24,7 @@ data BulkPublishStatus
     | InProgress
     | NotStarted
     | Succeeded
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText BulkPublishStatus where
     parser = takeLowerText >>= \case
@@ -53,7 +53,7 @@ instance FromJSON BulkPublishStatus where
 data Operation
     = Remove
     | Replace
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText Operation where
     parser = takeLowerText >>= \case
@@ -80,7 +80,7 @@ data Platform
     | APNS
     | APNSSandbox
     | GCM
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText Platform where
     parser = takeLowerText >>= \case
@@ -109,7 +109,7 @@ instance ToJSON Platform where
 data StreamingStatus
     = Disabled
     | Enabled
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText StreamingStatus where
     parser = takeLowerText >>= \case

--- a/amazonka-config/gen/Network/AWS/Config/Types/Sum.hs
+++ b/amazonka-config/gen/Network/AWS/Config/Types/Sum.hs
@@ -22,7 +22,7 @@ import           Network.AWS.Prelude
 data ChronologicalOrder
     = Forward
     | Reverse
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ChronologicalOrder where
     parser = takeLowerText >>= \case
@@ -49,7 +49,7 @@ data ComplianceType
     | InsufficientData
     | NonCompliant
     | NotApplicable
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ComplianceType where
     parser = takeLowerText >>= \case
@@ -81,7 +81,7 @@ instance FromJSON ComplianceType where
 data ConfigRuleState
     = Active
     | Deleting
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ConfigRuleState where
     parser = takeLowerText >>= \case
@@ -111,7 +111,7 @@ data ConfigurationItemStatus
     | Discovered
     | Failed
     | OK
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ConfigurationItemStatus where
     parser = takeLowerText >>= \case
@@ -141,7 +141,7 @@ data DeliveryStatus
     = DSFailure
     | DSNotApplicable
     | DSSuccess
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DeliveryStatus where
     parser = takeLowerText >>= \case
@@ -167,7 +167,7 @@ instance FromJSON DeliveryStatus where
 
 data EventSource =
     AWS_Config
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText EventSource where
     parser = takeLowerText >>= \case
@@ -196,7 +196,7 @@ data MaximumExecutionFrequency
     | ThreeHours
     | TwelveHours
     | TwentyFourHours
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText MaximumExecutionFrequency where
     parser = takeLowerText >>= \case
@@ -230,7 +230,7 @@ instance FromJSON MaximumExecutionFrequency where
 data MessageType
     = ConfigurationItemChangeNotification
     | ConfigurationSnapshotDeliveryCompleted
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText MessageType where
     parser = takeLowerText >>= \case
@@ -258,7 +258,7 @@ instance FromJSON MessageType where
 data Owner
     = AWS
     | CustomLambda
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText Owner where
     parser = takeLowerText >>= \case
@@ -287,7 +287,7 @@ data RecorderStatus
     = Failure
     | Pending
     | Success
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText RecorderStatus where
     parser = takeLowerText >>= \case
@@ -326,7 +326,7 @@ data ResourceType
     | AWSEC2VPNConnection
     | AWSEC2VPNGateway
     | AWSEC2Volume
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ResourceType where
     parser = takeLowerText >>= \case

--- a/amazonka-datapipeline/gen/Network/AWS/DataPipeline/Types/Sum.hs
+++ b/amazonka-datapipeline/gen/Network/AWS/DataPipeline/Types/Sum.hs
@@ -25,7 +25,7 @@ data OperatorType
     | OperatorGE
     | OperatorLE
     | OperatorRefEQ
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText OperatorType where
     parser = takeLowerText >>= \case
@@ -57,7 +57,7 @@ data TaskStatus
     = Failed
     | False'
     | Finished
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText TaskStatus where
     parser = takeLowerText >>= \case

--- a/amazonka-devicefarm/gen/Network/AWS/DeviceFarm/Types/Sum.hs
+++ b/amazonka-devicefarm/gen/Network/AWS/DeviceFarm/Types/Sum.hs
@@ -23,7 +23,7 @@ data ArtifactCategory
     = ACFile
     | ACLog
     | ACScreenshot
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ArtifactCategory where
     parser = takeLowerText >>= \case
@@ -67,7 +67,7 @@ data ArtifactType
     | Screenshot
     | ServiceLog
     | Unknown
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ArtifactType where
     parser = takeLowerText >>= \case
@@ -126,7 +126,7 @@ instance FromJSON ArtifactType where
 data BillingMethod
     = Metered
     | Unmetered
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText BillingMethod where
     parser = takeLowerText >>= \case
@@ -156,7 +156,7 @@ data DeviceAttribute
     | FormFactor
     | Manufacturer
     | Platform
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DeviceAttribute where
     parser = takeLowerText >>= \case
@@ -188,7 +188,7 @@ instance FromJSON DeviceAttribute where
 data DeviceFormFactor
     = Phone
     | Tablet
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DeviceFormFactor where
     parser = takeLowerText >>= \case
@@ -213,7 +213,7 @@ instance FromJSON DeviceFormFactor where
 data DevicePlatform
     = Android
     | Ios
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DevicePlatform where
     parser = takeLowerText >>= \case
@@ -238,7 +238,7 @@ instance FromJSON DevicePlatform where
 data DevicePoolType
     = Curated
     | Private
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DevicePoolType where
     parser = takeLowerText >>= \case
@@ -271,7 +271,7 @@ data ExecutionResult
     | ERSkipped
     | ERStopped
     | ERWarned
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ExecutionResult where
     parser = takeLowerText >>= \case
@@ -309,7 +309,7 @@ data ExecutionStatus
     | Processing
     | Running
     | Scheduling
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ExecutionStatus where
     parser = takeLowerText >>= \case
@@ -343,7 +343,7 @@ data RuleOperator
     | IN
     | LessThan
     | NotIn
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText RuleOperator where
     parser = takeLowerText >>= \case
@@ -392,7 +392,7 @@ data SampleType
     | TX
     | Threads
     | TxRate
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText SampleType where
     parser = takeLowerText >>= \case
@@ -454,7 +454,7 @@ data TestType
     | Uiautomation
     | Uiautomator
     | Xctest
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText TestType where
     parser = takeLowerText >>= \case
@@ -498,7 +498,7 @@ data UploadStatus
     | USInitialized
     | USProcessing
     | USSucceeded
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText UploadStatus where
     parser = takeLowerText >>= \case
@@ -535,7 +535,7 @@ data UploadType
     | UiautomationTestPackage
     | UiautomatorTestPackage
     | XctestTestPackage
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText UploadType where
     parser = takeLowerText >>= \case

--- a/amazonka-directconnect/gen/Network/AWS/DirectConnect/Types/Sum.hs
+++ b/amazonka-directconnect/gen/Network/AWS/DirectConnect/Types/Sum.hs
@@ -45,7 +45,7 @@ data ConnectionState
     | CSPending
     | CSRejected
     | CSRequested
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ConnectionState where
     parser = takeLowerText >>= \case
@@ -97,7 +97,7 @@ data InterconnectState
     | ISDown
     | ISPending
     | ISRequested
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText InterconnectState where
     parser = takeLowerText >>= \case
@@ -157,7 +157,7 @@ data VirtualInterfaceState
     | Pending
     | Rejected
     | Verifying
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText VirtualInterfaceState where
     parser = takeLowerText >>= \case

--- a/amazonka-ds/gen/Network/AWS/DirectoryService/Types/Sum.hs
+++ b/amazonka-ds/gen/Network/AWS/DirectoryService/Types/Sum.hs
@@ -22,7 +22,7 @@ import           Network.AWS.Prelude
 data DirectorySize
     = Large
     | Small
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DirectorySize where
     parser = takeLowerText >>= \case
@@ -59,7 +59,7 @@ data DirectoryStage
     | DSRequested
     | DSRestoreFailed
     | DSRestoring
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DirectoryStage where
     parser = takeLowerText >>= \case
@@ -102,7 +102,7 @@ instance FromJSON DirectoryStage where
 data DirectoryType
     = ADConnector
     | SimpleAD
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DirectoryType where
     parser = takeLowerText >>= \case
@@ -129,7 +129,7 @@ data RadiusAuthenticationProtocol
     | MsCHAPV1
     | MsCHAPV2
     | Pap
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText RadiusAuthenticationProtocol where
     parser = takeLowerText >>= \case
@@ -162,7 +162,7 @@ data RadiusStatus
     = Completed
     | Creating
     | Failed
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText RadiusStatus where
     parser = takeLowerText >>= \case
@@ -190,7 +190,7 @@ data SnapshotStatus
     = SSCompleted
     | SSCreating
     | SSFailed
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText SnapshotStatus where
     parser = takeLowerText >>= \case
@@ -217,7 +217,7 @@ instance FromJSON SnapshotStatus where
 data SnapshotType
     = Auto
     | Manual
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText SnapshotType where
     parser = takeLowerText >>= \case

--- a/amazonka-dynamodb-streams/gen/Network/AWS/DynamoDBStreams/Types/Sum.hs
+++ b/amazonka-dynamodb-streams/gen/Network/AWS/DynamoDBStreams/Types/Sum.hs
@@ -22,7 +22,7 @@ import           Network.AWS.Prelude
 data KeyType
     = Hash
     | Range
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText KeyType where
     parser = takeLowerText >>= \case
@@ -48,7 +48,7 @@ data OperationType
     = Insert
     | Modify
     | Remove
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText OperationType where
     parser = takeLowerText >>= \case
@@ -77,7 +77,7 @@ data ShardIteratorType
     | AtSequenceNumber
     | Latest
     | TrimHorizon
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ShardIteratorType where
     parser = takeLowerText >>= \case
@@ -108,7 +108,7 @@ data StreamStatus
     | Disabling
     | Enabled
     | Enabling
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText StreamStatus where
     parser = takeLowerText >>= \case
@@ -139,7 +139,7 @@ data StreamViewType
     | NewAndOldImages
     | NewImage
     | OldImage
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText StreamViewType where
     parser = takeLowerText >>= \case

--- a/amazonka-dynamodb/gen/Network/AWS/DynamoDB/Types/Sum.hs
+++ b/amazonka-dynamodb/gen/Network/AWS/DynamoDB/Types/Sum.hs
@@ -23,7 +23,7 @@ data AttributeAction
     = Add
     | Delete
     | Put
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText AttributeAction where
     parser = takeLowerText >>= \case
@@ -61,7 +61,7 @@ data ComparisonOperator
     | NotContains
     | NotNull
     | Null
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ComparisonOperator where
     parser = takeLowerText >>= \case
@@ -108,7 +108,7 @@ instance ToJSON ComparisonOperator where
 data ConditionalOperator
     = And
     | OR
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ConditionalOperator where
     parser = takeLowerText >>= \case
@@ -135,7 +135,7 @@ data IndexStatus
     | ISCreating
     | ISDeleting
     | ISUpdating
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText IndexStatus where
     parser = takeLowerText >>= \case
@@ -164,7 +164,7 @@ instance FromJSON IndexStatus where
 data KeyType
     = Hash
     | Range
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText KeyType where
     parser = takeLowerText >>= \case
@@ -193,7 +193,7 @@ data ProjectionType
     = All
     | Include
     | KeysOnly
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ProjectionType where
     parser = takeLowerText >>= \case
@@ -240,7 +240,7 @@ data ReturnConsumedCapacity
     = RCCIndexes
     | RCCNone
     | RCCTotal
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ReturnConsumedCapacity where
     parser = takeLowerText >>= \case
@@ -267,7 +267,7 @@ instance ToJSON ReturnConsumedCapacity where
 data ReturnItemCollectionMetrics
     = RICMNone
     | RICMSize
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ReturnItemCollectionMetrics where
     parser = takeLowerText >>= \case
@@ -295,7 +295,7 @@ data ReturnValue
     | None
     | UpdatedNew
     | UpdatedOld
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ReturnValue where
     parser = takeLowerText >>= \case
@@ -327,7 +327,7 @@ data ScalarAttributeType
     = B
     | N
     | S
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ScalarAttributeType where
     parser = takeLowerText >>= \case
@@ -359,7 +359,7 @@ data Select
     | AllProjectedAttributes
     | Count
     | SpecificAttributes
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText Select where
     parser = takeLowerText >>= \case
@@ -390,7 +390,7 @@ data StreamViewType
     | SVTNewAndOldImages
     | SVTNewImage
     | SVTOldImage
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText StreamViewType where
     parser = takeLowerText >>= \case
@@ -424,7 +424,7 @@ data TableStatus
     | Creating
     | Deleting
     | Updating
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText TableStatus where
     parser = takeLowerText >>= \case

--- a/amazonka-ec2/gen/Network/AWS/EC2/Types/Sum.hs
+++ b/amazonka-ec2/gen/Network/AWS/EC2/Types/Sum.hs
@@ -22,7 +22,7 @@ import           Network.AWS.Prelude
 data AccountAttributeName
     = DefaultVPC
     | SupportedPlatforms
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText AccountAttributeName where
     parser = takeLowerText >>= \case
@@ -45,7 +45,7 @@ data AddressStatus
     = InClassic
     | InVPC
     | MoveInProgress
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText AddressStatus where
     parser = takeLowerText >>= \case
@@ -72,7 +72,7 @@ instance FromXML AddressStatus where
 data AllocationStrategy
     = Diversified
     | LowestPrice
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText AllocationStrategy where
     parser = takeLowerText >>= \case
@@ -97,7 +97,7 @@ instance FromXML AllocationStrategy where
 data ArchitectureValues
     = I386
     | X86_64
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ArchitectureValues where
     parser = takeLowerText >>= \case
@@ -125,7 +125,7 @@ data AttachmentStatus
     | Busy
     | Detached
     | Detaching
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText AttachmentStatus where
     parser = takeLowerText >>= \case
@@ -158,7 +158,7 @@ data AvailabilityZoneState
     | AZSImpaired
     | AZSInformation
     | AZSUnavailable
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText AvailabilityZoneState where
     parser = takeLowerText >>= \case
@@ -192,7 +192,7 @@ data BatchState
     | BSFailed
     | BSModifying
     | BSSubmitted
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText BatchState where
     parser = takeLowerText >>= \case
@@ -232,7 +232,7 @@ data BundleTaskState
     | BTSPending
     | BTSStoring
     | BTSWaitingForShutdown
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText BundleTaskState where
     parser = takeLowerText >>= \case
@@ -269,7 +269,7 @@ data CancelBatchErrorCode
     | FleetRequestIdMalformed
     | FleetRequestNotInCancellableState
     | UnexpectedError
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText CancelBatchErrorCode where
     parser = takeLowerText >>= \case
@@ -301,7 +301,7 @@ data CancelSpotInstanceRequestState
     | CSIRSClosed
     | CSIRSCompleted
     | CSIRSOpen
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText CancelSpotInstanceRequestState where
     parser = takeLowerText >>= \case
@@ -331,7 +331,7 @@ instance FromXML CancelSpotInstanceRequestState where
 
 data ContainerFormat =
     Ova
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ContainerFormat where
     parser = takeLowerText >>= \case
@@ -356,7 +356,7 @@ data ConversionTaskState
     | CTSCancelled
     | CTSCancelling
     | CTSCompleted
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ConversionTaskState where
     parser = takeLowerText >>= \case
@@ -384,7 +384,7 @@ instance FromXML ConversionTaskState where
 
 data CurrencyCodeValues =
     Usd
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText CurrencyCodeValues where
     parser = takeLowerText >>= \case
@@ -407,7 +407,7 @@ instance FromXML CurrencyCodeValues where
 data DatafeedSubscriptionState
     = DSSActive
     | DSSInactive
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DatafeedSubscriptionState where
     parser = takeLowerText >>= \case
@@ -432,7 +432,7 @@ instance FromXML DatafeedSubscriptionState where
 data DeviceType
     = EBS
     | InstanceStore
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DeviceType where
     parser = takeLowerText >>= \case
@@ -458,7 +458,7 @@ data DiskImageFormat
     = Raw
     | VHD
     | VMDK
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DiskImageFormat where
     parser = takeLowerText >>= \case
@@ -485,7 +485,7 @@ instance FromXML DiskImageFormat where
 data DomainType
     = DTStandard
     | DTVPC
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DomainType where
     parser = takeLowerText >>= \case
@@ -513,7 +513,7 @@ data EventCode
     | InstanceStop
     | SystemMaintenance
     | SystemReboot
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText EventCode where
     parser = takeLowerText >>= \case
@@ -545,7 +545,7 @@ data EventType
     = Error'
     | FleetRequestChange
     | InstanceChange
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText EventType where
     parser = takeLowerText >>= \case
@@ -572,7 +572,7 @@ instance FromXML EventType where
 data ExcessCapacityTerminationPolicy
     = ECTPDefault
     | ECTPNoTermination
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ExcessCapacityTerminationPolicy where
     parser = takeLowerText >>= \case
@@ -598,7 +598,7 @@ data ExportEnvironment
     = Citrix
     | Microsoft
     | VMware
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ExportEnvironment where
     parser = takeLowerText >>= \case
@@ -627,7 +627,7 @@ data ExportTaskState
     | ETSCancelled
     | ETSCancelling
     | ETSCompleted
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ExportTaskState where
     parser = takeLowerText >>= \case
@@ -657,7 +657,7 @@ data FlowLogsResourceType
     = FLRTNetworkInterface
     | FLRTSubnet
     | FLRTVPC
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText FlowLogsResourceType where
     parser = takeLowerText >>= \case
@@ -680,7 +680,7 @@ instance ToHeader     FlowLogsResourceType
 
 data GatewayType =
     IPsec_1
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText GatewayType where
     parser = takeLowerText >>= \case
@@ -703,7 +703,7 @@ instance FromXML GatewayType where
 data HypervisorType
     = Ovm
     | Xen
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText HypervisorType where
     parser = takeLowerText >>= \case
@@ -733,7 +733,7 @@ data ImageAttributeName
     | ProductCodes
     | RAMDisk
     | SRIOVNetSupport
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ImageAttributeName where
     parser = takeLowerText >>= \case
@@ -770,7 +770,7 @@ data ImageState
     | ISInvalid
     | ISPending
     | ISTransient
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ImageState where
     parser = takeLowerText >>= \case
@@ -806,7 +806,7 @@ data ImageTypeValues
     = ITVKernel
     | ITVMachine
     | ITVRAMDisk
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ImageTypeValues where
     parser = takeLowerText >>= \case
@@ -844,7 +844,7 @@ data InstanceAttributeName
     | IANSRIOVNetSupport
     | IANSourceDestCheck
     | IANUserData
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText InstanceAttributeName where
     parser = takeLowerText >>= \case
@@ -887,7 +887,7 @@ instance ToHeader     InstanceAttributeName
 
 data InstanceLifecycleType =
     Spot
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText InstanceLifecycleType where
     parser = takeLowerText >>= \case
@@ -914,7 +914,7 @@ data InstanceStateName
     | ISNStopped
     | ISNStopping
     | ISNTerminated
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText InstanceStateName where
     parser = takeLowerText >>= \case
@@ -998,7 +998,7 @@ data InstanceType
     | T2_Medium
     | T2_Micro
     | T2_Small
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText InstanceType where
     parser = takeLowerText >>= \case
@@ -1127,7 +1127,7 @@ data ListingState
     | LCancelled
     | LPending
     | LSold
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ListingState where
     parser = takeLowerText >>= \case
@@ -1158,7 +1158,7 @@ data ListingStatus
     | LSCancelled
     | LSClosed
     | LSPending
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ListingStatus where
     parser = takeLowerText >>= \case
@@ -1189,7 +1189,7 @@ data MonitoringState
     | MSDisabling
     | MSEnabled
     | MSPending
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText MonitoringState where
     parser = takeLowerText >>= \case
@@ -1218,7 +1218,7 @@ instance FromXML MonitoringState where
 data MoveStatus
     = MovingToVPC
     | RestoringToClassic
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText MoveStatus where
     parser = takeLowerText >>= \case
@@ -1245,7 +1245,7 @@ data NetworkInterfaceAttribute
     | NIADescription
     | NIAGroupSet
     | NIASourceDestCheck
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText NetworkInterfaceAttribute where
     parser = takeLowerText >>= \case
@@ -1273,7 +1273,7 @@ data NetworkInterfaceStatus
     | NISAvailable
     | NISDetaching
     | NISInUse
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText NetworkInterfaceStatus where
     parser = takeLowerText >>= \case
@@ -1306,7 +1306,7 @@ data OfferingTypeValues
     | MediumUtilization
     | NoUpfront
     | PartialUpfront
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText OfferingTypeValues where
     parser = takeLowerText >>= \case
@@ -1339,7 +1339,7 @@ instance FromXML OfferingTypeValues where
 data OperationType
     = Add
     | Remove
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText OperationType where
     parser = takeLowerText >>= \case
@@ -1360,7 +1360,7 @@ instance ToHeader     OperationType
 
 data PermissionGroup =
     All
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText PermissionGroup where
     parser = takeLowerText >>= \case
@@ -1385,7 +1385,7 @@ data PlacementGroupState
     | Deleted
     | Deleting
     | Pending
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText PlacementGroupState where
     parser = takeLowerText >>= \case
@@ -1413,7 +1413,7 @@ instance FromXML PlacementGroupState where
 
 data PlacementStrategy =
     Cluster
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText PlacementStrategy where
     parser = takeLowerText >>= \case
@@ -1435,7 +1435,7 @@ instance FromXML PlacementStrategy where
 
 data PlatformValues =
     Windows
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText PlatformValues where
     parser = takeLowerText >>= \case
@@ -1458,7 +1458,7 @@ instance FromXML PlatformValues where
 data ProductCodeValues
     = Devpay
     | Marketplace
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ProductCodeValues where
     parser = takeLowerText >>= \case
@@ -1485,7 +1485,7 @@ data RIProductDescription
     | RIDLinuxUnixAmazonVPC
     | RIDWindows
     | RIDWindowsAmazonVPC
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText RIProductDescription where
     parser = takeLowerText >>= \case
@@ -1513,7 +1513,7 @@ instance FromXML RIProductDescription where
 
 data RecurringChargeFrequency =
     Hourly
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText RecurringChargeFrequency where
     parser = takeLowerText >>= \case
@@ -1543,7 +1543,7 @@ data ReportInstanceReasonCodes
     | PerformanceNetwork
     | PerformanceOther
     | Unresponsive
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ReportInstanceReasonCodes where
     parser = takeLowerText >>= \case
@@ -1579,7 +1579,7 @@ instance ToHeader     ReportInstanceReasonCodes
 data ReportStatusType
     = RSTImpaired
     | RSTOK
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ReportStatusType where
     parser = takeLowerText >>= \case
@@ -1603,7 +1603,7 @@ data ReservedInstanceState
     | PaymentFailed
     | PaymentPending
     | Retired
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ReservedInstanceState where
     parser = takeLowerText >>= \case
@@ -1631,7 +1631,7 @@ instance FromXML ReservedInstanceState where
 
 data ResetImageAttributeName =
     RIANLaunchPermission
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ResetImageAttributeName where
     parser = takeLowerText >>= \case
@@ -1666,7 +1666,7 @@ data ResourceType
     | VPNConnection
     | VPNGateway
     | Volume
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ResourceType where
     parser = takeLowerText >>= \case
@@ -1722,7 +1722,7 @@ data RouteOrigin
     = CreateRoute
     | CreateRouteTable
     | EnableVGWRoutePropagation
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText RouteOrigin where
     parser = takeLowerText >>= \case
@@ -1749,7 +1749,7 @@ instance FromXML RouteOrigin where
 data RouteState
     = RSActive
     | RSBlackhole
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText RouteState where
     parser = takeLowerText >>= \case
@@ -1774,7 +1774,7 @@ instance FromXML RouteState where
 data RuleAction
     = Allow
     | Deny
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText RuleAction where
     parser = takeLowerText >>= \case
@@ -1799,7 +1799,7 @@ instance FromXML RuleAction where
 data ShutdownBehavior
     = Stop
     | Terminate
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ShutdownBehavior where
     parser = takeLowerText >>= \case
@@ -1821,7 +1821,7 @@ instance ToHeader     ShutdownBehavior
 data SnapshotAttributeName
     = SANCreateVolumePermission
     | SANProductCodes
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText SnapshotAttributeName where
     parser = takeLowerText >>= \case
@@ -1844,7 +1844,7 @@ data SnapshotState
     = SSCompleted
     | SSError'
     | SSPending
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText SnapshotState where
     parser = takeLowerText >>= \case
@@ -1874,7 +1874,7 @@ data SpotInstanceState
     | SISClosed
     | SISFailed
     | SISOpen
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText SpotInstanceState where
     parser = takeLowerText >>= \case
@@ -1905,7 +1905,7 @@ instance FromXML SpotInstanceState where
 data SpotInstanceType
     = OneTime
     | Persistent
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText SpotInstanceType where
     parser = takeLowerText >>= \case
@@ -1932,7 +1932,7 @@ data State
     | SDeleted
     | SDeleting
     | SPending
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText State where
     parser = takeLowerText >>= \case
@@ -1960,7 +1960,7 @@ instance FromXML State where
 
 data StatusName =
     Reachability
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText StatusName where
     parser = takeLowerText >>= \case
@@ -1985,7 +1985,7 @@ data StatusType
     | STInitializing
     | STInsufficientData
     | STPassed
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText StatusType where
     parser = takeLowerText >>= \case
@@ -2014,7 +2014,7 @@ instance FromXML StatusType where
 data SubnetState
     = SubAvailable
     | SubPending
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText SubnetState where
     parser = takeLowerText >>= \case
@@ -2042,7 +2042,7 @@ data SummaryStatus
     | SSInsufficientData
     | SSNotApplicable
     | SSOK
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText SummaryStatus where
     parser = takeLowerText >>= \case
@@ -2073,7 +2073,7 @@ instance FromXML SummaryStatus where
 data TelemetryStatus
     = Down
     | UP
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText TelemetryStatus where
     parser = takeLowerText >>= \case
@@ -2098,7 +2098,7 @@ instance FromXML TelemetryStatus where
 data Tenancy
     = Dedicated
     | Default
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText Tenancy where
     parser = takeLowerText >>= \case
@@ -2124,7 +2124,7 @@ data TrafficType
     = TTAccept
     | TTAll
     | TTReject
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText TrafficType where
     parser = takeLowerText >>= \case
@@ -2151,7 +2151,7 @@ instance FromXML TrafficType where
 data VPCAttributeName
     = EnableDNSHostnames
     | EnableDNSSupport
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText VPCAttributeName where
     parser = takeLowerText >>= \case
@@ -2180,7 +2180,7 @@ data VPCPeeringConnectionStateReasonCode
     | VPCSRCPendingAcceptance
     | VPCSRCProvisioning
     | VPCSRCRejected
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText VPCPeeringConnectionStateReasonCode where
     parser = takeLowerText >>= \case
@@ -2219,7 +2219,7 @@ instance FromXML VPCPeeringConnectionStateReasonCode where
 data VPCState
     = VPCSAvailable
     | VPCSPending
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText VPCState where
     parser = takeLowerText >>= \case
@@ -2246,7 +2246,7 @@ data VPNState
     | VSDeleted
     | VSDeleting
     | VSPending
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText VPNState where
     parser = takeLowerText >>= \case
@@ -2274,7 +2274,7 @@ instance FromXML VPNState where
 
 data VPNStaticRouteSource =
     Static
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText VPNStaticRouteSource where
     parser = takeLowerText >>= \case
@@ -2297,7 +2297,7 @@ instance FromXML VPNStaticRouteSource where
 data VirtualizationType
     = HVM
     | Paravirtual
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText VirtualizationType where
     parser = takeLowerText >>= \case
@@ -2325,7 +2325,7 @@ data VolumeAttachmentState
     | VASBusy
     | VASDetached
     | VASDetaching
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText VolumeAttachmentState where
     parser = takeLowerText >>= \case
@@ -2356,7 +2356,7 @@ instance FromXML VolumeAttachmentState where
 data VolumeAttributeName
     = VANAutoEnableIO
     | VANProductCodes
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText VolumeAttributeName where
     parser = takeLowerText >>= \case
@@ -2382,7 +2382,7 @@ data VolumeState
     | VDeleting
     | VError'
     | VInUse
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText VolumeState where
     parser = takeLowerText >>= \case
@@ -2416,7 +2416,7 @@ data VolumeStatusInfoStatus
     = Impaired
     | InsufficientData
     | OK
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText VolumeStatusInfoStatus where
     parser = takeLowerText >>= \case
@@ -2443,7 +2443,7 @@ instance FromXML VolumeStatusInfoStatus where
 data VolumeStatusName
     = IOEnabled
     | IOPerformance
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText VolumeStatusName where
     parser = takeLowerText >>= \case
@@ -2469,7 +2469,7 @@ data VolumeType
     = GP2
     | IO1
     | Standard
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText VolumeType where
     parser = takeLowerText >>= \case

--- a/amazonka-ecs/gen/Network/AWS/ECS/Types/Sum.hs
+++ b/amazonka-ecs/gen/Network/AWS/ECS/Types/Sum.hs
@@ -26,7 +26,7 @@ data AgentUpdateStatus
     | AUSStaging
     | AUSUpdated
     | AUSUpdating
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText AgentUpdateStatus where
     parser = takeLowerText >>= \case
@@ -60,7 +60,7 @@ data DesiredStatus
     = Pending
     | Running
     | Stopped
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DesiredStatus where
     parser = takeLowerText >>= \case
@@ -90,7 +90,7 @@ data LogDriver
     | JSONFile
     | Journald
     | Syslog
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText LogDriver where
     parser = takeLowerText >>= \case
@@ -124,7 +124,7 @@ instance FromJSON LogDriver where
 data SortOrder
     = Asc
     | Desc
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText SortOrder where
     parser = takeLowerText >>= \case
@@ -149,7 +149,7 @@ instance ToJSON SortOrder where
 data TaskDefinitionStatus
     = Active
     | Inactive
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText TaskDefinitionStatus where
     parser = takeLowerText >>= \case
@@ -177,7 +177,7 @@ instance FromJSON TaskDefinitionStatus where
 data TransportProtocol
     = TCP
     | Udp
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText TransportProtocol where
     parser = takeLowerText >>= \case
@@ -218,7 +218,7 @@ data UlimitName
     | Rttime
     | Sigpending
     | Stack
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText UlimitName where
     parser = takeLowerText >>= \case

--- a/amazonka-efs/gen/Network/AWS/EFS/Types/Sum.hs
+++ b/amazonka-efs/gen/Network/AWS/EFS/Types/Sum.hs
@@ -24,7 +24,7 @@ data LifeCycleState
     | Creating
     | Deleted
     | Deleting
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText LifeCycleState where
     parser = takeLowerText >>= \case

--- a/amazonka-elasticache/gen/Network/AWS/ElastiCache/Types/Sum.hs
+++ b/amazonka-elasticache/gen/Network/AWS/ElastiCache/Types/Sum.hs
@@ -22,7 +22,7 @@ import           Network.AWS.Prelude
 data AZMode
     = CrossAz
     | SingleAz
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText AZMode where
     parser = takeLowerText >>= \case
@@ -46,7 +46,7 @@ data AutomaticFailoverStatus
     | AFSDisabling
     | AFSEnabled
     | AFSEnabling
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText AutomaticFailoverStatus where
     parser = takeLowerText >>= \case
@@ -75,7 +75,7 @@ instance FromXML AutomaticFailoverStatus where
 data PendingAutomaticFailoverStatus
     = Disabled
     | Enabled
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText PendingAutomaticFailoverStatus where
     parser = takeLowerText >>= \case
@@ -102,7 +102,7 @@ data SourceType
     | CacheParameterGroup
     | CacheSecurityGroup
     | CacheSubnetGroup
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText SourceType where
     parser = takeLowerText >>= \case

--- a/amazonka-elasticbeanstalk/gen/Network/AWS/ElasticBeanstalk/Types/Sum.hs
+++ b/amazonka-elasticbeanstalk/gen/Network/AWS/ElasticBeanstalk/Types/Sum.hs
@@ -23,7 +23,7 @@ data ConfigurationDeploymentStatus
     = Deployed
     | Failed
     | Pending
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ConfigurationDeploymentStatus where
     parser = takeLowerText >>= \case
@@ -50,7 +50,7 @@ instance FromXML ConfigurationDeploymentStatus where
 data ConfigurationOptionValueType
     = List
     | Scalar
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ConfigurationOptionValueType where
     parser = takeLowerText >>= \case
@@ -77,7 +77,7 @@ data EnvironmentHealth
     | Grey
     | Red
     | Yellow
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText EnvironmentHealth where
     parser = takeLowerText >>= \case
@@ -112,7 +112,7 @@ data EnvironmentHealthAttribute
     | EHAInstancesHealth
     | EHARefreshedAt
     | EHAStatus
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText EnvironmentHealthAttribute where
     parser = takeLowerText >>= \case
@@ -152,7 +152,7 @@ data EnvironmentHealthStatus
     | EHSSevere
     | EHSUnknown
     | EHSWarning
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText EnvironmentHealthStatus where
     parser = takeLowerText >>= \case
@@ -189,7 +189,7 @@ instance FromXML EnvironmentHealthStatus where
 data EnvironmentInfoType
     = Bundle
     | Tail
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText EnvironmentInfoType where
     parser = takeLowerText >>= \case
@@ -217,7 +217,7 @@ data EnvironmentStatus
     | Terminated
     | Terminating
     | Updating
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText EnvironmentStatus where
     parser = takeLowerText >>= \case
@@ -252,7 +252,7 @@ data EventSeverity
     | LevelInfo
     | LevelTrace
     | LevelWarn
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText EventSeverity where
     parser = takeLowerText >>= \case
@@ -291,7 +291,7 @@ data InstancesHealthAttribute
     | LaunchedAt
     | RefreshedAt
     | System
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText InstancesHealthAttribute where
     parser = takeLowerText >>= \case
@@ -325,7 +325,7 @@ instance ToHeader     InstancesHealthAttribute
 data ValidationSeverity
     = Error'
     | Warning
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ValidationSeverity where
     parser = takeLowerText >>= \case

--- a/amazonka-elasticsearch/gen/Network/AWS/ElasticSearch/Types/Sum.hs
+++ b/amazonka-elasticsearch/gen/Network/AWS/ElasticSearch/Types/Sum.hs
@@ -34,7 +34,7 @@ data ESPartitionInstanceType
     | T2_Medium_Elasticsearch
     | T2_Micro_Elasticsearch
     | T2_Small_Elasticsearch
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ESPartitionInstanceType where
     parser = takeLowerText >>= \case
@@ -92,7 +92,7 @@ data OptionState
     = Active
     | Processing
     | RequiresIndexDocuments
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText OptionState where
     parser = takeLowerText >>= \case
@@ -123,7 +123,7 @@ data VolumeType
     = GP2
     | IO1
     | Standard
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText VolumeType where
     parser = takeLowerText >>= \case

--- a/amazonka-emr/gen/Network/AWS/EMR/Types/Sum.hs
+++ b/amazonka-emr/gen/Network/AWS/EMR/Types/Sum.hs
@@ -24,7 +24,7 @@ data ActionOnFailure
     | Continue
     | TerminateCluster
     | TerminateJobFlow
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ActionOnFailure where
     parser = takeLowerText >>= \case
@@ -61,7 +61,7 @@ data ClusterState
     | CSTerminatedWithErrors
     | CSTerminating
     | CSWaiting
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ClusterState where
     parser = takeLowerText >>= \case
@@ -104,7 +104,7 @@ data ClusterStateChangeReasonCode
     | CSCRCStepFailure
     | CSCRCUserRequest
     | CSCRCValidationError
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ClusterStateChangeReasonCode where
     parser = takeLowerText >>= \case
@@ -147,7 +147,7 @@ data InstanceGroupState
     | Suspended
     | Terminated
     | Terminating
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText InstanceGroupState where
     parser = takeLowerText >>= \case
@@ -190,7 +190,7 @@ data InstanceGroupStateChangeReasonCode
     | InstanceFailure
     | InternalError
     | ValidationError
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText InstanceGroupStateChangeReasonCode where
     parser = takeLowerText >>= \case
@@ -220,7 +220,7 @@ data InstanceGroupType
     = Core
     | Master
     | Task
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText InstanceGroupType where
     parser = takeLowerText >>= \case
@@ -251,7 +251,7 @@ data InstanceRoleType
     = IRTCore
     | IRTMaster
     | IRTTask
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText InstanceRoleType where
     parser = takeLowerText >>= \case
@@ -281,7 +281,7 @@ data InstanceState
     | ISProvisioning
     | ISRunning
     | ISTerminated
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText InstanceState where
     parser = takeLowerText >>= \case
@@ -315,7 +315,7 @@ data InstanceStateChangeReasonCode
     | ISCRCInstanceFailure
     | ISCRCInternalError
     | ISCRCValidationError
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText InstanceStateChangeReasonCode where
     parser = takeLowerText >>= \case
@@ -346,7 +346,7 @@ instance FromJSON InstanceStateChangeReasonCode where
 data MarketType
     = OnDemand
     | Spot
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText MarketType where
     parser = takeLowerText >>= \case
@@ -378,7 +378,7 @@ data StepState
     | SSInterrupted
     | SSPending
     | SSRunning
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText StepState where
     parser = takeLowerText >>= \case
@@ -413,7 +413,7 @@ instance FromJSON StepState where
 
 data StepStateChangeReasonCode =
     None
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText StepStateChangeReasonCode where
     parser = takeLowerText >>= \case

--- a/amazonka-glacier/gen/Network/AWS/Glacier/Types/Sum.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/Types/Sum.hs
@@ -22,7 +22,7 @@ import           Network.AWS.Prelude
 data ActionCode
     = ArchiveRetrieval
     | InventoryRetrieval
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ActionCode where
     parser = takeLowerText >>= \case
@@ -48,7 +48,7 @@ data StatusCode
     = Failed
     | InProgress
     | Succeeded
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText StatusCode where
     parser = takeLowerText >>= \case

--- a/amazonka-iam/gen/Network/AWS/IAM/Types/Sum.hs
+++ b/amazonka-iam/gen/Network/AWS/IAM/Types/Sum.hs
@@ -23,7 +23,7 @@ data AssignmentStatusType
     = Any
     | Assigned
     | Unassigned
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText AssignmentStatusType where
     parser = takeLowerText >>= \case
@@ -57,7 +57,7 @@ data ContextKeyTypeEnum
     | NumericList
     | String
     | StringList
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ContextKeyTypeEnum where
     parser = takeLowerText >>= \case
@@ -99,7 +99,7 @@ instance ToHeader     ContextKeyTypeEnum
 data EncodingType
     = Pem
     | SSH
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText EncodingType where
     parser = takeLowerText >>= \case
@@ -124,7 +124,7 @@ data EntityType
     | ETLocalManagedPolicy
     | ETRole
     | ETUser
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText EntityType where
     parser = takeLowerText >>= \case
@@ -153,7 +153,7 @@ data PolicyEvaluationDecisionType
     = Allowed
     | ExplicitDeny
     | ImplicitDeny
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText PolicyEvaluationDecisionType where
     parser = takeLowerText >>= \case
@@ -181,7 +181,7 @@ data PolicyScopeType
     = AWS
     | All
     | Local
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText PolicyScopeType where
     parser = takeLowerText >>= \case
@@ -210,7 +210,7 @@ data PolicySourceType
     | Role
     | User
     | UserManaged
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText PolicySourceType where
     parser = takeLowerText >>= \case
@@ -244,7 +244,7 @@ instance FromXML PolicySourceType where
 
 data ReportFormatType =
     TextCSV
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ReportFormatType where
     parser = takeLowerText >>= \case
@@ -268,7 +268,7 @@ data ReportStateType
     = Complete
     | Inprogress
     | Started
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ReportStateType where
     parser = takeLowerText >>= \case
@@ -295,7 +295,7 @@ instance FromXML ReportStateType where
 data StatusType
     = Active
     | Inactive
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText StatusType where
     parser = takeLowerText >>= \case
@@ -343,7 +343,7 @@ data SummaryKeyType
     | Users
     | UsersQuota
     | VersionsPerPolicyQuota
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText SummaryKeyType where
     parser = takeLowerText >>= \case

--- a/amazonka-importexport/gen/Network/AWS/ImportExport/Types/Sum.hs
+++ b/amazonka-importexport/gen/Network/AWS/ImportExport/Types/Sum.hs
@@ -23,7 +23,7 @@ import           Network.AWS.Prelude
 data JobType
     = Export
     | Import
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText JobType where
     parser = takeLowerText >>= \case

--- a/amazonka-iot/gen/Network/AWS/IoT/Types/Sum.hs
+++ b/amazonka-iot/gen/Network/AWS/IoT/Types/Sum.hs
@@ -24,7 +24,7 @@ data CertificateStatus
     | Inactive
     | PendingTransfer
     | Revoked
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText CertificateStatus where
     parser = takeLowerText >>= \case
@@ -59,7 +59,7 @@ data LogLevel
     | Error'
     | Info
     | Warn
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText LogLevel where
     parser = takeLowerText >>= \case

--- a/amazonka-kinesis-firehose/gen/Network/AWS/Firehose/Types/Sum.hs
+++ b/amazonka-kinesis-firehose/gen/Network/AWS/Firehose/Types/Sum.hs
@@ -24,7 +24,7 @@ data CompressionFormat
     | Snappy
     | Uncompressed
     | Zip
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText CompressionFormat where
     parser = takeLowerText >>= \case
@@ -57,7 +57,7 @@ data DeliveryStreamStatus
     = Active
     | Creating
     | Deleting
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DeliveryStreamStatus where
     parser = takeLowerText >>= \case
@@ -83,7 +83,7 @@ instance FromJSON DeliveryStreamStatus where
 
 data NoEncryptionConfig =
     NoEncryption
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText NoEncryptionConfig where
     parser = takeLowerText >>= \case

--- a/amazonka-kinesis/gen/Network/AWS/Kinesis/Types/Sum.hs
+++ b/amazonka-kinesis/gen/Network/AWS/Kinesis/Types/Sum.hs
@@ -24,7 +24,7 @@ data ShardIteratorType
     | AtSequenceNumber
     | Latest
     | TrimHorizon
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ShardIteratorType where
     parser = takeLowerText >>= \case
@@ -55,7 +55,7 @@ data StreamStatus
     | Creating
     | Deleting
     | Updating
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText StreamStatus where
     parser = takeLowerText >>= \case

--- a/amazonka-kms/gen/Network/AWS/KMS/Types/Sum.hs
+++ b/amazonka-kms/gen/Network/AWS/KMS/Types/Sum.hs
@@ -22,7 +22,7 @@ import           Network.AWS.Prelude
 data DataKeySpec
     = AES128
     | AES256
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DataKeySpec where
     parser = takeLowerText >>= \case
@@ -54,7 +54,7 @@ data GrantOperation
     | ReEncryptFrom
     | ReEncryptTo
     | RetireGrant
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText GrantOperation where
     parser = takeLowerText >>= \case
@@ -97,7 +97,7 @@ data KeyState
     = Disabled
     | Enabled
     | PendingDeletion
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText KeyState where
     parser = takeLowerText >>= \case
@@ -123,7 +123,7 @@ instance FromJSON KeyState where
 
 data KeyUsageType =
     EncryptDecrypt
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText KeyUsageType where
     parser = takeLowerText >>= \case

--- a/amazonka-lambda/gen/Network/AWS/Lambda/Types/Sum.hs
+++ b/amazonka-lambda/gen/Network/AWS/Lambda/Types/Sum.hs
@@ -22,7 +22,7 @@ import           Network.AWS.Prelude
 data EventSourcePosition
     = Latest
     | TrimHorizon
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText EventSourcePosition where
     parser = takeLowerText >>= \case
@@ -48,7 +48,7 @@ data InvocationType
     = DryRun
     | Event
     | RequestResponse
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText InvocationType where
     parser = takeLowerText >>= \case
@@ -75,7 +75,7 @@ instance ToJSON InvocationType where
 data LogType
     = None
     | Tail
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText LogType where
     parser = takeLowerText >>= \case
@@ -101,7 +101,7 @@ data Runtime
     = JAVA8
     | Nodejs
     | PYTHON2_7
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText Runtime where
     parser = takeLowerText >>= \case

--- a/amazonka-marketplace-analytics/gen/Network/AWS/MarketplaceAnalytics/Types/Sum.hs
+++ b/amazonka-marketplace-analytics/gen/Network/AWS/MarketplaceAnalytics/Types/Sum.hs
@@ -37,7 +37,7 @@ data DataSetType
     | DisbursedAmountByProduct
     | MonthlyRevenueAnnualSubscriptions
     | MonthlyRevenueBillingAndRevenueData
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DataSetType where
     parser = takeLowerText >>= \case

--- a/amazonka-ml/gen/Network/AWS/MachineLearning/Types/Sum.hs
+++ b/amazonka-ml/gen/Network/AWS/MachineLearning/Types/Sum.hs
@@ -26,7 +26,7 @@ import           Network.AWS.Prelude
 -- -   RandomForest - Random forest of decision trees.
 data Algorithm =
     SGD
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText Algorithm where
     parser = takeLowerText >>= \case
@@ -72,7 +72,7 @@ data BatchPredictionFilterVariable
     | BatchMLModelId
     | BatchName
     | BatchStatus
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText BatchPredictionFilterVariable where
     parser = takeLowerText >>= \case
@@ -129,7 +129,7 @@ data DataSourceFilterVariable
     | DataLastUpdatedAt
     | DataName
     | DataStatus
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DataSourceFilterVariable where
     parser = takeLowerText >>= \case
@@ -165,7 +165,7 @@ instance ToJSON DataSourceFilterVariable where
 data DetailsAttributes
     = Algorithm
     | PredictiveModelType
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DetailsAttributes where
     parser = takeLowerText >>= \case
@@ -200,7 +200,7 @@ data EntityStatus
     | ESFailed
     | ESInprogress
     | ESPending
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText EntityStatus where
     parser = takeLowerText >>= \case
@@ -253,7 +253,7 @@ data EvaluationFilterVariable
     | EvalMLModelId
     | EvalName
     | EvalStatus
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText EvaluationFilterVariable where
     parser = takeLowerText >>= \case
@@ -298,7 +298,7 @@ data MLModelFilterVariable
     | MLMFVStatus
     | MLMFVTrainingDataSourceId
     | MLMFVTrainingDataURI
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText MLModelFilterVariable where
     parser = takeLowerText >>= \case
@@ -340,7 +340,7 @@ data MLModelType
     = Binary
     | Multiclass
     | Regression
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText MLModelType where
     parser = takeLowerText >>= \case
@@ -372,7 +372,7 @@ data RealtimeEndpointStatus
     | None
     | Ready
     | Updating
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText RealtimeEndpointStatus where
     parser = takeLowerText >>= \case
@@ -406,7 +406,7 @@ instance FromJSON RealtimeEndpointStatus where
 data SortOrder
     = Asc
     | Dsc
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText SortOrder where
     parser = takeLowerText >>= \case

--- a/amazonka-opsworks/gen/Network/AWS/OpsWorks/Types/Sum.hs
+++ b/amazonka-opsworks/gen/Network/AWS/OpsWorks/Types/Sum.hs
@@ -24,7 +24,7 @@ data AppAttributesKeys
     | AutoBundleOnDeploy
     | DocumentRoot
     | RailsEnv
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText AppAttributesKeys where
     parser = takeLowerText >>= \case
@@ -61,7 +61,7 @@ data AppType
     | ATPHP
     | ATRails
     | ATStatic
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText AppType where
     parser = takeLowerText >>= \case
@@ -99,7 +99,7 @@ instance FromJSON AppType where
 data Architecture
     = I386
     | X86_64
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText Architecture where
     parser = takeLowerText >>= \case
@@ -127,7 +127,7 @@ instance FromJSON Architecture where
 data AutoScalingType
     = Load
     | Timer
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText AutoScalingType where
     parser = takeLowerText >>= \case
@@ -165,7 +165,7 @@ data DeploymentCommandName
     | Undeploy
     | UpdateCustomCookbooks
     | UpdateDependencies
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DeploymentCommandName where
     parser = takeLowerText >>= \case
@@ -236,7 +236,7 @@ data LayerAttributesKeys
     | RailsStack
     | RubyVersion
     | RubygemsVersion
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText LayerAttributesKeys where
     parser = takeLowerText >>= \case
@@ -320,7 +320,7 @@ data LayerType
     | PHPApp
     | RailsApp
     | Web
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText LayerType where
     parser = takeLowerText >>= \case
@@ -368,7 +368,7 @@ instance FromJSON LayerType where
 data RootDeviceType
     = EBS
     | InstanceStore
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText RootDeviceType where
     parser = takeLowerText >>= \case
@@ -398,7 +398,7 @@ data SourceType
     | Git
     | S3
     | SVN
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText SourceType where
     parser = takeLowerText >>= \case
@@ -429,7 +429,7 @@ instance FromJSON SourceType where
 
 data StackAttributesKeys =
     Color
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText StackAttributesKeys where
     parser = takeLowerText >>= \case
@@ -455,7 +455,7 @@ instance FromJSON StackAttributesKeys where
 data VirtualizationType
     = HVM
     | Paravirtual
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText VirtualizationType where
     parser = takeLowerText >>= \case
@@ -481,7 +481,7 @@ data VolumeType
     = GP2
     | IO1
     | Standard
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText VolumeType where
     parser = takeLowerText >>= \case

--- a/amazonka-rds/gen/Network/AWS/RDS/Types/Sum.hs
+++ b/amazonka-rds/gen/Network/AWS/RDS/Types/Sum.hs
@@ -22,7 +22,7 @@ import           Network.AWS.Prelude
 data ApplyMethod
     = Immediate
     | PendingReboot
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ApplyMethod where
     parser = takeLowerText >>= \case
@@ -51,7 +51,7 @@ data SourceType
     | DBParameterGroup
     | DBSecurityGroup
     | DBSnapshot
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText SourceType where
     parser = takeLowerText >>= \case

--- a/amazonka-redshift/gen/Network/AWS/Redshift/Types/Sum.hs
+++ b/amazonka-redshift/gen/Network/AWS/Redshift/Types/Sum.hs
@@ -22,7 +22,7 @@ import           Network.AWS.Prelude
 data ParameterApplyType
     = Dynamic
     | Static
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ParameterApplyType where
     parser = takeLowerText >>= \case
@@ -49,7 +49,7 @@ data SourceType
     | ClusterParameterGroup
     | ClusterSecurityGroup
     | ClusterSnapshot
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText SourceType where
     parser = takeLowerText >>= \case

--- a/amazonka-route53-domains/gen/Network/AWS/Route53Domains/Types/Sum.hs
+++ b/amazonka-route53-domains/gen/Network/AWS/Route53Domains/Types/Sum.hs
@@ -25,7 +25,7 @@ data ContactType
     | Person
     | PublicBody
     | Reseller
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ContactType where
     parser = takeLowerText >>= \case
@@ -286,7 +286,7 @@ data CountryCode
     | ZA
     | ZM
     | ZW
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText CountryCode where
     parser = takeLowerText >>= \case
@@ -774,7 +774,7 @@ data DomainAvailability
     | Unavailable
     | UnavailablePremium
     | UnavailableRestricted
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DomainAvailability where
     parser = takeLowerText >>= \case
@@ -829,7 +829,7 @@ data ExtraParamName
     | SeIdNumber
     | SgIdNumber
     | VatNumber
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ExtraParamName where
     parser = takeLowerText >>= \case
@@ -896,7 +896,7 @@ data OperationStatus
     | InProgress
     | Submitted
     | Successful
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText OperationStatus where
     parser = takeLowerText >>= \case
@@ -932,7 +932,7 @@ data OperationType
     | TransferInDomain
     | UpdateDomainContact
     | UpdateNameserver
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText OperationType where
     parser = takeLowerText >>= \case

--- a/amazonka-route53/gen/Network/AWS/Route53/Types/Sum.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/Types/Sum.hs
@@ -24,7 +24,7 @@ data ChangeAction
     = Create
     | Delete
     | Upsert
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ChangeAction where
     parser = takeLowerText >>= \case
@@ -51,7 +51,7 @@ instance ToXML ChangeAction where
 data ChangeStatus
     = Insync
     | Pending
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ChangeStatus where
     parser = takeLowerText >>= \case
@@ -76,7 +76,7 @@ instance FromXML ChangeStatus where
 data Failover
     = Primary
     | Secondary
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText Failover where
     parser = takeLowerText >>= \case
@@ -108,7 +108,7 @@ data HealthCheckType
     | HTTPSStrMatch
     | HTTPStrMatch
     | TCP
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText HealthCheckType where
     parser = takeLowerText >>= \case
@@ -152,7 +152,7 @@ data RecordType
     | Spf
     | Srv
     | Txt
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText RecordType where
     parser = takeLowerText >>= \case
@@ -196,7 +196,7 @@ instance ToXML RecordType where
 data TagResourceType
     = Healthcheck
     | Hostedzone
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText TagResourceType where
     parser = takeLowerText >>= \case
@@ -232,7 +232,7 @@ data VPCRegion
     | UsEast1
     | UsWest1
     | UsWest2
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText VPCRegion where
     parser = takeLowerText >>= \case

--- a/amazonka-s3/gen/Network/AWS/S3/Types/Sum.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/Types/Sum.hs
@@ -25,7 +25,7 @@ data BucketCannedACL
     | BPrivate
     | BPublicRead
     | BPublicReadWrite
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText BucketCannedACL where
     parser = takeLowerText >>= \case
@@ -55,7 +55,7 @@ data BucketLogsPermission
     = FullControl
     | Read
     | Write
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText BucketLogsPermission where
     parser = takeLowerText >>= \case
@@ -85,7 +85,7 @@ instance ToXML BucketLogsPermission where
 data BucketVersioningStatus
     = BVSEnabled
     | BVSSuspended
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText BucketVersioningStatus where
     parser = takeLowerText >>= \case
@@ -118,7 +118,7 @@ instance ToXML BucketVersioningStatus where
 -- Amazon S3 encode the keys in the response.
 data EncodingType =
     URL
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText EncodingType where
     parser = takeLowerText >>= \case
@@ -152,7 +152,7 @@ data Event
     | S3ObjectRemovedDelete
     | S3ObjectRemovedDeleteMarkerCreated
     | S3ReducedRedundancyLostObject
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText Event where
     parser = takeLowerText >>= \case
@@ -194,7 +194,7 @@ instance ToXML Event where
 data ExpirationStatus
     = ESDisabled
     | ESEnabled
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ExpirationStatus where
     parser = takeLowerText >>= \case
@@ -222,7 +222,7 @@ instance ToXML ExpirationStatus where
 data FilterRuleName
     = Prefix
     | Suffix
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText FilterRuleName where
     parser = takeLowerText >>= \case
@@ -250,7 +250,7 @@ instance ToXML FilterRuleName where
 data MFADelete
     = MDDisabled
     | MDEnabled
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText MFADelete where
     parser = takeLowerText >>= \case
@@ -275,7 +275,7 @@ instance ToXML MFADelete where
 data MFADeleteStatus
     = MDSDisabled
     | MDSEnabled
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText MFADeleteStatus where
     parser = takeLowerText >>= \case
@@ -300,7 +300,7 @@ instance FromXML MFADeleteStatus where
 data MetadataDirective
     = Copy
     | Replace
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText MetadataDirective where
     parser = takeLowerText >>= \case
@@ -329,7 +329,7 @@ data ObjectCannedACL
     | OPrivate
     | OPublicRead
     | OPublicReadWrite
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ObjectCannedACL where
     parser = takeLowerText >>= \case
@@ -364,7 +364,7 @@ data ObjectStorageClass
     | OSCReducedRedundancy
     | OSCStandard
     | OSCStandardIA
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ObjectStorageClass where
     parser = takeLowerText >>= \case
@@ -392,7 +392,7 @@ instance FromXML ObjectStorageClass where
 
 data ObjectVersionStorageClass =
     OVSCStandard
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ObjectVersionStorageClass where
     parser = takeLowerText >>= \case
@@ -415,7 +415,7 @@ instance FromXML ObjectVersionStorageClass where
 data Payer
     = BucketOwner
     | Requester
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText Payer where
     parser = takeLowerText >>= \case
@@ -446,7 +446,7 @@ data Permission
     | PReadAcp
     | PWrite
     | PWriteAcp
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText Permission where
     parser = takeLowerText >>= \case
@@ -480,7 +480,7 @@ instance ToXML Permission where
 data Protocol
     = HTTP
     | HTTPS
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText Protocol where
     parser = takeLowerText >>= \case
@@ -508,7 +508,7 @@ instance ToXML Protocol where
 data ReplicationRuleStatus
     = Disabled
     | Enabled
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ReplicationRuleStatus where
     parser = takeLowerText >>= \case
@@ -538,7 +538,7 @@ data ReplicationStatus
     | Failed
     | Pending
     | Replica
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ReplicationStatus where
     parser = takeLowerText >>= \case
@@ -568,7 +568,7 @@ instance FromXML ReplicationStatus where
 -- the request.
 data RequestCharged =
     RCRequester
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText RequestCharged where
     parser = takeLowerText >>= \case
@@ -595,7 +595,7 @@ instance FromXML RequestCharged where
 -- http:\/\/docs.aws.amazon.com\/AmazonS3\/latest\/dev\/ObjectsinRequesterPaysBuckets.html
 data RequestPayer =
     RPRequester
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText RequestPayer where
     parser = takeLowerText >>= \case
@@ -618,7 +618,7 @@ instance ToXML RequestPayer where
 data ServerSideEncryption
     = AES256
     | AWSKMS
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ServerSideEncryption where
     parser = takeLowerText >>= \case
@@ -647,7 +647,7 @@ data StorageClass
     = ReducedRedundancy
     | Standard
     | StandardIA
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText StorageClass where
     parser = takeLowerText >>= \case
@@ -677,7 +677,7 @@ instance ToXML StorageClass where
 data TransitionStorageClass
     = TSCGlacier
     | TSCStandardIA
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText TransitionStorageClass where
     parser = takeLowerText >>= \case
@@ -706,7 +706,7 @@ data Type
     = AmazonCustomerByEmail
     | CanonicalUser
     | Group
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText Type where
     parser = takeLowerText >>= \case

--- a/amazonka-ses/gen/Network/AWS/SES/Types/Sum.hs
+++ b/amazonka-ses/gen/Network/AWS/SES/Types/Sum.hs
@@ -26,7 +26,7 @@ data BounceType
     | BTMessageTooLarge
     | BTTemporaryFailure
     | BTUndefined
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText BounceType where
     parser = takeLowerText >>= \case
@@ -59,7 +59,7 @@ data DsnAction
     | DAExpanded
     | DAFailed
     | DARelayed
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DsnAction where
     parser = takeLowerText >>= \case
@@ -87,7 +87,7 @@ instance ToHeader     DsnAction
 data IdentityType
     = Domain
     | EmailAddress
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText IdentityType where
     parser = takeLowerText >>= \case
@@ -109,7 +109,7 @@ instance ToHeader     IdentityType
 data InvocationType
     = Event
     | RequestResponse
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText InvocationType where
     parser = takeLowerText >>= \case
@@ -135,7 +135,7 @@ data NotificationType
     = Bounce
     | Complaint
     | Delivery
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText NotificationType where
     parser = takeLowerText >>= \case
@@ -159,7 +159,7 @@ instance ToHeader     NotificationType
 data ReceiptFilterPolicy
     = Allow
     | Block
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ReceiptFilterPolicy where
     parser = takeLowerText >>= \case
@@ -183,7 +183,7 @@ instance FromXML ReceiptFilterPolicy where
 
 data StopScope =
     RuleSet
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText StopScope where
     parser = takeLowerText >>= \case
@@ -206,7 +206,7 @@ instance FromXML StopScope where
 data TLSPolicy
     = Optional
     | Require
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText TLSPolicy where
     parser = takeLowerText >>= \case
@@ -234,7 +234,7 @@ data VerificationStatus
     | Pending
     | Success
     | TemporaryFailure
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText VerificationStatus where
     parser = takeLowerText >>= \case

--- a/amazonka-sqs/gen/Network/AWS/SQS/Types/Sum.hs
+++ b/amazonka-sqs/gen/Network/AWS/SQS/Types/Sum.hs
@@ -25,7 +25,7 @@ data MessageAttribute
     | ApproximateReceiveCount
     | SenderId
     | SentTimestamp
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText MessageAttribute where
     parser = takeLowerText >>= \case
@@ -67,7 +67,7 @@ data QueueAttributeName
     | ReceiveMessageWaitTimeSeconds
     | RedrivePolicy
     | VisibilityTimeout
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText QueueAttributeName where
     parser = takeLowerText >>= \case

--- a/amazonka-ssm/gen/Network/AWS/SSM/Types/Sum.hs
+++ b/amazonka-ssm/gen/Network/AWS/SSM/Types/Sum.hs
@@ -22,7 +22,7 @@ import           Network.AWS.Prelude
 data AssociationFilterKey
     = AFKInstanceId
     | AFKName
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText AssociationFilterKey where
     parser = takeLowerText >>= \case
@@ -48,7 +48,7 @@ data AssociationStatusName
     = ASNFailed
     | ASNPending
     | ASNSuccess
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText AssociationStatusName where
     parser = takeLowerText >>= \case
@@ -79,7 +79,7 @@ data CommandFilterKey
     = CommandInvokedAfter
     | CommandInvokedBefore
     | CommandStatus
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText CommandFilterKey where
     parser = takeLowerText >>= \case
@@ -111,7 +111,7 @@ data CommandInvocationStatus
     | CISPending
     | CISSuccess
     | CISTimedOut
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText CommandInvocationStatus where
     parser = takeLowerText >>= \case
@@ -150,7 +150,7 @@ data CommandPluginStatus
     | CPSPending
     | CPSSuccess
     | CPSTimedOut
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText CommandPluginStatus where
     parser = takeLowerText >>= \case
@@ -188,7 +188,7 @@ data CommandStatus
     | Pending
     | Success
     | TimedOut
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText CommandStatus where
     parser = takeLowerText >>= \case
@@ -224,7 +224,7 @@ data DocumentFilterKey
     = Name
     | Owner
     | PlatformTypes
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DocumentFilterKey where
     parser = takeLowerText >>= \case
@@ -251,7 +251,7 @@ instance ToJSON DocumentFilterKey where
 data DocumentParameterType
     = String
     | StringList
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DocumentParameterType where
     parser = takeLowerText >>= \case
@@ -277,7 +277,7 @@ data DocumentStatus
     = Active
     | Creating
     | Deleting
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DocumentStatus where
     parser = takeLowerText >>= \case
@@ -305,7 +305,7 @@ data Fault
     = Client
     | Server
     | Unknown
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText Fault where
     parser = takeLowerText >>= \case
@@ -334,7 +334,7 @@ data InstanceInformationFilterKey
     | IIFKInstanceIds
     | IIFKPingStatus
     | IIFKPlatformTypes
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText InstanceInformationFilterKey where
     parser = takeLowerText >>= \case
@@ -364,7 +364,7 @@ data PingStatus
     = ConnectionLost
     | Inactive
     | Online
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText PingStatus where
     parser = takeLowerText >>= \case
@@ -391,7 +391,7 @@ instance FromJSON PingStatus where
 data PlatformType
     = Linux
     | Windows
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText PlatformType where
     parser = takeLowerText >>= \case

--- a/amazonka-swf/gen/Network/AWS/SWF/Types/Sum.hs
+++ b/amazonka-swf/gen/Network/AWS/SWF/Types/Sum.hs
@@ -24,7 +24,7 @@ data ActivityTaskTimeoutType
     | ATTTScheduleToClose
     | ATTTScheduleToStart
     | ATTTStartToClose
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ActivityTaskTimeoutType where
     parser = takeLowerText >>= \case
@@ -53,7 +53,7 @@ instance FromJSON ActivityTaskTimeoutType where
 data CancelTimerFailedCause
     = CTFCOperationNotPermitted
     | CTFCTimerIdUnknown
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText CancelTimerFailedCause where
     parser = takeLowerText >>= \case
@@ -78,7 +78,7 @@ instance FromJSON CancelTimerFailedCause where
 data CancelWorkflowExecutionFailedCause
     = COperationNotPermitted
     | CUnhandledDecision
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText CancelWorkflowExecutionFailedCause where
     parser = takeLowerText >>= \case
@@ -104,7 +104,7 @@ data ChildPolicy
     = Abandon
     | RequestCancel
     | Terminate
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ChildPolicy where
     parser = takeLowerText >>= \case
@@ -138,7 +138,7 @@ data CloseStatus
     | Failed
     | Terminated
     | TimedOut
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText CloseStatus where
     parser = takeLowerText >>= \case
@@ -174,7 +174,7 @@ instance FromJSON CloseStatus where
 data CompleteWorkflowExecutionFailedCause
     = CWEFCOperationNotPermitted
     | CWEFCUnhandledDecision
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText CompleteWorkflowExecutionFailedCause where
     parser = takeLowerText >>= \case
@@ -206,7 +206,7 @@ data ContinueAsNewWorkflowExecutionFailedCause
     | CANWEFCUnhandledDecision
     | CANWEFCWorkflowTypeDeprecated
     | CANWEFCWorkflowTypeDoesNotExist
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ContinueAsNewWorkflowExecutionFailedCause where
     parser = takeLowerText >>= \case
@@ -244,7 +244,7 @@ instance FromJSON ContinueAsNewWorkflowExecutionFailedCause where
 
 data DecisionTaskTimeoutType =
     StartToClose
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DecisionTaskTimeoutType where
     parser = takeLowerText >>= \case
@@ -278,7 +278,7 @@ data DecisionType
     | SignalExternalWorkflowExecution
     | StartChildWorkflowExecution
     | StartTimer
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText DecisionType where
     parser = takeLowerText >>= \case
@@ -377,7 +377,7 @@ data EventType
     | WorkflowExecutionStarted
     | WorkflowExecutionTerminated
     | WorkflowExecutionTimedOut
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText EventType where
     parser = takeLowerText >>= \case
@@ -506,7 +506,7 @@ instance FromJSON EventType where
 data ExecutionStatus
     = Closed
     | Open
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ExecutionStatus where
     parser = takeLowerText >>= \case
@@ -531,7 +531,7 @@ instance FromJSON ExecutionStatus where
 data FailWorkflowExecutionFailedCause
     = FWEFCOperationNotPermitted
     | FWEFCUnhandledDecision
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText FailWorkflowExecutionFailedCause where
     parser = takeLowerText >>= \case
@@ -555,7 +555,7 @@ instance FromJSON FailWorkflowExecutionFailedCause where
 
 data LambdaFunctionTimeoutType =
     LFTTStartToClose
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText LambdaFunctionTimeoutType where
     parser = takeLowerText >>= \case
@@ -577,7 +577,7 @@ instance FromJSON LambdaFunctionTimeoutType where
 
 data RecordMarkerFailedCause =
     OperationNotPermitted
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText RecordMarkerFailedCause where
     parser = takeLowerText >>= \case
@@ -600,7 +600,7 @@ instance FromJSON RecordMarkerFailedCause where
 data RegistrationStatus
     = Deprecated
     | Registered
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText RegistrationStatus where
     parser = takeLowerText >>= \case
@@ -628,7 +628,7 @@ instance FromJSON RegistrationStatus where
 data RequestCancelActivityTaskFailedCause
     = RCATFCActivityIdUnknown
     | RCATFCOperationNotPermitted
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText RequestCancelActivityTaskFailedCause where
     parser = takeLowerText >>= \case
@@ -654,7 +654,7 @@ data RequestCancelExternalWorkflowExecutionFailedCause
     = RCEWEFCOperationNotPermitted
     | RCEWEFCRequestCancelExternalWorkflowExecutionRateExceeded
     | RCEWEFCUnknownExternalWorkflowExecution
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText RequestCancelExternalWorkflowExecutionFailedCause where
     parser = takeLowerText >>= \case
@@ -690,7 +690,7 @@ data ScheduleActivityTaskFailedCause
     | SATFCDefaultTaskListUndefined
     | SATFCOpenActivitiesLimitExceeded
     | SATFCOperationNotPermitted
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ScheduleActivityTaskFailedCause where
     parser = takeLowerText >>= \case
@@ -735,7 +735,7 @@ data ScheduleLambdaFunctionFailedCause
     | LambdaFunctionCreationRateExceeded
     | LambdaServiceNotAvailableInRegion
     | OpenLambdaFunctionsLimitExceeded
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ScheduleLambdaFunctionFailedCause where
     parser = takeLowerText >>= \case
@@ -765,7 +765,7 @@ data SignalExternalWorkflowExecutionFailedCause
     = SEWEFCOperationNotPermitted
     | SEWEFCSignalExternalWorkflowExecutionRateExceeded
     | SEWEFCUnknownExternalWorkflowExecution
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText SignalExternalWorkflowExecutionFailedCause where
     parser = takeLowerText >>= \case
@@ -801,7 +801,7 @@ data StartChildWorkflowExecutionFailedCause
     | SCWEFCWorkflowAlreadyRunning
     | SCWEFCWorkflowTypeDeprecated
     | SCWEFCWorkflowTypeDoesNotExist
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText StartChildWorkflowExecutionFailedCause where
     parser = takeLowerText >>= \case
@@ -843,7 +843,7 @@ instance FromJSON StartChildWorkflowExecutionFailedCause where
 
 data StartLambdaFunctionFailedCause =
     AssumeRoleFailed
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText StartLambdaFunctionFailedCause where
     parser = takeLowerText >>= \case
@@ -868,7 +868,7 @@ data StartTimerFailedCause
     | STFCOperationNotPermitted
     | STFCTimerCreationRateExceeded
     | STFCTimerIdAlreadyInUse
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText StartTimerFailedCause where
     parser = takeLowerText >>= \case
@@ -896,7 +896,7 @@ instance FromJSON StartTimerFailedCause where
 
 data WorkflowExecutionCancelRequestedCause =
     ChildPolicyApplied
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText WorkflowExecutionCancelRequestedCause where
     parser = takeLowerText >>= \case
@@ -920,7 +920,7 @@ data WorkflowExecutionTerminatedCause
     = WETCChildPolicyApplied
     | WETCEventLimitExceeded
     | WETCOperatorInitiated
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText WorkflowExecutionTerminatedCause where
     parser = takeLowerText >>= \case
@@ -946,7 +946,7 @@ instance FromJSON WorkflowExecutionTerminatedCause where
 
 data WorkflowExecutionTimeoutType =
     WETTStartToClose
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText WorkflowExecutionTimeoutType where
     parser = takeLowerText >>= \case

--- a/amazonka-waf/gen/Network/AWS/WAF/Types/Sum.hs
+++ b/amazonka-waf/gen/Network/AWS/WAF/Types/Sum.hs
@@ -22,7 +22,7 @@ import           Network.AWS.Prelude
 data ChangeAction
     = Delete
     | Insert
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ChangeAction where
     parser = takeLowerText >>= \case
@@ -48,7 +48,7 @@ data ChangeTokenStatus
     = Insync
     | Pending
     | Provisioned
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText ChangeTokenStatus where
     parser = takeLowerText >>= \case
@@ -74,7 +74,7 @@ instance FromJSON ChangeTokenStatus where
 
 data IPSetDescriptorType =
     IPV4
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText IPSetDescriptorType where
     parser = takeLowerText >>= \case
@@ -102,7 +102,7 @@ data MatchFieldType
     | Method
     | QueryString
     | URI
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText MatchFieldType where
     parser = takeLowerText >>= \case
@@ -137,7 +137,7 @@ data PositionalConstraint
     | EndsWith
     | Exactly
     | StartsWith
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText PositionalConstraint where
     parser = takeLowerText >>= \case
@@ -172,7 +172,7 @@ data PredicateType
     = ByteMatch
     | IPMatch
     | SqlInjectionMatch
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText PredicateType where
     parser = takeLowerText >>= \case
@@ -206,7 +206,7 @@ data TextTransformation
     | Lowercase
     | None
     | URLDecode
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText TextTransformation where
     parser = takeLowerText >>= \case
@@ -243,7 +243,7 @@ data WafActionType
     = Allow
     | Block
     | Count
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText WafActionType where
     parser = takeLowerText >>= \case

--- a/amazonka-workspaces/gen/Network/AWS/WorkSpaces/Types/Sum.hs
+++ b/amazonka-workspaces/gen/Network/AWS/WorkSpaces/Types/Sum.hs
@@ -23,7 +23,7 @@ data Compute
     = Performance
     | Standard
     | Value
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText Compute where
     parser = takeLowerText >>= \case
@@ -53,7 +53,7 @@ data WorkspaceDirectoryState
     | Error'
     | Registered
     | Registering
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText WorkspaceDirectoryState where
     parser = takeLowerText >>= \case
@@ -84,7 +84,7 @@ instance FromJSON WorkspaceDirectoryState where
 data WorkspaceDirectoryType
     = AdConnector
     | SimpleAd
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText WorkspaceDirectoryType where
     parser = takeLowerText >>= \case
@@ -117,7 +117,7 @@ data WorkspaceState
     | WSTerminated
     | WSTerminating
     | WSUnhealthy
-    deriving (Eq,Ord,Read,Show,Enum,Data,Typeable,Generic)
+    deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText WorkspaceState where
     parser = takeLowerText >>= \case

--- a/gen/src/Gen/AST/TypeOf.hs
+++ b/gen/src/Gen/AST/TypeOf.hs
@@ -120,7 +120,7 @@ string = [DOrd, DIsString]
 num    = DNum : DIntegral : DReal : enum
 frac   = [DOrd, DRealFrac, DRealFloat]
 monoid = [DMonoid, DSemigroup]
-enum   = [DOrd, DEnum]
+enum   = [DOrd, DEnum, DBounded]
 base   = [DEq, DRead, DShow, DData, DTypeable, DGeneric]
 
 typeDefault :: TType -> Bool

--- a/gen/src/Gen/Types/Ann.hs
+++ b/gen/src/Gen/Types/Ann.hs
@@ -85,6 +85,7 @@ data Derive
     | DRead
     | DShow
     | DEnum
+    | DBounded
     | DNum
     | DIntegral
     | DReal


### PR DESCRIPTION
Since the types have auto-derived `Enum` instances, it makes sense to also have `Bounded` instances.

Fixes #255.