### PR TITLE
Add upper bounds to http-conduit

### DIFF
--- a/core/amazonka-core.cabal
+++ b/core/amazonka-core.cabal
@@ -83,7 +83,7 @@ library
         , deepseq              >= 1.4
         , exceptions           >= 0.6
         , hashable             >= 1.2
-        , http-conduit         >= 2.1.4
+        , http-conduit         >= 2.1.4 && < 2.2
         , http-types           >= 0.8
         , lens                 >= 4.4
         , memory               >= 0.6


### PR DESCRIPTION
Also I advice to add upper bounds for all dependencies. To prevent large breakages in the future.

<img width="691" alt="screen shot 2016-07-05 at 12 33 51" src="https://cloud.githubusercontent.com/assets/51087/16580421/0cad24b8-42ad-11e6-8e24-8dd9c1aa7be7.png">

With https://github.com/hvr/hackage-cli is handy (scrioptably) make revisions to package when you only need to bump bounds