### PR TITLE
AttachmentStatus missing "available" (#273)

### DIFF
--- a/amazonka-ec2/gen/Network/AWS/EC2/Types/Sum.hs
+++ b/amazonka-ec2/gen/Network/AWS/EC2/Types/Sum.hs
@@ -181,6 +181,7 @@ data AttachmentStatus
     | Busy
     | Detached
     | Detaching
+    | IsAvailable
     deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText AttachmentStatus where
@@ -190,8 +191,9 @@ instance FromText AttachmentStatus where
         "busy" -> pure Busy
         "detached" -> pure Detached
         "detaching" -> pure Detaching
+        "available" -> pure IsAvailable
         e -> fromTextError $ "Failure parsing AttachmentStatus from value: '" <> e
-           <> "'. Accepted values: attached, attaching, busy, detached, detaching"
+           <> "'. Accepted values: attached, attaching, busy, detached, detaching, available"
 
 instance ToText AttachmentStatus where
     toText = \case

--- a/gen/annex/ec2.json
+++ b/gen/annex/ec2.json
@@ -5,6 +5,7 @@
     "shapes": {
         "AttachmentStatus": {
             "enum":[
+                "available",
                 "attaching",
                 "attached",
                 "detaching",


### PR DESCRIPTION
I mean this is clearly not in the API docs either, so there's that, too.

The latest API version I can find is [API Version 2015-10-01][APIRef],
and it clearly fails to mention "available" as a state. On the
management console, there are two states, too.

1. State: attached
2. Attachment state: available

I'm just going to guess that this means it's attached to the VPC, and
it's available for routing traffic, but that's definitely a guess.

I've also just tested that this change fixes this error.

Thanks!

[APIRef]: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_InternetGatewayAttachment.html "Latest API for InternetGatewayAttachment"