### PR TITLE
Exporting the ErrorCode data constructor

### DIFF
--- a/core/src/Network/AWS/Types.hs
+++ b/core/src/Network/AWS/Types.hs
@@ -89,7 +89,7 @@ module Network.AWS.Types
     , serviceMessage
     , serviceRequestId
     -- ** Error Types
-    , ErrorCode
+    , ErrorCode      (..)
     , errorCode
     , ErrorMessage   (..)
     , RequestId      (..)


### PR DESCRIPTION
So we can pattern match on the specific error code wrapped by the `ErrorCode` newtype.