### PR TITLE
Change Kinesis MetricsNameList min length to 0

### DIFF
--- a/gen/annex/kinesis.json
+++ b/gen/annex/kinesis.json
@@ -1,0 +1,7 @@
+{
+    "shapes": {
+        "MetricsNameList": {
+            "min": 0
+        }
+    }
+}


### PR DESCRIPTION
AWS can actually respond with an EnhancedMonitoring field containing a
ShardLevelMetrics with a length of 0.

This change targets all fields of shape MetricsNameList. It might be
possible to restrict it to just changing ShardLevelMetrics.

--

 Fixes #305 