### PR TITLE
Override EC2 AttachmentStatus to support 'available'

### DIFF
--- a/amazonka-ec2/gen/Network/AWS/EC2/Types/Sum.hs
+++ b/amazonka-ec2/gen/Network/AWS/EC2/Types/Sum.hs
@@ -178,6 +178,7 @@ instance FromXML ArchitectureValues where
 data AttachmentStatus
     = Attached
     | Attaching
+    | Available
     | Busy
     | Detached
     | Detaching
@@ -187,16 +188,18 @@ instance FromText AttachmentStatus where
     parser = takeLowerText >>= \case
         "attached" -> pure Attached
         "attaching" -> pure Attaching
+        "available" -> pure Available
         "busy" -> pure Busy
         "detached" -> pure Detached
         "detaching" -> pure Detaching
         e -> fromTextError $ "Failure parsing AttachmentStatus from value: '" <> e
-           <> "'. Accepted values: attached, attaching, busy, detached, detaching"
+           <> "'. Accepted values: attached, attaching, available, busy, detached, detaching"
 
 instance ToText AttachmentStatus where
     toText = \case
         Attached -> "attached"
         Attaching -> "attaching"
+        Available -> "available"
         Busy -> "busy"
         Detached -> "detached"
         Detaching -> "detaching"
@@ -623,24 +626,24 @@ instance FromXML EventCode where
     parseXML = parseXMLText "EventCode"
 
 data EventType
-    = Error'
-    | FleetRequestChange
-    | InstanceChange
+    = ETError'
+    | ETFleetRequestChange
+    | ETInstanceChange
     deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText EventType where
     parser = takeLowerText >>= \case
-        "error" -> pure Error'
-        "fleetrequestchange" -> pure FleetRequestChange
-        "instancechange" -> pure InstanceChange
+        "error" -> pure ETError'
+        "fleetrequestchange" -> pure ETFleetRequestChange
+        "instancechange" -> pure ETInstanceChange
         e -> fromTextError $ "Failure parsing EventType from value: '" <> e
            <> "'. Accepted values: error, fleetRequestChange, instanceChange"
 
 instance ToText EventType where
     toText = \case
-        Error' -> "error"
-        FleetRequestChange -> "fleetRequestChange"
-        InstanceChange -> "instanceChange"
+        ETError' -> "error"
+        ETFleetRequestChange -> "fleetRequestChange"
+        ETInstanceChange -> "instanceChange"
 
 instance Hashable     EventType
 instance ToByteString EventType
@@ -1552,27 +1555,27 @@ instance FromXML PermissionGroup where
     parseXML = parseXMLText "PermissionGroup"
 
 data PlacementGroupState
-    = Available
-    | Deleted
-    | Deleting
-    | Pending
+    = PGSAvailable
+    | PGSDeleted
+    | PGSDeleting
+    | PGSPending
     deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText PlacementGroupState where
     parser = takeLowerText >>= \case
-        "available" -> pure Available
-        "deleted" -> pure Deleted
-        "deleting" -> pure Deleting
-        "pending" -> pure Pending
+        "available" -> pure PGSAvailable
+        "deleted" -> pure PGSDeleted
+        "deleting" -> pure PGSDeleting
+        "pending" -> pure PGSPending
         e -> fromTextError $ "Failure parsing PlacementGroupState from value: '" <> e
            <> "'. Accepted values: available, deleted, deleting, pending"
 
 instance ToText PlacementGroupState where
     toText = \case
-        Available -> "available"
-        Deleted -> "deleted"
-        Deleting -> "deleting"
-        Pending -> "pending"
+        PGSAvailable -> "available"
+        PGSDeleted -> "deleted"
+        PGSDeleting -> "deleting"
+        PGSPending -> "pending"
 
 instance Hashable     PlacementGroupState
 instance ToByteString PlacementGroupState
@@ -2012,24 +2015,24 @@ instance ToQuery      SnapshotAttributeName
 instance ToHeader     SnapshotAttributeName
 
 data SnapshotState
-    = SSCompleted
-    | SSError'
-    | SSPending
+    = Completed
+    | Error'
+    | Pending
     deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText SnapshotState where
     parser = takeLowerText >>= \case
-        "completed" -> pure SSCompleted
-        "error" -> pure SSError'
-        "pending" -> pure SSPending
+        "completed" -> pure Completed
+        "error" -> pure Error'
+        "pending" -> pure Pending
         e -> fromTextError $ "Failure parsing SnapshotState from value: '" <> e
            <> "'. Accepted values: completed, error, pending"
 
 instance ToText SnapshotState where
     toText = \case
-        SSCompleted -> "completed"
-        SSError' -> "error"
-        SSPending -> "pending"
+        Completed -> "completed"
+        Error' -> "error"
+        Pending -> "pending"
 
 instance Hashable     SnapshotState
 instance ToByteString SnapshotState
@@ -2183,21 +2186,21 @@ instance FromXML StatusType where
     parseXML = parseXMLText "StatusType"
 
 data SubnetState
-    = SubAvailable
-    | SubPending
+    = SSAvailable
+    | SSPending
     deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText SubnetState where
     parser = takeLowerText >>= \case
-        "available" -> pure SubAvailable
-        "pending" -> pure SubPending
+        "available" -> pure SSAvailable
+        "pending" -> pure SSPending
         e -> fromTextError $ "Failure parsing SubnetState from value: '" <> e
            <> "'. Accepted values: available, pending"
 
 instance ToText SubnetState where
     toText = \case
-        SubAvailable -> "available"
-        SubPending -> "pending"
+        SSAvailable -> "available"
+        SSPending -> "pending"
 
 instance Hashable     SubnetState
 instance ToByteString SubnetState

--- a/amazonka-ec2/gen/Network/AWS/EC2/Types/Sum.hs
+++ b/amazonka-ec2/gen/Network/AWS/EC2/Types/Sum.hs
@@ -176,33 +176,33 @@ instance FromXML ArchitectureValues where
     parseXML = parseXMLText "ArchitectureValues"
 
 data AttachmentStatus
-    = Attached
-    | Attaching
-    | Available
-    | Busy
-    | Detached
-    | Detaching
+    = AAttached
+    | AAttaching
+    | AAvailable
+    | ABusy
+    | ADetached
+    | ADetaching
     deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText AttachmentStatus where
     parser = takeLowerText >>= \case
-        "attached" -> pure Attached
-        "attaching" -> pure Attaching
-        "available" -> pure Available
-        "busy" -> pure Busy
-        "detached" -> pure Detached
-        "detaching" -> pure Detaching
+        "attached" -> pure AAttached
+        "attaching" -> pure AAttaching
+        "available" -> pure AAvailable
+        "busy" -> pure ABusy
+        "detached" -> pure ADetached
+        "detaching" -> pure ADetaching
         e -> fromTextError $ "Failure parsing AttachmentStatus from value: '" <> e
            <> "'. Accepted values: attached, attaching, available, busy, detached, detaching"
 
 instance ToText AttachmentStatus where
     toText = \case
-        Attached -> "attached"
-        Attaching -> "attaching"
-        Available -> "available"
-        Busy -> "busy"
-        Detached -> "detached"
-        Detaching -> "detaching"
+        AAttached -> "attached"
+        AAttaching -> "attaching"
+        AAvailable -> "available"
+        ABusy -> "busy"
+        ADetached -> "detached"
+        ADetaching -> "detaching"
 
 instance Hashable     AttachmentStatus
 instance ToByteString AttachmentStatus
@@ -626,24 +626,24 @@ instance FromXML EventCode where
     parseXML = parseXMLText "EventCode"
 
 data EventType
-    = ETError'
-    | ETFleetRequestChange
-    | ETInstanceChange
+    = Error'
+    | FleetRequestChange
+    | InstanceChange
     deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText EventType where
     parser = takeLowerText >>= \case
-        "error" -> pure ETError'
-        "fleetrequestchange" -> pure ETFleetRequestChange
-        "instancechange" -> pure ETInstanceChange
+        "error" -> pure Error'
+        "fleetrequestchange" -> pure FleetRequestChange
+        "instancechange" -> pure InstanceChange
         e -> fromTextError $ "Failure parsing EventType from value: '" <> e
            <> "'. Accepted values: error, fleetRequestChange, instanceChange"
 
 instance ToText EventType where
     toText = \case
-        ETError' -> "error"
-        ETFleetRequestChange -> "fleetRequestChange"
-        ETInstanceChange -> "instanceChange"
+        Error' -> "error"
+        FleetRequestChange -> "fleetRequestChange"
+        InstanceChange -> "instanceChange"
 
 instance Hashable     EventType
 instance ToByteString EventType
@@ -1555,27 +1555,27 @@ instance FromXML PermissionGroup where
     parseXML = parseXMLText "PermissionGroup"
 
 data PlacementGroupState
-    = PGSAvailable
-    | PGSDeleted
-    | PGSDeleting
-    | PGSPending
+    = Available
+    | Deleted
+    | Deleting
+    | Pending
     deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText PlacementGroupState where
     parser = takeLowerText >>= \case
-        "available" -> pure PGSAvailable
-        "deleted" -> pure PGSDeleted
-        "deleting" -> pure PGSDeleting
-        "pending" -> pure PGSPending
+        "available" -> pure Available
+        "deleted" -> pure Deleted
+        "deleting" -> pure Deleting
+        "pending" -> pure Pending
         e -> fromTextError $ "Failure parsing PlacementGroupState from value: '" <> e
            <> "'. Accepted values: available, deleted, deleting, pending"
 
 instance ToText PlacementGroupState where
     toText = \case
-        PGSAvailable -> "available"
-        PGSDeleted -> "deleted"
-        PGSDeleting -> "deleting"
-        PGSPending -> "pending"
+        Available -> "available"
+        Deleted -> "deleted"
+        Deleting -> "deleting"
+        Pending -> "pending"
 
 instance Hashable     PlacementGroupState
 instance ToByteString PlacementGroupState
@@ -2015,24 +2015,24 @@ instance ToQuery      SnapshotAttributeName
 instance ToHeader     SnapshotAttributeName
 
 data SnapshotState
-    = Completed
-    | Error'
-    | Pending
+    = SSCompleted
+    | SSError'
+    | SSPending
     deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText SnapshotState where
     parser = takeLowerText >>= \case
-        "completed" -> pure Completed
-        "error" -> pure Error'
-        "pending" -> pure Pending
+        "completed" -> pure SSCompleted
+        "error" -> pure SSError'
+        "pending" -> pure SSPending
         e -> fromTextError $ "Failure parsing SnapshotState from value: '" <> e
            <> "'. Accepted values: completed, error, pending"
 
 instance ToText SnapshotState where
     toText = \case
-        Completed -> "completed"
-        Error' -> "error"
-        Pending -> "pending"
+        SSCompleted -> "completed"
+        SSError' -> "error"
+        SSPending -> "pending"
 
 instance Hashable     SnapshotState
 instance ToByteString SnapshotState
@@ -2186,21 +2186,21 @@ instance FromXML StatusType where
     parseXML = parseXMLText "StatusType"
 
 data SubnetState
-    = SSAvailable
-    | SSPending
+    = SubAvailable
+    | SubPending
     deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText SubnetState where
     parser = takeLowerText >>= \case
-        "available" -> pure SSAvailable
-        "pending" -> pure SSPending
+        "available" -> pure SubAvailable
+        "pending" -> pure SubPending
         e -> fromTextError $ "Failure parsing SubnetState from value: '" <> e
            <> "'. Accepted values: available, pending"
 
 instance ToText SubnetState where
     toText = \case
-        SSAvailable -> "available"
-        SSPending -> "pending"
+        SubAvailable -> "available"
+        SubPending -> "pending"
 
 instance Hashable     SubnetState
 instance ToByteString SubnetState
@@ -2497,30 +2497,30 @@ instance FromXML VirtualizationType where
     parseXML = parseXMLText "VirtualizationType"
 
 data VolumeAttachmentState
-    = VASAttached
-    | VASAttaching
-    | VASBusy
-    | VASDetached
-    | VASDetaching
+    = VAttached
+    | VAttaching
+    | VBusy
+    | VDetached
+    | VDetaching
     deriving (Eq,Ord,Read,Show,Enum,Bounded,Data,Typeable,Generic)
 
 instance FromText VolumeAttachmentState where
     parser = takeLowerText >>= \case
-        "attached" -> pure VASAttached
-        "attaching" -> pure VASAttaching
-        "busy" -> pure VASBusy
-        "detached" -> pure VASDetached
-        "detaching" -> pure VASDetaching
+        "attached" -> pure VAttached
+        "attaching" -> pure VAttaching
+        "busy" -> pure VBusy
+        "detached" -> pure VDetached
+        "detaching" -> pure VDetaching
         e -> fromTextError $ "Failure parsing VolumeAttachmentState from value: '" <> e
            <> "'. Accepted values: attached, attaching, busy, detached, detaching"
 
 instance ToText VolumeAttachmentState where
     toText = \case
-        VASAttached -> "attached"
-        VASAttaching -> "attaching"
-        VASBusy -> "busy"
-        VASDetached -> "detached"
-        VASDetaching -> "detaching"
+        VAttached -> "attached"
+        VAttaching -> "attaching"
+        VBusy -> "busy"
+        VDetached -> "detached"
+        VDetaching -> "detaching"
 
 instance Hashable     VolumeAttachmentState
 instance ToByteString VolumeAttachmentState

--- a/amazonka-ec2/test/Test/AWS/EC2.hs
+++ b/amazonka-ec2/test/Test/AWS/EC2.hs
@@ -97,7 +97,7 @@ fixtures =
                                         & ibdmEBS        ?~
                                             (ebsInstanceBlockDevice
                                                 & eibdDeleteOnTermination ?~ True
-                                                & eibdStatus              ?~ Attached
+                                                & eibdStatus              ?~ AAttached
                                                 & eibdVolumeId            ?~ "vol-1a2b3c4d"
                                                 & eibdAttachTime          ?~ $(mkTime "2014-03-18T21:47:02+0000"))
                                     ]
@@ -116,7 +116,7 @@ fixtures =
                                         & iniAttachment          ?~
                                             (instanceNetworkInterfaceAttachment
                                                 & iniaDeleteOnTermination ?~ True
-                                                & iniaStatus              ?~ Attached
+                                                & iniaStatus              ?~ AAttached
                                                 & iniaAttachmentId        ?~ "eni-attach-1a2b3c4d"
                                                 & iniaAttachTime          ?~ $(mkTime "2014-03-18T21:47:02+0000")
                                                 & iniaDeviceIndex         ?~ 0)

--- a/gen/annex/ec2.json
+++ b/gen/annex/ec2.json
@@ -9,7 +9,8 @@
                 "attached",
                 "detaching",
                 "detached",
-                "busy"
+                "busy",
+                "available"
             ]
         },
         "VolumeAttachmentState": {

--- a/gen/config/ec2.json
+++ b/gen/config/ec2.json
@@ -212,6 +212,12 @@
             "requiredFields": [
                 "Status"
             ]
+        },
+        "AttachmentStatus": {
+            "enumPrefix": "A"
+        },
+        "VolumeAttachmentState": {
+            "enumPrefix": "V"
         }
     }
 }


### PR DESCRIPTION
Adds additional annex+config overrides to support `AttachmentStatus.available`. 

Since the constructor name `Available` introduced by this change would be non-unique, the prefixing steps in the generator cause cascade of renaming to occur unless  the `enumPrefix` is configured. Both `VolumeAttachmentState` and `AttachmentStatus` now have `enumPrefix`es set to prevent this.

See #274.