### PR TITLE
Add ImageExists to ec2 annex file in generator

### DIFF
--- a/gen/annex/ec2.json
+++ b/gen/annex/ec2.json
@@ -75,6 +75,23 @@
                     "state": "retry"
                 }
             ]
+        },
+        "ImageExists": {
+            "delay": 5,
+            "maxAttempts": 40,
+            "operation": "DescribeImages",
+            "acceptors": [
+                {
+                    "matcher": "status",
+                    "expected": 200,
+                    "state": "success"
+                },
+                {
+                    "matcher": "error",
+                    "expected": "InvalidAMIIDNotFound",
+                    "state": "retry"
+                }
+            ]
         }
     }
 }


### PR DESCRIPTION
Required for creating image-related ec2 functions

Fixes #287