### PR TITLE
APIGateway fixes

### DIFF
--- a/examples/src/Example/APIGateway.hs
+++ b/examples/src/Example/APIGateway.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+
+{-# OPTIONS_GHC -fno-warn-partial-type-signatures #-}
+{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
+{-# OPTIONS_GHC -fno-warn-unused-imports #-}
+
+module Example.APIGateway where
+
+import           Control.Lens
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.AWS
+import           Data.Monoid
+import           Network.AWS.Data
+import           Network.AWS.APIGateway
+import           System.IO
+
+main :: IO ()
+main = do
+    lgr <- newLogger Trace stdout
+    env <- newEnv Ireland Discover <&> envLogger .~ lgr
+    runResourceT (runAWST env go) >>= print
+
+go :: AWST _ _
+go = do
+    restApi <- send (createRestAPI "myApi")
+    let Just apiId = restApi ^. raId
+    resources :: [Resource] <- (view grrsItems) <$> send (getResources apiId)
+    let Just rootId = head resources ^. rId
+    resource :: Resource <- send (createResource apiId rootId "{file}")
+    let Just fileResourceId = resource ^. rId
+    method :: Method <- send (putMethod apiId fileResourceId "GET" "NONE")
+    return method

--- a/gen/annex/apigateway.json
+++ b/gen/annex/apigateway.json
@@ -1,6 +1,7 @@
 {
     "metadata": {
-        "serviceAbbreviation": "APIGateway"
+        "serviceAbbreviation": "APIGateway",
+        "protocol": "api-gateway"
     },
     "shapes": {
         "Blob": {

--- a/gen/src/Gen/AST/Data/Instance.hs
+++ b/gen/src/Gen/AST/Data/Instance.hs
@@ -65,19 +65,21 @@ shapeInsts p m fs = go m
 
     inp :: Protocol -> [Field] -> Inst
     inp = \case
-        JSON     -> ToJSON
-        RestJSON -> ToJSON
-        RestXML  -> ToXML
-        Query    -> ToQuery . map Right
-        EC2      -> ToQuery . map Right
+        JSON       -> ToJSON
+        RestJSON   -> ToJSON
+        RestXML    -> ToXML
+        Query      -> ToQuery . map Right
+        EC2        -> ToQuery . map Right
+        APIGateway -> ToJSON
 
     out :: Protocol -> [Field] -> Inst
     out = \case
-        JSON     -> FromJSON
-        RestJSON -> FromJSON
-        RestXML  -> FromXML
-        Query    -> FromXML
-        EC2      -> FromXML
+        JSON       -> FromJSON
+        RestJSON   -> FromJSON
+        RestXML    -> FromXML
+        Query      -> FromXML
+        EC2        -> FromXML
+        APIGateway -> FromJSON
 
 requestInsts :: HasMetadata a f
              => a
@@ -183,12 +185,14 @@ requestInsts m oname h r fs = do
 
     protocolHeaders :: [(Text, Text)]
     protocolHeaders = case p of
-        JSON     -> t ++ c
-        RestJSON -> c
-        _        -> []
+        JSON       -> t ++ c
+        RestJSON   -> c
+        APIGateway -> j ++ c
+        _          -> []
       where
         t = maybeToList $ ("X-Amz-Target",) <$> target
         c = maybeToList $ ("Content-Type",) <$> content
+        j = [("Accept", "application/json")]
 
     protocolQuery :: [(Text, Maybe Text)]
     protocolQuery = case p of

--- a/gen/src/Gen/AST/Data/Syntax.hs
+++ b/gen/src/Gen/AST/Data/Syntax.hs
@@ -332,6 +332,7 @@ responseE p r fs = app (responseF p r fs) bdy
             _ | f ^. fieldPayload -> parseOne   f
             JSON                  -> parseJSONE p pJE pJEMay pJEDef f
             RestJSON              -> parseJSONE p pJE pJEMay pJEDef f
+            APIGateway            -> parseJSONE p pJE pJEMay pJEDef f
             _                     -> parseXMLE  p f
 
     parseOne :: Field -> Exp
@@ -347,9 +348,10 @@ responseE p r fs = app (responseF p r fs) bdy
     parseAll :: Exp
     parseAll = flip app (var "x") $
         case p of
-            JSON     -> var "eitherParseJSON"
-            RestJSON -> var "eitherParseJSON"
-            _        -> var "parseXML"
+            JSON       -> var "eitherParseJSON"
+            RestJSON   -> var "eitherParseJSON"
+            APIGateway -> var "eitherParseJSON"
+            _          -> var "parseXML"
 
     body = any fieldStream fs
 

--- a/gen/src/Gen/Protocol.hs
+++ b/gen/src/Gen/Protocol.hs
@@ -31,11 +31,12 @@ data Level = Flat | Nest
 
 suffix :: Protocol -> Text
 suffix = \case
-    JSON     -> "JSON"
-    RestJSON -> "JSON"
-    RestXML  -> "XML"
-    Query    -> "XML"
-    EC2      -> "XML"
+    JSON       -> "JSON"
+    RestJSON   -> "JSON"
+    APIGateway -> "JSON"
+    RestXML    -> "XML"
+    Query      -> "XML"
+    EC2        -> "XML"
 
 data Names
     = NMap  (Maybe Text) Text Text Text

--- a/gen/src/Gen/Types/Service.hs
+++ b/gen/src/Gen/Types/Service.hs
@@ -100,6 +100,7 @@ data Protocol
     | RestXML
     | Query
     | EC2
+    | APIGateway
       deriving (Eq, Show, Generic)
 
 instance FromJSON Protocol where
@@ -107,19 +108,21 @@ instance FromJSON Protocol where
 
 instance ToJSON Protocol where
     toJSON = String . \case
-        JSON     -> "JSON"
-        RestJSON -> "JSON"
-        RestXML  -> "XML"
-        Query    -> "Query"
-        EC2      -> "Query"
+        JSON       -> "JSON"
+        RestJSON   -> "JSON"
+        RestXML    -> "XML"
+        Query      -> "Query"
+        EC2        -> "Query"
+        APIGateway -> "APIGateway"
 
 timestamp :: Protocol -> Timestamp
 timestamp = \case
-    JSON     -> POSIX
-    RestJSON -> POSIX
-    RestXML  -> ISO8601
-    Query    -> ISO8601
-    EC2      -> ISO8601
+    JSON       -> POSIX
+    RestJSON   -> POSIX
+    RestXML    -> ISO8601
+    Query      -> ISO8601
+    EC2        -> ISO8601
+    APIGateway -> POSIX
 
 data Checksum
     = MD5
@@ -432,11 +435,12 @@ instance ToJSON (Metadata Identity) where
 serviceError :: HasMetadata a f => a -> Text
 serviceError m =
     case m ^. protocol of
-        JSON     -> "parseJSONError"
-        RestJSON -> "parseJSONError"
-        RestXML  -> "parseXMLError"
-        Query    -> "parseXMLError"
-        EC2      -> "parseXMLError"
+        JSON       -> "parseJSONError"
+        RestJSON   -> "parseJSONError"
+        RestXML    -> "parseXMLError"
+        Query      -> "parseXMLError"
+        EC2        -> "parseXMLError"
+        APIGateway -> "parseJSONError"
 
 serviceFunction :: HasMetadata a f => a -> Text
 serviceFunction m = lowerHead (m ^. serviceAbbrev)


### PR DESCRIPTION
Turns out, APIGateway has two protocol modes, `Accept: application/hal+json` and `Accept: application/json` where the latter is the one that's actually specified in the botocore spec.

`make -C release MODELS=model/apigateway` generates a thorough diff (updated `ToHeaders` for every request), which is not included.

The only reason I added a whole protocol to `gen` is to set the header because `requestInsts` matches on the protocol. It probably makes sense to remove it to make the patch more lightweight, however earlier versions of the patch included a ton of changes for the timestamp format and for pulling the root resource id by parsing stuff in `_links` before I realised I should try see what botocore does. (｡･ω..･)っ So let me know if you'd like the change to be done differently.