### PR TITLE
Override EC2 DeleteTags to use custom DeleteTag type

### DIFF
--- a/amazonka-ec2/amazonka-ec2.cabal
+++ b/amazonka-ec2/amazonka-ec2.cabal
@@ -250,7 +250,8 @@ library
         , Network.AWS.EC2.Waiters
 
     other-modules:
-          Network.AWS.EC2.Types.Product
+          Network.AWS.EC2.Internal
+        , Network.AWS.EC2.Types.Product
         , Network.AWS.EC2.Types.Sum
 
     build-depends:

--- a/amazonka-ec2/gen/Network/AWS/EC2.hs
+++ b/amazonka-ec2/gen/Network/AWS/EC2.hs
@@ -714,6 +714,9 @@ module Network.AWS.EC2
 
     -- * Types
 
+    -- ** Re-exported Types
+    , module Network.AWS.EC2.Internal
+
     -- ** AccountAttributeName
     , AccountAttributeName (..)
 
@@ -2771,6 +2774,7 @@ import           Network.AWS.EC2.ImportInstance
 import           Network.AWS.EC2.ImportKeyPair
 import           Network.AWS.EC2.ImportSnapshot
 import           Network.AWS.EC2.ImportVolume
+import           Network.AWS.EC2.Internal
 import           Network.AWS.EC2.ModifyHosts
 import           Network.AWS.EC2.ModifyIdFormat
 import           Network.AWS.EC2.ModifyImageAttribute

--- a/amazonka-ec2/gen/Network/AWS/EC2/Types.hs
+++ b/amazonka-ec2/gen/Network/AWS/EC2/Types.hs
@@ -17,6 +17,9 @@ module Network.AWS.EC2.Types
 
     -- * Errors
 
+    -- * Re-exported Types
+    , module Network.AWS.EC2.Internal
+
     -- * AccountAttributeName
     , AccountAttributeName (..)
 
@@ -1917,6 +1920,7 @@ module Network.AWS.EC2.Types
     , vsiVolumeId
     ) where
 
+import           Network.AWS.EC2.Internal
 import           Network.AWS.EC2.Types.Product
 import           Network.AWS.EC2.Types.Sum
 import           Network.AWS.Lens

--- a/amazonka-ec2/gen/Network/AWS/EC2/Types/Product.hs
+++ b/amazonka-ec2/gen/Network/AWS/EC2/Types/Product.hs
@@ -17,6 +17,7 @@
 --
 module Network.AWS.EC2.Types.Product where
 
+import           Network.AWS.EC2.Internal
 import           Network.AWS.EC2.Types.Sum
 import           Network.AWS.Lens
 import           Network.AWS.Prelude

--- a/amazonka-ec2/gen/Network/AWS/EC2/Types/Sum.hs
+++ b/amazonka-ec2/gen/Network/AWS/EC2/Types/Sum.hs
@@ -17,6 +17,7 @@
 --
 module Network.AWS.EC2.Types.Sum where
 
+import           Network.AWS.EC2.Internal
 import           Network.AWS.Prelude
 
 data AccountAttributeName

--- a/amazonka-ec2/src/Network/AWS/EC2/Internal.hs
+++ b/amazonka-ec2/src/Network/AWS/EC2/Internal.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE RecordWildCards    #-}
+
+-- |
+-- Module      : Network.AWS.EC2.Internal
+-- Copyright   : (c) 2013-2015 Brendan Hay
+-- License     : Mozilla Public License, v. 2.0.
+-- Maintainer  : Brendan Hay <brendan.g.hay@gmail.com>
+-- Stability   : experimental
+-- Portability : non-portable (GHC extensions)
+--
+module Network.AWS.EC2.Internal where
+
+import           Network.AWS.Lens
+import           Network.AWS.Prelude
+
+-- | Custom 'Tag' type which has an optional value component.
+--
+-- /See:/ 'tag' smart constructor.
+data DeleteTag = DeleteTag
+    { _deleteTagKey   :: !Text
+    , _deleteTagValue :: !(Maybe Text)
+    } deriving (Eq, Read, Show, Data, Typeable, Generic)
+
+deleteTag :: Text -- ^ 'deleteTagKey'
+          -> DeleteTag
+deleteTag k = DeleteTag k Nothing
+
+-- | The key of the tag to delete.
+--
+-- Constraints: Tag keys are case-sensitive and accept a maximum of 127
+-- Unicode characters. May not begin with 'aws:'
+deleteTagKey :: Lens' DeleteTag Text
+deleteTagKey = lens _deleteTagKey (\s a -> s { _deleteTagKey = a })
+
+-- | The optional value of the tag to delete.
+--
+-- Constraints: Tag values are case-sensitive and accept a maximum of 255
+-- Unicode characters.
+deleteTagValue :: Lens' DeleteTag (Maybe Text)
+deleteTagValue = lens _deleteTagValue (\ s a -> s{_deleteTagValue = a});
+
+instance FromXML DeleteTag where
+    parseXML x = DeleteTag <$> (x .@ "key") <*> (x .@? "value")
+
+instance ToQuery DeleteTag where
+    toQuery DeleteTag {..} = mconcat
+        [ "Key"   =: _deleteTagKey
+        , "Value" =: _deleteTagValue
+        ]

--- a/gen/annex/ec2.json
+++ b/gen/annex/ec2.json
@@ -21,6 +21,22 @@
                 "detached",
                 "busy"
             ]
+        },
+        "DeleteTag": {
+            "type": "structure",
+            "members": {}
+        },
+        "DeleteTagList":{
+            "type": "list",
+            "member": {
+                "shape": "DeleteTag",
+                "locationName": "item"
+            }
+        },
+        "DeleteTagsRequest": {
+            "Tags": {
+                "shape": "DeleteTagList"
+            }
         }
     },
     "waiters": {

--- a/gen/config/ec2.json
+++ b/gen/config/ec2.json
@@ -4,6 +4,9 @@
         "ConsoleOutputAvailable",
         "KeyPairExists"
     ],
+    "typeModules": [
+        "Network.AWS.EC2.Internal"
+    ],
     "typeOverrides": {
         "Status": {
             "renamedTo": "AddressStatus"
@@ -218,6 +221,12 @@
         },
         "VolumeAttachmentState": {
             "enumPrefix": "V"
+        },
+        "DeleteTag": {
+            "replacedBy": {
+                "name": "DeleteTag",
+                "deriving": []
+            }
         }
     }
 }


### PR DESCRIPTION
The `DeleteTag` type features a value component which will not be serialised if absent/unset.

Fixes #270.