### PR TITLE
Override optional fields for SWF ActivityTask and DecisionTask

### DIFF
--- a/amazonka-swf/gen/Network/AWS/SWF/PollForActivityTask.hs
+++ b/amazonka-swf/gen/Network/AWS/SWF/PollForActivityTask.hs
@@ -67,10 +67,10 @@ module Network.AWS.SWF.PollForActivityTask
     , pollForActivityTaskResponse
     , PollForActivityTaskResponse
     -- * Response Lenses
-    , pfatrsInput
-    , pfatrsResponseStatus
-    , pfatrsTaskToken
     , pfatrsActivityId
+    , pfatrsInput
+    , pfatrsTaskToken
+    , pfatrsResponseStatus
     , pfatrsStartedEventId
     , pfatrsWorkflowExecution
     , pfatrsActivityType
@@ -137,9 +137,9 @@ instance AWSRequest PollForActivityTask where
           = receiveJSON
               (\ s h x ->
                  PollForActivityTaskResponse' <$>
-                   (x .?> "input") <*> (pure (fromEnum s)) <*>
-                     (x .:> "taskToken")
-                     <*> (x .:> "activityId")
+                   (x .?> "activityId") <*> (x .?> "input") <*>
+                     (x .?> "taskToken")
+                     <*> (pure (fromEnum s))
                      <*> (x .:> "startedEventId")
                      <*> (x .:> "workflowExecution")
                      <*> (x .:> "activityType"))
@@ -172,10 +172,10 @@ instance ToQuery PollForActivityTask where
 --
 -- /See:/ 'pollForActivityTaskResponse' smart constructor.
 data PollForActivityTaskResponse = PollForActivityTaskResponse'
-    { _pfatrsInput             :: !(Maybe Text)
+    { _pfatrsActivityId        :: !(Maybe Text)
+    , _pfatrsInput             :: !(Maybe Text)
+    , _pfatrsTaskToken         :: !(Maybe Text)
     , _pfatrsResponseStatus    :: !Int
-    , _pfatrsTaskToken         :: !Text
-    , _pfatrsActivityId        :: !Text
     , _pfatrsStartedEventId    :: !Integer
     , _pfatrsWorkflowExecution :: !WorkflowExecution
     , _pfatrsActivityType      :: !ActivityType
@@ -185,13 +185,13 @@ data PollForActivityTaskResponse = PollForActivityTaskResponse'
 --
 -- Use one of the following lenses to modify other fields as desired:
 --
--- * 'pfatrsInput'
+-- * 'pfatrsActivityId'
 --
--- * 'pfatrsResponseStatus'
+-- * 'pfatrsInput'
 --
 -- * 'pfatrsTaskToken'
 --
--- * 'pfatrsActivityId'
+-- * 'pfatrsResponseStatus'
 --
 -- * 'pfatrsStartedEventId'
 --
@@ -200,22 +200,24 @@ data PollForActivityTaskResponse = PollForActivityTaskResponse'
 -- * 'pfatrsActivityType'
 pollForActivityTaskResponse
     :: Int -- ^ 'pfatrsResponseStatus'
-    -> Text -- ^ 'pfatrsTaskToken'
-    -> Text -- ^ 'pfatrsActivityId'
     -> Integer -- ^ 'pfatrsStartedEventId'
     -> WorkflowExecution -- ^ 'pfatrsWorkflowExecution'
     -> ActivityType -- ^ 'pfatrsActivityType'
     -> PollForActivityTaskResponse
-pollForActivityTaskResponse pResponseStatus_ pTaskToken_ pActivityId_ pStartedEventId_ pWorkflowExecution_ pActivityType_ =
+pollForActivityTaskResponse pResponseStatus_ pStartedEventId_ pWorkflowExecution_ pActivityType_ =
     PollForActivityTaskResponse'
-    { _pfatrsInput = Nothing
+    { _pfatrsActivityId = Nothing
+    , _pfatrsInput = Nothing
+    , _pfatrsTaskToken = Nothing
     , _pfatrsResponseStatus = pResponseStatus_
-    , _pfatrsTaskToken = pTaskToken_
-    , _pfatrsActivityId = pActivityId_
     , _pfatrsStartedEventId = pStartedEventId_
     , _pfatrsWorkflowExecution = pWorkflowExecution_
     , _pfatrsActivityType = pActivityType_
     }
+
+-- | The unique ID of the task.
+pfatrsActivityId :: Lens' PollForActivityTaskResponse (Maybe Text)
+pfatrsActivityId = lens _pfatrsActivityId (\ s a -> s{_pfatrsActivityId = a});
 
 -- | The inputs provided when the activity task was scheduled. The form of
 -- the input is user defined and should be meaningful to the activity
@@ -223,19 +225,15 @@ pollForActivityTaskResponse pResponseStatus_ pTaskToken_ pActivityId_ pStartedEv
 pfatrsInput :: Lens' PollForActivityTaskResponse (Maybe Text)
 pfatrsInput = lens _pfatrsInput (\ s a -> s{_pfatrsInput = a});
 
--- | The response status code.
-pfatrsResponseStatus :: Lens' PollForActivityTaskResponse Int
-pfatrsResponseStatus = lens _pfatrsResponseStatus (\ s a -> s{_pfatrsResponseStatus = a});
-
 -- | The opaque string used as a handle on the task. This token is used by
 -- workers to communicate progress and response information back to the
 -- system about the task.
-pfatrsTaskToken :: Lens' PollForActivityTaskResponse Text
+pfatrsTaskToken :: Lens' PollForActivityTaskResponse (Maybe Text)
 pfatrsTaskToken = lens _pfatrsTaskToken (\ s a -> s{_pfatrsTaskToken = a});
 
--- | The unique ID of the task.
-pfatrsActivityId :: Lens' PollForActivityTaskResponse Text
-pfatrsActivityId = lens _pfatrsActivityId (\ s a -> s{_pfatrsActivityId = a});
+-- | The response status code.
+pfatrsResponseStatus :: Lens' PollForActivityTaskResponse Int
+pfatrsResponseStatus = lens _pfatrsResponseStatus (\ s a -> s{_pfatrsResponseStatus = a});
 
 -- | The ID of the 'ActivityTaskStarted' event recorded in the history.
 pfatrsStartedEventId :: Lens' PollForActivityTaskResponse Integer

--- a/amazonka-swf/gen/Network/AWS/SWF/PollForDecisionTask.hs
+++ b/amazonka-swf/gen/Network/AWS/SWF/PollForDecisionTask.hs
@@ -85,8 +85,8 @@ module Network.AWS.SWF.PollForDecisionTask
     -- * Response Lenses
     , pfdtrsNextPageToken
     , pfdtrsPreviousStartedEventId
-    , pfdtrsResponseStatus
     , pfdtrsTaskToken
+    , pfdtrsResponseStatus
     , pfdtrsStartedEventId
     , pfdtrsWorkflowExecution
     , pfdtrsWorkflowType
@@ -211,8 +211,8 @@ instance AWSRequest PollForDecisionTask where
                  PollForDecisionTaskResponse' <$>
                    (x .?> "nextPageToken") <*>
                      (x .?> "previousStartedEventId")
+                     <*> (x .?> "taskToken")
                      <*> (pure (fromEnum s))
-                     <*> (x .:> "taskToken")
                      <*> (x .:> "startedEventId")
                      <*> (x .:> "workflowExecution")
                      <*> (x .:> "workflowType")
@@ -252,8 +252,8 @@ instance ToQuery PollForDecisionTask where
 data PollForDecisionTaskResponse = PollForDecisionTaskResponse'
     { _pfdtrsNextPageToken          :: !(Maybe Text)
     , _pfdtrsPreviousStartedEventId :: !(Maybe Integer)
+    , _pfdtrsTaskToken              :: !(Maybe Text)
     , _pfdtrsResponseStatus         :: !Int
-    , _pfdtrsTaskToken              :: !Text
     , _pfdtrsStartedEventId         :: !Integer
     , _pfdtrsWorkflowExecution      :: !WorkflowExecution
     , _pfdtrsWorkflowType           :: !WorkflowType
@@ -268,9 +268,9 @@ data PollForDecisionTaskResponse = PollForDecisionTaskResponse'
 --
 -- * 'pfdtrsPreviousStartedEventId'
 --
--- * 'pfdtrsResponseStatus'
---
 -- * 'pfdtrsTaskToken'
+--
+-- * 'pfdtrsResponseStatus'
 --
 -- * 'pfdtrsStartedEventId'
 --
@@ -281,17 +281,16 @@ data PollForDecisionTaskResponse = PollForDecisionTaskResponse'
 -- * 'pfdtrsEvents'
 pollForDecisionTaskResponse
     :: Int -- ^ 'pfdtrsResponseStatus'
-    -> Text -- ^ 'pfdtrsTaskToken'
     -> Integer -- ^ 'pfdtrsStartedEventId'
     -> WorkflowExecution -- ^ 'pfdtrsWorkflowExecution'
     -> WorkflowType -- ^ 'pfdtrsWorkflowType'
     -> PollForDecisionTaskResponse
-pollForDecisionTaskResponse pResponseStatus_ pTaskToken_ pStartedEventId_ pWorkflowExecution_ pWorkflowType_ =
+pollForDecisionTaskResponse pResponseStatus_ pStartedEventId_ pWorkflowExecution_ pWorkflowType_ =
     PollForDecisionTaskResponse'
     { _pfdtrsNextPageToken = Nothing
     , _pfdtrsPreviousStartedEventId = Nothing
+    , _pfdtrsTaskToken = Nothing
     , _pfdtrsResponseStatus = pResponseStatus_
-    , _pfdtrsTaskToken = pTaskToken_
     , _pfdtrsStartedEventId = pStartedEventId_
     , _pfdtrsWorkflowExecution = pWorkflowExecution_
     , _pfdtrsWorkflowType = pWorkflowType_
@@ -315,15 +314,15 @@ pfdtrsNextPageToken = lens _pfdtrsNextPageToken (\ s a -> s{_pfdtrsNextPageToken
 pfdtrsPreviousStartedEventId :: Lens' PollForDecisionTaskResponse (Maybe Integer)
 pfdtrsPreviousStartedEventId = lens _pfdtrsPreviousStartedEventId (\ s a -> s{_pfdtrsPreviousStartedEventId = a});
 
--- | The response status code.
-pfdtrsResponseStatus :: Lens' PollForDecisionTaskResponse Int
-pfdtrsResponseStatus = lens _pfdtrsResponseStatus (\ s a -> s{_pfdtrsResponseStatus = a});
-
 -- | The opaque string used as a handle on the task. This token is used by
 -- workers to communicate progress and response information back to the
 -- system about the task.
-pfdtrsTaskToken :: Lens' PollForDecisionTaskResponse Text
+pfdtrsTaskToken :: Lens' PollForDecisionTaskResponse (Maybe Text)
 pfdtrsTaskToken = lens _pfdtrsTaskToken (\ s a -> s{_pfdtrsTaskToken = a});
+
+-- | The response status code.
+pfdtrsResponseStatus :: Lens' PollForDecisionTaskResponse Int
+pfdtrsResponseStatus = lens _pfdtrsResponseStatus (\ s a -> s{_pfdtrsResponseStatus = a});
 
 -- | The ID of the 'DecisionTaskStarted' event recorded in the history.
 pfdtrsStartedEventId :: Lens' PollForDecisionTaskResponse Integer

--- a/amazonka-swf/test/Test/AWS/SWF.hs
+++ b/amazonka-swf/test/Test/AWS/SWF.hs
@@ -21,7 +21,6 @@ import           Network.AWS.Prelude
 import           Network.AWS.SWF
 import           Test.AWS.Gen.SWF
 import           Test.AWS.Prelude
-import           Test.Tasty
 
 tests :: [TestTree]
 tests = []
@@ -30,20 +29,21 @@ fixtures :: [TestTree]
 fixtures =
     [ testGroup "response"
         [ testPollForActivityTaskResponse $
-            pollForActivityTaskResponse 200
-                "AAAAKgAAAAEAAAAAAAAAATZDvCYwk/hP/X1ZGdJhb+T6OWzcBx2DPhsIi5HF4aGQI4OXrDE7Ny3uM+aiAhGrmeNyVAa4yNIBQuoZuJA5G+BoaB0JuHFBOynHDTnm7ayNH43KhMkfdrDG4elfHSz3m/EtbLnFGueAr7+3NKDG6x4sTKg3cZpOtSguSx05yI1X3AtscS8ATcLB2Y3Aub1YonN/i/k67voca/GFsSiwSz3AAnJj1IPvrujgIj9KUvckwRPC5ET7d33XJcRp+gHYzZsBLVBaRmV3gEYAnp2ICslFn4YSjGy+dFXCNpOa4G1O8pczCbFUGbQ3+5wf0RSaa/xMq2pfdBKnuFp0wp8kw1k+5ZsbtDZeZn8g5GyKCLiLms/xD0OxugGGUe5ZlAoHEkTWGxZj/G32P7cMoCgrcACfFPdx1LNYYEre7YiGiyjGnfW2t5mW7VK9Np28vcXVbdpH4JNEB9OuB1xqL8N8ifPVtc72uxB1i9XEdq/8rkXasSEw4TubB2FwgqnuJstmfEhpOdb5HfhR6OwmnHuk9eszO/fUkGucTUXQP2hhB+Gz"
-                "verification-27"
-                11
+            pollForActivityTaskResponse 200 11
                 (workflowExecution "20110927-T-1" "cfa2bd33-31b0-4b75-b131-255bb0d97b3f")
                 (activityType "activityVerify" "1.0")
-                & pfatrsInput ?~ "5634-0056-4367-0923,12/12,437"
+                & pfatrsInput      ?~ "5634-0056-4367-0923,12/12,437"
+                & pfatrsActivityId ?~ "verification-27"
+                & pfatrsTaskToken  ?~
+                    "AAAAKgAAAAEAAAAAAAAAATZDvCYwk/hP/X1ZGdJhb+T6OWzcBx2DPhsIi5HF4aGQI4OXrDE7Ny3uM+aiAhGrmeNyVAa4yNIBQuoZuJA5G+BoaB0JuHFBOynHDTnm7ayNH43KhMkfdrDG4elfHSz3m/EtbLnFGueAr7+3NKDG6x4sTKg3cZpOtSguSx05yI1X3AtscS8ATcLB2Y3Aub1YonN/i/k67voca/GFsSiwSz3AAnJj1IPvrujgIj9KUvckwRPC5ET7d33XJcRp+gHYzZsBLVBaRmV3gEYAnp2ICslFn4YSjGy+dFXCNpOa4G1O8pczCbFUGbQ3+5wf0RSaa/xMq2pfdBKnuFp0wp8kw1k+5ZsbtDZeZn8g5GyKCLiLms/xD0OxugGGUe5ZlAoHEkTWGxZj/G32P7cMoCgrcACfFPdx1LNYYEre7YiGiyjGnfW2t5mW7VK9Np28vcXVbdpH4JNEB9OuB1xqL8N8ifPVtc72uxB1i9XEdq/8rkXasSEw4TubB2FwgqnuJstmfEhpOdb5HfhR6OwmnHuk9eszO/fUkGucTUXQP2hhB+Gz"
 
         , testPollForDecisionTaskResponse $
             pollForDecisionTaskResponse 200
-                "AAAAKgAAAAEAAAAAAAAAATZDvCYwk/hP/X1ZGdJhb+T6OWzcBx2DPhsIi5HF4aGQI4OXrDE7Ny3uM+aiAhGrmeNyVAa4yNIBQuoZuJA5G+BoaB0JuHFBOynHDTnm7ayNH43KhMkfdrDG4elfHSz3m/EtbLnFGueAr7+3NKDG6x4sTKg3cZpOtSguSx05yI1X3AtscS8ATcLB2Y3Aub1YonN/i/k67voca/GFsSiwSz3AAnJj1IPvrujgIj9KUvckwRPC5ET7d33XJcRp+gHYzZsBLVBaRmV3gEYAnp2ICslFn4YSjGy+dFXCNpOa4G1O8pczCbFUGbQ3+5wf0RSaa/xMq2pfdBKnuFp0wp8kw1k+5ZsbtDZeZn8g5GyKCLiLms/xD0OxugGGUe5ZlAoHEkTWGxZj/G32P7cMoCgrcACfFPdx1LNYYEre7YiGiyjGnfW2t5mW7VK9Np28vcXVbdpH4JNEB9OuB1xqL8N8ifPVtc72uxB1i9XEdq/8rkXasSEw4TubB2FwgqnuJstmfEhpOdb5HfhR6OwmnHuk9eszO/fUkGucTUXQP2hhB+Gz"
                 3
                 (workflowExecution "20110927-T-1" "06b8f87a-24b3-40b6-9ceb-9676f28e9493")
                 (workflowType "customerOrderWorkflow" "1.0")
+                & pfdtrsTaskToken              ?~
+                    "AAAAKgAAAAEAAAAAAAAAATZDvCYwk/hP/X1ZGdJhb+T6OWzcBx2DPhsIi5HF4aGQI4OXrDE7Ny3uM+aiAhGrmeNyVAa4yNIBQuoZuJA5G+BoaB0JuHFBOynHDTnm7ayNH43KhMkfdrDG4elfHSz3m/EtbLnFGueAr7+3NKDG6x4sTKg3cZpOtSguSx05yI1X3AtscS8ATcLB2Y3Aub1YonN/i/k67voca/GFsSiwSz3AAnJj1IPvrujgIj9KUvckwRPC5ET7d33XJcRp+gHYzZsBLVBaRmV3gEYAnp2ICslFn4YSjGy+dFXCNpOa4G1O8pczCbFUGbQ3+5wf0RSaa/xMq2pfdBKnuFp0wp8kw1k+5ZsbtDZeZn8g5GyKCLiLms/xD0OxugGGUe5ZlAoHEkTWGxZj/G32P7cMoCgrcACfFPdx1LNYYEre7YiGiyjGnfW2t5mW7VK9Np28vcXVbdpH4JNEB9OuB1xqL8N8ifPVtc72uxB1i9XEdq/8rkXasSEw4TubB2FwgqnuJstmfEhpOdb5HfhR6OwmnHuk9eszO/fUkGucTUXQP2hhB+Gz"
                 & pfdtrsPreviousStartedEventId ?~ 0
                 & pfdtrsEvents                 .~
                     [ historyEvent $(mkTime "2012-01-15T03:09:54.566+01:00") DecisionTaskStarted 3

--- a/gen/config/swf.json
+++ b/gen/config/swf.json
@@ -1,5 +1,18 @@
 {
     "referenceUrl": "http://docs.aws.amazon.com/amazonswf/latest/apireference/Welcome.html",
     "operationUrl": "http://docs.aws.amazon.com/amazonswf/latest/apireference/API_",
-    "libraryName": "amazonka-swf"
+    "libraryName": "amazonka-swf",
+    "typeOverrides": {
+        "ActivityTask": {
+            "optionalFields": [
+                "activityId",
+                "taskToken"
+            ]
+        },
+        "DecisionTask": {
+            "optionalFields": [
+                "taskToken"
+            ]
+        }
+    }
 }


### PR DESCRIPTION
Due to the deserialisation issues outlined by @mfine in #257, `taskToken` has been marked as optional for both the `ActivityTask` and `DecisionTask` shapes in the SWF service definition.

Additionally `activityId` has been marked as optional for `ActivityTask` (which is lifted into multiple operation's response types), see #108 for reference.

Fixes #257.