### PR TITLE
Add non-streaming response body to thrown serialisation errors

### DIFF
--- a/amazonka-apigateway/gen/Network/AWS/APIGateway/Types.hs
+++ b/amazonka-apigateway/gen/Network/AWS/APIGateway/Types.hs
@@ -247,7 +247,7 @@ apiGateway =
     , _svcEndpoint = defaultEndpoint apiGateway
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "APIGateway"
     , _svcRetry = retry
     }
   where

--- a/amazonka-application-autoscaling/gen/Network/AWS/ApplicationAutoScaling/Types.hs
+++ b/amazonka-application-autoscaling/gen/Network/AWS/ApplicationAutoScaling/Types.hs
@@ -121,7 +121,7 @@ applicationAutoScaling =
     , _svcEndpoint = defaultEndpoint applicationAutoScaling
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "ApplicationAutoScaling"
     , _svcRetry = retry
     }
   where

--- a/amazonka-autoscaling/gen/Network/AWS/AutoScaling/Types.hs
+++ b/amazonka-autoscaling/gen/Network/AWS/AutoScaling/Types.hs
@@ -285,7 +285,7 @@ autoScaling =
     , _svcEndpoint = defaultEndpoint autoScaling
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseXMLError
+    , _svcError = parseXMLError "AutoScaling"
     , _svcRetry = retry
     }
   where

--- a/amazonka-certificatemanager/gen/Network/AWS/CertificateManager/Types.hs
+++ b/amazonka-certificatemanager/gen/Network/AWS/CertificateManager/Types.hs
@@ -99,7 +99,7 @@ certificateManager =
     , _svcEndpoint = defaultEndpoint certificateManager
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "CertificateManager"
     , _svcRetry = retry
     }
   where

--- a/amazonka-cloudformation/gen/Network/AWS/CloudFormation/Types.hs
+++ b/amazonka-cloudformation/gen/Network/AWS/CloudFormation/Types.hs
@@ -253,7 +253,7 @@ cloudFormation =
     , _svcEndpoint = defaultEndpoint cloudFormation
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseXMLError
+    , _svcError = parseXMLError "CloudFormation"
     , _svcRetry = retry
     }
   where

--- a/amazonka-cloudfront/gen/Network/AWS/CloudFront/Types.hs
+++ b/amazonka-cloudfront/gen/Network/AWS/CloudFront/Types.hs
@@ -496,7 +496,7 @@ cloudFront =
     , _svcEndpoint = defaultEndpoint cloudFront
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseXMLError
+    , _svcError = parseXMLError "CloudFront"
     , _svcRetry = retry
     }
   where

--- a/amazonka-cloudhsm/gen/Network/AWS/CloudHSM/Types.hs
+++ b/amazonka-cloudhsm/gen/Network/AWS/CloudHSM/Types.hs
@@ -56,7 +56,7 @@ cloudHSM =
     , _svcEndpoint = defaultEndpoint cloudHSM
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "CloudHSM"
     , _svcRetry = retry
     }
   where

--- a/amazonka-cloudsearch-domains/gen/Network/AWS/CloudSearchDomains/Types.hs
+++ b/amazonka-cloudsearch-domains/gen/Network/AWS/CloudSearchDomains/Types.hs
@@ -113,7 +113,7 @@ cloudSearchDomains =
     , _svcEndpoint = defaultEndpoint cloudSearchDomains
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "CloudSearchDomains"
     , _svcRetry = retry
     }
   where

--- a/amazonka-cloudsearch/gen/Network/AWS/CloudSearch/Types.hs
+++ b/amazonka-cloudsearch/gen/Network/AWS/CloudSearch/Types.hs
@@ -302,7 +302,7 @@ cloudSearch =
     , _svcEndpoint = defaultEndpoint cloudSearch
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseXMLError
+    , _svcError = parseXMLError "CloudSearch"
     , _svcRetry = retry
     }
   where

--- a/amazonka-cloudtrail/gen/Network/AWS/CloudTrail/Types.hs
+++ b/amazonka-cloudtrail/gen/Network/AWS/CloudTrail/Types.hs
@@ -128,7 +128,7 @@ cloudTrail =
     , _svcEndpoint = defaultEndpoint cloudTrail
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "CloudTrail"
     , _svcRetry = retry
     }
   where

--- a/amazonka-cloudwatch-events/gen/Network/AWS/CloudWatchEvents/Types.hs
+++ b/amazonka-cloudwatch-events/gen/Network/AWS/CloudWatchEvents/Types.hs
@@ -92,7 +92,7 @@ cloudWatchEvents =
     , _svcEndpoint = defaultEndpoint cloudWatchEvents
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "CloudWatchEvents"
     , _svcRetry = retry
     }
   where

--- a/amazonka-cloudwatch-logs/gen/Network/AWS/CloudWatchLogs/Types.hs
+++ b/amazonka-cloudwatch-logs/gen/Network/AWS/CloudWatchLogs/Types.hs
@@ -174,7 +174,7 @@ cloudWatchLogs =
     , _svcEndpoint = defaultEndpoint cloudWatchLogs
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "CloudWatchLogs"
     , _svcRetry = retry
     }
   where

--- a/amazonka-cloudwatch/gen/Network/AWS/CloudWatch/Types.hs
+++ b/amazonka-cloudwatch/gen/Network/AWS/CloudWatch/Types.hs
@@ -140,7 +140,7 @@ cloudWatch =
     , _svcEndpoint = defaultEndpoint cloudWatch
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseXMLError
+    , _svcError = parseXMLError "CloudWatch"
     , _svcRetry = retry
     }
   where

--- a/amazonka-codecommit/gen/Network/AWS/CodeCommit/Types.hs
+++ b/amazonka-codecommit/gen/Network/AWS/CodeCommit/Types.hs
@@ -139,7 +139,7 @@ codeCommit =
     , _svcEndpoint = defaultEndpoint codeCommit
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "CodeCommit"
     , _svcRetry = retry
     }
   where

--- a/amazonka-codedeploy/gen/Network/AWS/CodeDeploy/Types.hs
+++ b/amazonka-codedeploy/gen/Network/AWS/CodeDeploy/Types.hs
@@ -328,7 +328,7 @@ codeDeploy =
     , _svcEndpoint = defaultEndpoint codeDeploy
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "CodeDeploy"
     , _svcRetry = retry
     }
   where

--- a/amazonka-codepipeline/gen/Network/AWS/CodePipeline/Types.hs
+++ b/amazonka-codepipeline/gen/Network/AWS/CodePipeline/Types.hs
@@ -360,7 +360,7 @@ codePipeline =
     , _svcEndpoint = defaultEndpoint codePipeline
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "CodePipeline"
     , _svcRetry = retry
     }
   where

--- a/amazonka-cognito-identity/gen/Network/AWS/CognitoIdentity/Types.hs
+++ b/amazonka-cognito-identity/gen/Network/AWS/CognitoIdentity/Types.hs
@@ -94,7 +94,7 @@ cognitoIdentity =
     , _svcEndpoint = defaultEndpoint cognitoIdentity
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "CognitoIdentity"
     , _svcRetry = retry
     }
   where

--- a/amazonka-cognito-idp/gen/Network/AWS/CognitoIdentityProvider/Types.hs
+++ b/amazonka-cognito-idp/gen/Network/AWS/CognitoIdentityProvider/Types.hs
@@ -194,7 +194,7 @@ cognitoIdentityProvider =
     , _svcEndpoint = defaultEndpoint cognitoIdentityProvider
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "CognitoIdentityProvider"
     , _svcRetry = retry
     }
   where

--- a/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/Types.hs
+++ b/amazonka-cognito-sync/gen/Network/AWS/CognitoSync/Types.hs
@@ -120,7 +120,7 @@ cognitoSync =
     , _svcEndpoint = defaultEndpoint cognitoSync
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "CognitoSync"
     , _svcRetry = retry
     }
   where

--- a/amazonka-config/gen/Network/AWS/Config/Types.hs
+++ b/amazonka-config/gen/Network/AWS/Config/Types.hs
@@ -317,7 +317,7 @@ config =
     , _svcEndpoint = defaultEndpoint config
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "Config"
     , _svcRetry = retry
     }
   where

--- a/amazonka-datapipeline/gen/Network/AWS/DataPipeline/Types.hs
+++ b/amazonka-datapipeline/gen/Network/AWS/DataPipeline/Types.hs
@@ -142,7 +142,7 @@ dataPipeline =
     , _svcEndpoint = defaultEndpoint dataPipeline
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "DataPipeline"
     , _svcRetry = retry
     }
   where

--- a/amazonka-devicefarm/gen/Network/AWS/DeviceFarm/Types.hs
+++ b/amazonka-devicefarm/gen/Network/AWS/DeviceFarm/Types.hs
@@ -374,7 +374,7 @@ deviceFarm =
     , _svcEndpoint = defaultEndpoint deviceFarm
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "DeviceFarm"
     , _svcRetry = retry
     }
   where

--- a/amazonka-directconnect/gen/Network/AWS/DirectConnect/Types.hs
+++ b/amazonka-directconnect/gen/Network/AWS/DirectConnect/Types.hs
@@ -153,7 +153,7 @@ directConnect =
     , _svcEndpoint = defaultEndpoint directConnect
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "DirectConnect"
     , _svcRetry = retry
     }
   where

--- a/amazonka-discovery/gen/Network/AWS/Discovery/Types.hs
+++ b/amazonka-discovery/gen/Network/AWS/Discovery/Types.hs
@@ -110,7 +110,7 @@ discovery =
     , _svcEndpoint = defaultEndpoint discovery
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "Discovery"
     , _svcRetry = retry
     }
   where

--- a/amazonka-dms/gen/Network/AWS/DMS/Types.hs
+++ b/amazonka-dms/gen/Network/AWS/DMS/Types.hs
@@ -218,7 +218,7 @@ dms =
     , _svcEndpoint = defaultEndpoint dms
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "DMS"
     , _svcRetry = retry
     }
   where

--- a/amazonka-ds/gen/Network/AWS/DirectoryService/Types.hs
+++ b/amazonka-ds/gen/Network/AWS/DirectoryService/Types.hs
@@ -222,7 +222,7 @@ directoryService =
     , _svcEndpoint = defaultEndpoint directoryService
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "DirectoryService"
     , _svcRetry = retry
     }
   where

--- a/amazonka-dynamodb-streams/gen/Network/AWS/DynamoDBStreams/Types.hs
+++ b/amazonka-dynamodb-streams/gen/Network/AWS/DynamoDBStreams/Types.hs
@@ -128,7 +128,7 @@ dynamoDBStreams =
     , _svcEndpoint = defaultEndpoint dynamoDBStreams
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "DynamoDBStreams"
     , _svcRetry = retry
     }
   where

--- a/amazonka-dynamodb/gen/Network/AWS/DynamoDB/Types.hs
+++ b/amazonka-dynamodb/gen/Network/AWS/DynamoDB/Types.hs
@@ -281,7 +281,7 @@ dynamoDB =
     , _svcEndpoint = defaultEndpoint dynamoDB
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "DynamoDB"
     , _svcRetry = retry
     }
   where

--- a/amazonka-ec2/gen/Network/AWS/EC2/Types.hs
+++ b/amazonka-ec2/gen/Network/AWS/EC2/Types.hs
@@ -1957,7 +1957,7 @@ ec2 =
     , _svcEndpoint = defaultEndpoint ec2
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseXMLError
+    , _svcError = parseXMLError "EC2"
     , _svcRetry = retry
     }
   where

--- a/amazonka-ecr/gen/Network/AWS/ECR/Types.hs
+++ b/amazonka-ecr/gen/Network/AWS/ECR/Types.hs
@@ -110,7 +110,7 @@ ecr =
     , _svcEndpoint = defaultEndpoint ecr
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "ECR"
     , _svcRetry = retry
     }
   where

--- a/amazonka-ecs/gen/Network/AWS/ECS/Types.hs
+++ b/amazonka-ecs/gen/Network/AWS/ECS/Types.hs
@@ -315,7 +315,7 @@ ecs =
     , _svcEndpoint = defaultEndpoint ecs
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "ECS"
     , _svcRetry = retry
     }
   where

--- a/amazonka-efs/gen/Network/AWS/EFS/Types.hs
+++ b/amazonka-efs/gen/Network/AWS/EFS/Types.hs
@@ -91,7 +91,7 @@ efs =
     , _svcEndpoint = defaultEndpoint efs
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "EFS"
     , _svcRetry = retry
     }
   where

--- a/amazonka-elasticache/gen/Network/AWS/ElastiCache/Types.hs
+++ b/amazonka-elasticache/gen/Network/AWS/ElastiCache/Types.hs
@@ -384,7 +384,7 @@ elastiCache =
     , _svcEndpoint = defaultEndpoint elastiCache
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseXMLError
+    , _svcError = parseXMLError "ElastiCache"
     , _svcRetry = retry
     }
   where

--- a/amazonka-elasticbeanstalk/gen/Network/AWS/ElasticBeanstalk/Types.hs
+++ b/amazonka-elasticbeanstalk/gen/Network/AWS/ElasticBeanstalk/Types.hs
@@ -425,7 +425,7 @@ elasticBeanstalk =
     , _svcEndpoint = defaultEndpoint elasticBeanstalk
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseXMLError
+    , _svcError = parseXMLError "ElasticBeanstalk"
     , _svcRetry = retry
     }
   where

--- a/amazonka-elasticsearch/gen/Network/AWS/ElasticSearch/Types.hs
+++ b/amazonka-elasticsearch/gen/Network/AWS/ElasticSearch/Types.hs
@@ -150,7 +150,7 @@ elasticSearch =
     , _svcEndpoint = defaultEndpoint elasticSearch
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "ElasticSearch"
     , _svcRetry = retry
     }
   where

--- a/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/Types.hs
+++ b/amazonka-elastictranscoder/gen/Network/AWS/ElasticTranscoder/Types.hs
@@ -350,7 +350,7 @@ elasticTranscoder =
     , _svcEndpoint = defaultEndpoint elasticTranscoder
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "ElasticTranscoder"
     , _svcRetry = retry
     }
   where

--- a/amazonka-elb/gen/Network/AWS/ELB/Types.hs
+++ b/amazonka-elb/gen/Network/AWS/ELB/Types.hs
@@ -233,7 +233,7 @@ elb =
     , _svcEndpoint = defaultEndpoint elb
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseXMLError
+    , _svcError = parseXMLError "ELB"
     , _svcRetry = retry
     }
   where

--- a/amazonka-emr/gen/Network/AWS/EMR/Types.hs
+++ b/amazonka-emr/gen/Network/AWS/EMR/Types.hs
@@ -407,7 +407,7 @@ emr =
     , _svcEndpoint = defaultEndpoint emr
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "EMR"
     , _svcRetry = retry
     }
   where

--- a/amazonka-gamelift/gen/Network/AWS/GameLift/Types.hs
+++ b/amazonka-gamelift/gen/Network/AWS/GameLift/Types.hs
@@ -246,7 +246,7 @@ gameLift =
     , _svcEndpoint = defaultEndpoint gameLift
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "GameLift"
     , _svcRetry = retry
     }
   where

--- a/amazonka-glacier/gen/Network/AWS/Glacier/Types.hs
+++ b/amazonka-glacier/gen/Network/AWS/Glacier/Types.hs
@@ -156,7 +156,7 @@ glacier =
     , _svcEndpoint = defaultEndpoint glacier
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "Glacier"
     , _svcRetry = retry
     }
   where

--- a/amazonka-iam/gen/Network/AWS/IAM/Types.hs
+++ b/amazonka-iam/gen/Network/AWS/IAM/Types.hs
@@ -402,7 +402,7 @@ iam =
     , _svcEndpoint = defaultEndpoint iam
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseXMLError
+    , _svcError = parseXMLError "IAM"
     , _svcRetry = retry
     }
   where

--- a/amazonka-importexport/gen/Network/AWS/ImportExport/Types.hs
+++ b/amazonka-importexport/gen/Network/AWS/ImportExport/Types.hs
@@ -72,7 +72,7 @@ importExport =
     , _svcEndpoint = defaultEndpoint importExport
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseXMLError
+    , _svcError = parseXMLError "ImportExport"
     , _svcRetry = retry
     }
   where

--- a/amazonka-inspector/gen/Network/AWS/Inspector/Types.hs
+++ b/amazonka-inspector/gen/Network/AWS/Inspector/Types.hs
@@ -293,7 +293,7 @@ inspector =
     , _svcEndpoint = defaultEndpoint inspector
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "Inspector"
     , _svcRetry = retry
     }
   where

--- a/amazonka-iot-dataplane/gen/Network/AWS/IoTDataPlane/Types.hs
+++ b/amazonka-iot-dataplane/gen/Network/AWS/IoTDataPlane/Types.hs
@@ -45,7 +45,7 @@ ioTDataPlane =
     , _svcEndpoint = defaultEndpoint ioTDataPlane
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "IoTDataPlane"
     , _svcRetry = retry
     }
   where

--- a/amazonka-iot/gen/Network/AWS/IoT/Types.hs
+++ b/amazonka-iot/gen/Network/AWS/IoT/Types.hs
@@ -278,7 +278,7 @@ ioT =
     , _svcEndpoint = defaultEndpoint ioT
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "IoT"
     , _svcRetry = retry
     }
   where

--- a/amazonka-kinesis-firehose/gen/Network/AWS/Firehose/Types.hs
+++ b/amazonka-kinesis-firehose/gen/Network/AWS/Firehose/Types.hs
@@ -236,7 +236,7 @@ firehose =
     , _svcEndpoint = defaultEndpoint firehose
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "Firehose"
     , _svcRetry = retry
     }
   where

--- a/amazonka-kinesis/gen/Network/AWS/Kinesis/Types.hs
+++ b/amazonka-kinesis/gen/Network/AWS/Kinesis/Types.hs
@@ -123,7 +123,7 @@ kinesis =
     , _svcEndpoint = defaultEndpoint kinesis
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "Kinesis"
     , _svcRetry = retry
     }
   where

--- a/amazonka-kms/gen/Network/AWS/KMS/Types.hs
+++ b/amazonka-kms/gen/Network/AWS/KMS/Types.hs
@@ -116,7 +116,7 @@ kms =
     , _svcEndpoint = defaultEndpoint kms
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "KMS"
     , _svcRetry = retry
     }
   where

--- a/amazonka-lambda/gen/Network/AWS/Lambda/Types.hs
+++ b/amazonka-lambda/gen/Network/AWS/Lambda/Types.hs
@@ -128,7 +128,7 @@ lambda =
     , _svcEndpoint = defaultEndpoint lambda
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "Lambda"
     , _svcRetry = retry
     }
   where

--- a/amazonka-marketplace-analytics/gen/Network/AWS/MarketplaceAnalytics/Types.hs
+++ b/amazonka-marketplace-analytics/gen/Network/AWS/MarketplaceAnalytics/Types.hs
@@ -39,7 +39,7 @@ marketplaceAnalytics =
     , _svcEndpoint = defaultEndpoint marketplaceAnalytics
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "MarketplaceAnalytics"
     , _svcRetry = retry
     }
   where

--- a/amazonka-marketplace-metering/gen/Network/AWS/MarketplaceMetering/Types.hs
+++ b/amazonka-marketplace-metering/gen/Network/AWS/MarketplaceMetering/Types.hs
@@ -42,7 +42,7 @@ marketplaceMetering =
     , _svcEndpoint = defaultEndpoint marketplaceMetering
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "MarketplaceMetering"
     , _svcRetry = retry
     }
   where

--- a/amazonka-ml/gen/Network/AWS/MachineLearning/Types.hs
+++ b/amazonka-ml/gen/Network/AWS/MachineLearning/Types.hs
@@ -236,7 +236,7 @@ machineLearning =
     , _svcEndpoint = defaultEndpoint machineLearning
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "MachineLearning"
     , _svcRetry = retry
     }
   where

--- a/amazonka-opsworks/gen/Network/AWS/OpsWorks/Types.hs
+++ b/amazonka-opsworks/gen/Network/AWS/OpsWorks/Types.hs
@@ -521,7 +521,7 @@ opsWorks =
     , _svcEndpoint = defaultEndpoint opsWorks
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "OpsWorks"
     , _svcRetry = retry
     }
   where

--- a/amazonka-rds/gen/Network/AWS/RDS/Types.hs
+++ b/amazonka-rds/gen/Network/AWS/RDS/Types.hs
@@ -648,7 +648,7 @@ rds =
     , _svcEndpoint = defaultEndpoint rds
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseXMLError
+    , _svcError = parseXMLError "RDS"
     , _svcRetry = retry
     }
   where

--- a/amazonka-redshift/gen/Network/AWS/Redshift/Types.hs
+++ b/amazonka-redshift/gen/Network/AWS/Redshift/Types.hs
@@ -520,7 +520,7 @@ redshift =
     , _svcEndpoint = defaultEndpoint redshift
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseXMLError
+    , _svcError = parseXMLError "Redshift"
     , _svcRetry = retry
     }
   where

--- a/amazonka-route53-domains/gen/Network/AWS/Route53Domains/Types.hs
+++ b/amazonka-route53-domains/gen/Network/AWS/Route53Domains/Types.hs
@@ -114,7 +114,7 @@ route53Domains =
     , _svcEndpoint = defaultEndpoint route53Domains
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "Route53Domains"
     , _svcRetry = retry
     }
   where

--- a/amazonka-route53/gen/Network/AWS/Route53/Types.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/Types.hs
@@ -320,7 +320,7 @@ route53 =
     , _svcEndpoint = defaultEndpoint route53
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseXMLError
+    , _svcError = parseXMLError "Route53"
     , _svcRetry = retry
     }
   where

--- a/amazonka-s3/gen/Network/AWS/S3/Types.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/Types.hs
@@ -493,7 +493,7 @@ s3 =
     , _svcEndpoint = defaultEndpoint s3
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseXMLError
+    , _svcError = parseXMLError "S3"
     , _svcRetry = retry
     }
   where

--- a/amazonka-sdb/gen/Network/AWS/SDB/Types.hs
+++ b/amazonka-sdb/gen/Network/AWS/SDB/Types.hs
@@ -93,7 +93,7 @@ sdb =
     , _svcEndpoint = defaultEndpoint sdb
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseXMLError
+    , _svcError = parseXMLError "SDB"
     , _svcRetry = retry
     }
   where

--- a/amazonka-ses/gen/Network/AWS/SES/Types.hs
+++ b/amazonka-ses/gen/Network/AWS/SES/Types.hs
@@ -268,7 +268,7 @@ ses =
     , _svcEndpoint = defaultEndpoint ses
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseXMLError
+    , _svcError = parseXMLError "SES"
     , _svcRetry = retry
     }
   where

--- a/amazonka-sns/gen/Network/AWS/SNS/Types.hs
+++ b/amazonka-sns/gen/Network/AWS/SNS/Types.hs
@@ -77,7 +77,7 @@ sns =
     , _svcEndpoint = defaultEndpoint sns
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseXMLError
+    , _svcError = parseXMLError "SNS"
     , _svcRetry = retry
     }
   where

--- a/amazonka-sqs/gen/Network/AWS/SQS/Types.hs
+++ b/amazonka-sqs/gen/Network/AWS/SQS/Types.hs
@@ -124,7 +124,7 @@ sqs =
     , _svcEndpoint = defaultEndpoint sqs
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseXMLError
+    , _svcError = parseXMLError "SQS"
     , _svcRetry = retry
     }
   where

--- a/amazonka-ssm/gen/Network/AWS/SSM/Types.hs
+++ b/amazonka-ssm/gen/Network/AWS/SSM/Types.hs
@@ -231,7 +231,7 @@ ssm =
     , _svcEndpoint = defaultEndpoint ssm
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "SSM"
     , _svcRetry = retry
     }
   where

--- a/amazonka-storagegateway/gen/Network/AWS/StorageGateway/Types.hs
+++ b/amazonka-storagegateway/gen/Network/AWS/StorageGateway/Types.hs
@@ -171,7 +171,7 @@ storageGateway =
     , _svcEndpoint = defaultEndpoint storageGateway
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "StorageGateway"
     , _svcRetry = retry
     }
   where

--- a/amazonka-sts/gen/Network/AWS/STS/Types.hs
+++ b/amazonka-sts/gen/Network/AWS/STS/Types.hs
@@ -63,7 +63,7 @@ sts =
     , _svcEndpoint = defaultEndpoint sts
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseXMLError
+    , _svcError = parseXMLError "STS"
     , _svcRetry = retry
     }
   where

--- a/amazonka-support/gen/Network/AWS/Support/Types.hs
+++ b/amazonka-support/gen/Network/AWS/Support/Types.hs
@@ -170,7 +170,7 @@ support =
     , _svcEndpoint = defaultEndpoint support
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "Support"
     , _svcRetry = retry
     }
   where

--- a/amazonka-swf/gen/Network/AWS/SWF/Types.hs
+++ b/amazonka-swf/gen/Network/AWS/SWF/Types.hs
@@ -887,7 +887,7 @@ swf =
     , _svcEndpoint = defaultEndpoint swf
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "SWF"
     , _svcRetry = retry
     }
   where

--- a/amazonka-waf/gen/Network/AWS/WAF/Types.hs
+++ b/amazonka-waf/gen/Network/AWS/WAF/Types.hs
@@ -298,7 +298,7 @@ waf =
     , _svcEndpoint = defaultEndpoint waf
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "WAF"
     , _svcRetry = retry
     }
   where

--- a/amazonka-workspaces/gen/Network/AWS/WorkSpaces/Types.hs
+++ b/amazonka-workspaces/gen/Network/AWS/WorkSpaces/Types.hs
@@ -151,7 +151,7 @@ workSpaces =
     , _svcEndpoint = defaultEndpoint workSpaces
     , _svcTimeout = Just 70
     , _svcCheck = statusSuccess
-    , _svcError = parseJSONError
+    , _svcError = parseJSONError "WorkSpaces"
     , _svcRetry = retry
     }
   where

--- a/core/src/Network/AWS/Error.hs
+++ b/core/src/Network/AWS/Error.hs
@@ -40,8 +40,8 @@ httpStatus = _Error . f
             -> TransportError <$> (StatusCodeException <$> g s <*> pure h <*> pure c)
         TransportError e
             -> pure (TransportError e)
-        SerializeError (SerializeError' a s e)
-            -> g s <&> \x -> SerializeError (SerializeError' a x e)
+        SerializeError (SerializeError' a s b e)
+            -> g s <&> \x -> SerializeError (SerializeError' a x b e)
         ServiceError e
             -> g (_serviceStatus e) <&> \x -> ServiceError (e { _serviceStatus = x })
 
@@ -132,6 +132,6 @@ decodeError :: Abbrev
 decodeError a s h bs e
     | LBS.null bs = parseRESTError a s h bs
     | otherwise   =
-        either (SerializeError . SerializeError' a s)
+        either (SerializeError . SerializeError' a s (Just bs))
                ServiceError
                e

--- a/core/src/Network/AWS/Response.hs
+++ b/core/src/Network/AWS/Response.hs
@@ -14,6 +14,7 @@
 --
 module Network.AWS.Response where
 
+import           Control.Applicative          (pure)
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Resource

--- a/core/src/Network/AWS/Types.hs
+++ b/core/src/Network/AWS/Types.hs
@@ -223,6 +223,8 @@ instance ToLog Error where
 data SerializeError = SerializeError'
     { _serializeAbbrev  :: !Abbrev
     , _serializeStatus  :: !Status
+    , _serializeBody    :: Maybe LazyByteString
+      -- ^ The response body, if the response was not streaming.
     , _serializeMessage :: String
     } deriving (Eq, Show, Typeable)
 
@@ -232,6 +234,7 @@ instance ToLog SerializeError where
         , "  service = " <> build _serializeAbbrev
         , "  status  = " <> build _serializeStatus
         , "  message = " <> build _serializeMessage
+        , "  body    = " <> build _serializeBody
         , "}"
         ]
 
@@ -418,7 +421,7 @@ data Service = Service
     , _svcEndpoint :: !(Region -> Endpoint)
     , _svcTimeout  :: !(Maybe Seconds)
     , _svcCheck    :: !(Status -> Bool)
-    , _svcError    :: !(Abbrev -> Status -> [Header] -> LazyByteString -> Error)
+    , _svcError    :: !(Status -> [Header] -> LazyByteString -> Error)
     , _svcRetry    :: !Retry
     }
 

--- a/gen/src/Gen/AST/Data/Syntax.hs
+++ b/gen/src/Gen/AST/Data/Syntax.hs
@@ -180,7 +180,7 @@ serviceD m r = patBindWhere noLoc (pvar n) rhs bs
             , FieldUpdate (unqual "_svcEndpoint") (app (var "defaultEndpoint") (var n))
             , FieldUpdate (unqual "_svcTimeout")  (app justE (intE 70))
             , FieldUpdate (unqual "_svcCheck")    (var "statusSuccess")
-            , FieldUpdate (unqual "_svcError")    (var (serviceError m))
+            , FieldUpdate (unqual "_svcError")    (var (serviceError m) `app` str abbrev)
             , FieldUpdate (unqual "_svcRetry")    (var "retry")
             ]
 


### PR DESCRIPTION
This allows the handling a thrown `SerialzeError` by catching the error using `Control.Exception.Lens.*` + `_SerializeError` or similar, and then manually parsing `_serializeBody` if present.

Additional quality of life fix for #291.