### PR TITLE
Discover Region from environment variables

### DIFF
--- a/amazonka/src/Control/Monad/Trans/AWS.hs
+++ b/amazonka/src/Control/Monad/Trans/AWS.hs
@@ -430,7 +430,7 @@ use non-SSL localhost as the endpoint:
 
 The updated configuration is then passed to the 'Env' during setup:
 
-> e <- newEnv Frankfurt Discover <&> configure dynamo
+> e <- newEnv Discover <&> configure dynamo
 > runResourceT . runAWS e $ do
 >     -- This S3 operation will communicate with remote AWS APIs.
 >     x <- send listBuckets
@@ -444,7 +444,7 @@ The updated configuration is then passed to the 'Env' during setup:
 You can also scope the 'Endpoint' modifications (or any other 'Service' configuration)
 to specific actions:
 
-> e <- newEnv Ireland Discover
+> e <- newEnv Discover
 > runResourceT . runAWS e $ do
 >     -- Service operations here will communicate with AWS, even DynamoDB.
 >     x <- send listTables

--- a/amazonka/src/Network/AWS.hs
+++ b/amazonka/src/Network/AWS.hs
@@ -320,20 +320,26 @@ import System.IO
 
 example :: IO PutObjectResponse
 example = do
-    -- A new 'Logger' to replace the default noop logger is created, with the logger set to print debug information and errors to stdout:
+    -- A new 'Logger' to replace the default noop logger is created, with the logger
+    -- set to print debug information and errors to stdout:
     lgr  <- newLogger Debug stdout
 
-    -- To specify configuration preferences, 'newEnv' is used to create a new configuration environment.
-    -- The 'Region' denotes the AWS region requests will be performed against, and 'Credentials' is used to specify the desired mechanism for supplying or retrieving AuthN/AuthZ information.
-    -- In this case, 'Discover' will cause the library to try a number of options such as default environment variables, or an instance's IAM Profile:
-    env  <- newEnv Frankfurt Discover
+    -- To specify configuration preferences, 'newEnv' is used to create a new
+    -- configuration environment. The 'Credentials' parameter is used to specify
+    -- mechanism for supplying or retrieving AuthN/AuthZ information.
+    -- In this case 'Discover' will cause the library to try a number of options such
+    -- as default environment variables, or an instance's IAM Profile and identity document:
+    env  <- newEnv Discover
 
     -- The payload (and hash) for the S3 object is retrieved from a 'FilePath':
     body <- sourceFileIO "local\/path\/to\/object-payload"
 
-    -- We now run the 'AWS' computation with the overriden logger, performing the 'PutObject' request:
-    runResourceT . runAWS (env & envLogger .~ lgr) $
-        send (putObject "bucket-name" "object-key" body)
+    -- We now run the 'AWS' computation with the overriden logger, performing the
+    -- 'PutObject' request. 'envRegion' or 'within' can be used to set the
+    -- remote AWS 'Region':
+    runResourceT $ runAWS (env & envLogger .~ lgr) $
+        within Frankfurt $
+            send (putObject "bucket-name" "object-key" body)
 @
 -}
 

--- a/amazonka/src/Network/AWS/Auth.hs
+++ b/amazonka/src/Network/AWS/Auth.hs
@@ -331,7 +331,7 @@ getAuth m = \case
 -- cannot be read, but not if the session token is absent.
 --
 -- /See:/ 'envAccessKey', 'envSecretKey', 'envSessionToken'
-fromEnv :: (MonadIO m, MonadThrow m) => m (Auth, Maybe Region)
+fromEnv :: (Applicative m, MonadIO m, MonadThrow m) => m (Auth, Maybe Region)
 fromEnv =
     fromEnvKeys
         envAccessKey
@@ -344,7 +344,7 @@ fromEnv =
 --
 -- Throws 'MissingEnvError' if either of the specified key environment variables
 -- cannot be read, but not if the session token is absent.
-fromEnvKeys :: (MonadIO m, MonadThrow m)
+fromEnvKeys :: (Applicative m, MonadIO m, MonadThrow m)
             => Text       -- ^ Access key environment variable.
             -> Text       -- ^ Secret key environment variable.
             -> Maybe Text -- ^ Session token environment variable.

--- a/amazonka/src/Network/AWS/Auth.hs
+++ b/amazonka/src/Network/AWS/Auth.hs
@@ -65,6 +65,7 @@ import           Control.Concurrent
 import           Control.Monad
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Maybe  (MaybeT (..))
 import qualified Data.ByteString.Char8      as BS8
 import qualified Data.ByteString.Lazy.Char8 as LBS8
 import           Data.Char                  (isSpace)
@@ -78,7 +79,7 @@ import           Network.AWS.Data.Log
 import           Network.AWS.EC2.Metadata
 import           Network.AWS.Lens           (catching, catching_, exception,
                                              throwingM, _IOException)
-import           Network.AWS.Lens           (Prism', prism)
+import           Network.AWS.Lens           (Prism', prism, (<&>))
 import           Network.AWS.Prelude
 import           Network.AWS.Types
 import           Network.HTTP.Conduit
@@ -98,9 +99,13 @@ envSecretKey = "AWS_SECRET_ACCESS_KEY"
 envSessionToken :: Text -- ^ AWS_SESSION_TOKEN
 envSessionToken = "AWS_SESSION_TOKEN"
 
--- | Credentials profile environment variable.
+-- | Default credentials profile environment variable.
 envProfile :: Text -- ^ AWS_PROFILE
 envProfile = "AWS_PROFILE"
+
+-- | Default region environment variable
+envRegion :: Text -- ^ AWS_REGION
+envRegion = "AWS_REGION"
 
 -- | Credentials INI file access key variable.
 credAccessKey :: Text -- ^ aws_access_key_id
@@ -159,9 +164,9 @@ data Credentials
     | FromSession AccessKey SecretKey SessionToken
       -- ^ Explicit access key, secret key and a session token. See 'fromSession'.
 
-    | FromEnv Text Text (Maybe Text)
-      -- ^ Lookup specific environment variables for access key, secret key, and
-      -- an optional session token respectively.
+    | FromEnv Text Text (Maybe Text) (Maybe Text)
+      -- ^ Lookup specific environment variables for access key, secret key,
+      -- an optional session token, and an optional region, respectively.
 
     | FromProfile Text
       -- ^ An IAM Profile name to lookup from the local EC2 instance-data.
@@ -175,11 +180,12 @@ data Credentials
     | Discover
       -- ^ Attempt credentials discovery via the following steps:
       --
-      -- * Read the 'envAccessKey' and 'envSecretKey' from the environment if they are set.
+      -- * Read the 'envAccessKey', 'envSecretKey', and 'envRegion' from the environment if they are set.
       --
       -- * Read the credentials file if 'credFile' exists.
       --
-      -- * Retrieve the first available IAM profile if running on EC2.
+      -- * Retrieve the first available IAM profile and read
+      -- the 'Region' from the instance identity document, if running on EC2.
       --
       -- An attempt is made to resolve <http://instance-data> rather than directly
       -- retrieving <http://169.254.169.254> for IAM profile information.
@@ -189,12 +195,18 @@ data Credentials
 
 instance ToLog Credentials where
     build = \case
-        FromKeys    a _   -> "FromKeys "    <> build a <> " ****"
-        FromSession a _ _ -> "FromSession " <> build a <> " **** ****"
-        FromEnv     a s t -> "FromEnv "     <> build a <> " " <> build s <> " " <> m t
-        FromProfile n     -> "FromProfile " <> build n
-        FromFile    n f   -> "FromFile "    <> build n <> " " <> build f
-        Discover          -> "Discover"
+        FromKeys    a _ ->
+            "FromKeys " <> build a <> " ****"
+        FromSession a _ _ ->
+            "FromSession " <> build a <> " **** ****"
+        FromEnv     a s t r ->
+            "FromEnv " <> build a <> " " <> build s <> " " <> m t <> " " <> m r
+        FromProfile n ->
+            "FromProfile " <> build n
+        FromFile    n f ->
+            "FromFile " <> build n <> " " <> build f
+        Discover ->
+            "Discover"
       where
         m (Just x) = "(Just " <> build x <> ")"
         m Nothing  = "Nothing"
@@ -206,6 +218,7 @@ instance Show Credentials where
 data AuthError
     = RetrievalError   HttpException
     | MissingEnvError  Text
+    | InvalidEnvError  Text
     | MissingFileError FilePath
     | InvalidFileError Text
     | InvalidIAMError  Text
@@ -217,6 +230,7 @@ instance ToLog AuthError where
     build = \case
         RetrievalError   e -> build e
         MissingEnvError  e -> "[MissingEnvError]  { message = " <> build e <> "}"
+        InvalidEnvError  e -> "[InvalidEnvError]  { message = " <> build e <> "}"
         MissingFileError f -> "[MissingFileError] { path = "    <> build f <> "}"
         InvalidFileError e -> "[InvalidFileError] { message = " <> build e <> "}"
         InvalidIAMError  e -> "[InvalidIAMError]  { message = " <> build e <> "}"
@@ -230,8 +244,11 @@ class AsAuthError a where
     -- the local metadata endpoint.
     _RetrievalError   :: Prism' a HttpException
 
-    -- | An error occured looking up a named environment variable.
+    -- | The named environment variable was not found.
     _MissingEnvError  :: Prism' a Text
+
+    -- | An error occured parsing named environment variable's value.
+    _InvalidEnvError  :: Prism' a Text
 
     -- | The specified credentials file could not be found.
     _MissingFileError :: Prism' a FilePath
@@ -244,6 +261,7 @@ class AsAuthError a where
 
     _RetrievalError   = _AuthError . _RetrievalError
     _MissingEnvError  = _AuthError . _MissingEnvError
+    _InvalidEnvError  = _AuthError . _InvalidEnvError
     _MissingFileError = _AuthError . _MissingFileError
     _InvalidFileError = _AuthError . _InvalidFileError
     _InvalidIAMError  = _AuthError . _InvalidIAMError
@@ -260,6 +278,10 @@ instance AsAuthError AuthError where
 
     _MissingEnvError = prism MissingEnvError $ \case
         MissingEnvError  e -> Right e
+        x                  -> Left  x
+
+    _InvalidEnvError = prism InvalidEnvError $ \case
+        InvalidEnvError  e -> Right e
         x                  -> Left  x
 
     _MissingFileError = prism MissingFileError $ \case
@@ -281,14 +303,14 @@ instance AsAuthError AuthError where
 getAuth :: (Applicative m, MonadIO m, MonadCatch m)
         => Manager
         -> Credentials
-        -> m Auth
+        -> m (Auth, Maybe Region)
 getAuth m = \case
-    FromKeys    a s   -> return (fromKeys a s)
-    FromSession a s t -> return (fromSession a s t)
-    FromEnv     a s t -> fromEnvKeys a s t
-    FromProfile n     -> fromProfileName m n
-    FromFile    n f   -> fromFilePath n f
-    Discover          ->
+    FromKeys    a s     -> return (fromKeys a s, Nothing)
+    FromSession a s t   -> return (fromSession a s t, Nothing)
+    FromEnv     a s t r -> fromEnvKeys a s t r
+    FromProfile n       -> fromProfileName m n
+    FromFile    n f     -> fromFilePath n f
+    Discover            ->
         -- Don't try and catch InvalidFileError, or InvalidIAMProfile,
         -- let both errors propagate.
         catching_ _MissingEnvError fromEnv $
@@ -309,25 +331,43 @@ getAuth m = \case
 -- cannot be read, but not if the session token is absent.
 --
 -- /See:/ 'envAccessKey', 'envSecretKey', 'envSessionToken'
-fromEnv :: (Applicative m, MonadIO m, MonadThrow m) => m Auth
-fromEnv = fromEnvKeys envAccessKey envSecretKey (Just envSessionToken)
+fromEnv :: (MonadIO m, MonadThrow m) => m (Auth, Maybe Region)
+fromEnv =
+    fromEnvKeys
+        envAccessKey
+        envSecretKey
+        (Just envSessionToken)
+        (Just envRegion)
 
 -- | Retrieve access key, secret key and a session token from specific
 -- environment variables.
 --
 -- Throws 'MissingEnvError' if either of the specified key environment variables
 -- cannot be read, but not if the session token is absent.
-fromEnvKeys :: (Applicative m, MonadIO m, MonadThrow m)
+fromEnvKeys :: (MonadIO m, MonadThrow m)
             => Text       -- ^ Access key environment variable.
             -> Text       -- ^ Secret key environment variable.
             -> Maybe Text -- ^ Session token environment variable.
-            -> m Auth
-fromEnvKeys a s t = fmap Auth $ AuthEnv
-    <$> (AccessKey         <$> req a)
-    <*> (SecretKey         <$> req s)
-    <*> (fmap SessionToken <$> opt t)
-    <*> pure Nothing
+            -> Maybe Text -- ^ Region environment variable.
+            -> m (Auth, Maybe Region)
+fromEnvKeys access secret session region =
+    (,) <$> fmap Auth lookupKeys <*> lookupRegion
   where
+    lookupKeys = AuthEnv
+        <$> (req access  <&> AccessKey . BS8.pack)
+        <*> (req secret  <&> SecretKey . BS8.pack)
+        <*> (opt session <&> fmap (SessionToken . BS8.pack))
+        <*> return Nothing
+
+    lookupRegion :: (MonadIO m, MonadThrow m) => m (Maybe Region)
+    lookupRegion = runMaybeT $ do
+        k <- MaybeT (return region)
+        r <- MaybeT (opt region)
+        case fromText (Text.pack r) of
+            Right x -> return x
+            Left  e -> throwM . InvalidEnvError $
+                "Unable to parse ENV variable: " <> k <> ", " <> Text.pack e
+
     req k = do
         m <- opt (Just k)
         maybe (throwM . MissingEnvError $ "Unable to read ENV variable: " <> k)
@@ -335,7 +375,7 @@ fromEnvKeys a s t = fmap Auth $ AuthEnv
               m
 
     opt Nothing  = return Nothing
-    opt (Just k) = fmap BS8.pack <$> liftIO (lookupEnv (Text.unpack k))
+    opt (Just k) = liftIO (lookupEnv (Text.unpack k))
 
 -- | Loads the default @credentials@ INI file using the default profile name.
 --
@@ -343,12 +383,11 @@ fromEnvKeys a s t = fmap Auth $ AuthEnv
 -- if an error occurs during parsing.
 --
 -- /See:/ 'credProfile', 'credFile', and 'envProfile'
-fromFile :: (Applicative m, MonadIO m, MonadCatch m) => m Auth
+fromFile :: (Applicative m, MonadIO m, MonadCatch m) => m (Auth, Maybe Region)
 fromFile = do
-  f <- credFile
-  ep <- liftIO (lookupEnv (Text.unpack envProfile))
-  let p = Text.pack (fromMaybe (Text.unpack credProfile) ep)
-  fromFilePath p f
+  p <- liftIO (lookupEnv (Text.unpack envProfile))
+  fromFilePath (maybe credProfile Text.pack p)
+      =<< credFile
 
 -- | Retrieve the access, secret and session token from the specified section
 -- (profile) in a valid INI @credentials@ file.
@@ -358,17 +397,18 @@ fromFile = do
 fromFilePath :: (Applicative m, MonadIO m, MonadCatch m)
              => Text
              -> FilePath
-             -> m Auth
+             -> m (Auth, Maybe Region)
 fromFilePath n f = do
     p <- liftIO (doesFileExist f)
     unless p $
         throwM (MissingFileError f)
-    i <- liftIO (INI.readIniFile f) >>= either (invalidErr Nothing) return
-    fmap Auth $ AuthEnv
-        <$> (AccessKey         <$> req credAccessKey    i)
-        <*> (SecretKey         <$> req credSecretKey    i)
-        <*> (fmap SessionToken <$> opt credSessionToken i)
-        <*> pure Nothing
+    ini <- either (invalidErr Nothing) return =<< liftIO (INI.readIniFile f)
+    env <- AuthEnv
+        <$> (req credAccessKey    ini <&> AccessKey)
+        <*> (req credSecretKey    ini <&> SecretKey)
+        <*> (opt credSessionToken ini <&> fmap SessionToken)
+        <*> return Nothing
+    return (Auth env, Nothing)
   where
     req k i =
         case INI.lookupValue n k i of
@@ -396,7 +436,7 @@ fromFilePath n f = do
 --
 -- Throws 'RetrievalError' if the HTTP call fails, or 'InvalidIAMError' if
 -- the default IAM profile cannot be read.
-fromProfile :: (MonadIO m, MonadCatch m) => Manager -> m Auth
+fromProfile :: (MonadIO m, MonadCatch m) => Manager -> m (Auth, Maybe Region)
 fromProfile m = do
     ls <- try $ metadata m (IAM (SecurityCredentials Nothing))
     case BS8.lines `liftM` ls of
@@ -419,21 +459,34 @@ fromProfile m = do
 --
 -- Throws 'RetrievalError' if the HTTP call fails, or 'InvalidIAMError' if
 -- the specified IAM profile cannot be read.
-fromProfileName :: (MonadIO m, MonadCatch m) => Manager -> Text -> m Auth
-fromProfileName m name = auth >>= start
+fromProfileName :: (MonadIO m, MonadCatch m)
+                => Manager
+                -> Text
+                -> m (Auth, Maybe Region)
+fromProfileName m name = do
+    auth <- getCredentials >>= start
+    reg  <- getRegion
+    return (auth, Just reg)
   where
-    auth :: (MonadIO m, MonadCatch m) => m AuthEnv
-    auth = do
-        bs <- try $ metadata m (IAM . SecurityCredentials $ Just name)
-        case bs of
-            Left  e -> throwM (RetrievalError e)
-            Right x ->
-                either (throwM . invalidErr)
-                       return
-                       (eitherDecode' (LBS8.fromStrict x))
+    getCredentials :: (MonadIO m, MonadCatch m) => m AuthEnv
+    getCredentials =
+        try (metadata m (IAM . SecurityCredentials $ Just name)) >>=
+            handleErr (eitherDecode' . LBS8.fromStrict) invalidIAMErr
 
-    invalidErr = InvalidIAMError
+    getRegion :: (MonadIO m, MonadCatch m) => m Region
+    getRegion =
+       try (identity m) >>=
+           handleErr (fmap _region) invalidIdentityErr
+
+    handleErr _ _ (Left  e) = throwM (RetrievalError e)
+    handleErr f g (Right x) = either (throwM . g) return (f x)
+
+    invalidIAMErr = InvalidIAMError
         . mappend ("Error parsing IAM profile '" <> name <> "' ")
+        . Text.pack
+
+    invalidIdentityErr = InvalidIAMError
+        . mappend "Error parsing Instance Identity Document "
         . Text.pack
 
     start :: MonadIO m => AuthEnv -> m Auth
@@ -455,8 +508,8 @@ fromProfileName m name = auth >>= start
     loop :: Weak (IORef AuthEnv) -> ThreadId -> UTCTime -> IO ()
     loop w !p !x = do
         diff x <$> getCurrentTime >>= threadDelay
-        ea <- try auth
-        case ea of
+        env <- try getCredentials
+        case env of
             Left   e -> throwTo p (RetrievalError e)
             Right !a -> do
                  mr <- deRefWeak w

--- a/amazonka/src/Network/AWS/EC2/Metadata.hs
+++ b/amazonka/src/Network/AWS/EC2/Metadata.hs
@@ -28,9 +28,6 @@ module Network.AWS.EC2.Metadata
     , dynamic
     , metadata
     , userdata
-
-    -- ** Identity Documents
-    , IdentityDocument (..)
     , identity
 
     -- ** Path Constructors
@@ -39,6 +36,24 @@ module Network.AWS.EC2.Metadata
     , Mapping          (..)
     , Info             (..)
     , Interface        (..)
+
+    -- ** Identity Document
+    , IdentityDocument (..)
+
+    -- *** Lenses
+    , devpayProductCodes
+    , billingProducts
+    , version
+    , privateIP
+    , availabilityZone
+    , region
+    , instanceID
+    , instanceType
+    , accountID
+    , imageID
+    , kernelID
+    , ramdiskID
+    , architecture
     ) where
 
 import           Control.Monad
@@ -49,6 +64,7 @@ import qualified Data.ByteString.Lazy   as LBS
 import           Data.Monoid
 import qualified Data.Text              as Text
 import           Network.AWS.Data.JSON
+import           Network.AWS.Lens       (Lens', lens)
 import           Network.AWS.Prelude    hiding (request)
 import           Network.HTTP.Conduit
 
@@ -318,15 +334,7 @@ userdata m = do
         Left  e -> throwM e
         Right b -> return (Just b)
 
--- | Retrieve the instance's identity document.
---
--- /See:/ <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html AWS Instance Identity Documents>.
-identity :: (MonadIO m, MonadThrow m)
-         => Manager
-         -> m (Either String IdentityDocument)
-identity m = (eitherDecode . LBS.fromStrict) `liftM` dynamic m Document
-
--- | Represents an instance's identity document, detailing various EC2 metadata.
+-- | Represents an instance's identity document.
 --
 -- /Note:/ Fields such as '_instanceType' are represented as unparsed 'Text' and
 -- will need to be manually parsed using 'fromText' when the relevant types
@@ -346,6 +354,45 @@ data IdentityDocument = IdentityDocument
     , _ramdiskID          :: Maybe Text
     , _architecture       :: Text
     } deriving (Eq, Show)
+
+devpayProductCodes :: Lens' IdentityDocument (Maybe Text)
+devpayProductCodes = lens _devpayProductCodes (\s a -> s { _devpayProductCodes = a })
+
+billingProducts :: Lens' IdentityDocument (Maybe Text)
+billingProducts = lens _billingProducts (\s a -> s { _billingProducts = a })
+
+version :: Lens' IdentityDocument Text
+version = lens _version (\s a -> s { _version = a })
+
+privateIP :: Lens' IdentityDocument Text
+privateIP = lens _privateIP (\s a -> s { _privateIP = a })
+
+availabilityZone :: Lens' IdentityDocument Text
+availabilityZone = lens _availabilityZone (\s a -> s { _availabilityZone = a })
+
+region :: Lens' IdentityDocument Region
+region = lens _region (\s a -> s { _region = a })
+
+instanceID :: Lens' IdentityDocument Text
+instanceID = lens _instanceID (\s a -> s { _instanceID = a })
+
+instanceType :: Lens' IdentityDocument Text
+instanceType = lens _instanceType (\s a -> s { _instanceType = a })
+
+accountID :: Lens' IdentityDocument Text
+accountID = lens _accountID (\s a -> s { _accountID = a })
+
+imageID :: Lens' IdentityDocument Text
+imageID = lens _imageID (\s a -> s { _imageID = a })
+
+kernelID :: Lens' IdentityDocument Text
+kernelID = lens _kernelID (\s a -> s { _kernelID = a })
+
+ramdiskID :: Lens' IdentityDocument (Maybe Text)
+ramdiskID = lens _ramdiskID (\s a -> s { _ramdiskID = a })
+
+architecture :: Lens' IdentityDocument Text
+architecture = lens _architecture (\s a -> s { _architecture = a })
 
 instance FromJSON IdentityDocument where
     parseJSON = withObject "dynamic/instance-identity/document" $ \o ->
@@ -381,6 +428,14 @@ instance ToJSON IdentityDocument where
             , "ramdiskId"          .= _ramdiskID
             , "architecture"       .= _architecture
             ]
+
+-- | Retrieve the instance's identity document, detailing various EC2 metadata.
+--
+-- /See:/ <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html AWS Instance Identity Documents>.
+identity :: (MonadIO m, MonadThrow m)
+         => Manager
+         -> m (Either String IdentityDocument)
+identity m = (eitherDecode . LBS.fromStrict) `liftM` dynamic m Document
 
 get :: (MonadIO m, MonadThrow m) => Manager -> Text -> m ByteString
 get m url = liftIO (strip `liftM` request m url)

--- a/amazonka/src/Network/AWS/EC2/Metadata.hs
+++ b/amazonka/src/Network/AWS/EC2/Metadata.hs
@@ -61,6 +61,7 @@ data Dynamic
     | Document
     -- ^ JSON containing instance attributes, such as instance-id,
     -- private IP address, etc.
+    -- /See:/ 'identity', 'InstanceDocument'.
     | PKCS7
     -- ^ Used to verify the document's authenticity and content against the
     -- signature.
@@ -317,15 +318,19 @@ userdata m = do
         Left  e -> throwM e
         Right b -> return (Just b)
 
--- | TODO: what an IdentityDocument is, and what values are available.
+-- | Retrieve the instance's identity document.
 --
--- Note about either return type.
+-- /See:/ <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html AWS Instance Identity Documents>.
 identity :: (MonadIO m, MonadThrow m)
          => Manager
          -> m (Either String IdentityDocument)
 identity m = (eitherDecode . LBS.fromStrict) `liftM` dynamic m Document
 
--- | TODO: note about deserialisation of 'Text' values vs what's available in core.
+-- | Represents an instance's identity document, detailing various EC2 metadata.
+--
+-- /Note:/ Fields such as '_instanceType' are represented as unparsed 'Text' and
+-- will need to be manually parsed using 'fromText' when the relevant types
+-- from a library such as "Network.AWS.EC2" are brought into scope.
 data IdentityDocument = IdentityDocument
     { _devpayProductCodes :: Maybe Text
     , _billingProducts    :: Maybe Text

--- a/core/src/Network/AWS/Data/JSON.hs
+++ b/core/src/Network/AWS/Data/JSON.hs
@@ -13,6 +13,7 @@ module Network.AWS.Data.JSON
     -- * FromJSON
       FromJSON (..)
     , parseJSONText
+    , eitherDecode
     , eitherDecode'
 
     -- ** Parser a
@@ -34,7 +35,7 @@ module Network.AWS.Data.JSON
     , (.=)
     ) where
 
-import           Data.Aeson            (eitherDecode')
+import           Data.Aeson            (eitherDecode, eitherDecode')
 import           Data.Aeson.Types
 import qualified Data.HashMap.Strict   as Map
 import           Network.AWS.Data.Text

--- a/core/src/Network/AWS/Types.hs
+++ b/core/src/Network/AWS/Types.hs
@@ -618,8 +618,10 @@ instance ToByteString Region
 instance ToLog Region where
     build = build . toBS
 
-instance FromXML Region where parseXML = parseXMLText "Region"
-instance ToXML   Region where toXML    = toXMLText
+instance FromXML  Region where parseXML  = parseXMLText "Region"
+instance ToXML    Region where toXML     = toXMLText
+instance FromJSON Region where parseJSON = parseJSONText "Region"
+instance ToJSON   Region where toJSON    = toJSONText
 
 -- | An integral value representing seconds.
 newtype Seconds = Seconds Int

--- a/examples/amazonka-examples.cabal
+++ b/examples/amazonka-examples.cabal
@@ -18,20 +18,22 @@ library
     ghc-options:       -Wall
 
     exposed-modules:
-          Example.DynamoDB
+          Example.APIGateway
+        , Example.DynamoDB
         , Example.EC2
         , Example.ExceptionSemantics
         , Example.S3
         , Example.SQS
 
     build-depends:
-          amazonka      == 1.4.3.*
+          amazonka            == 1.4.3.*
+        , amazonka-apigateway
         , amazonka-core
         , amazonka-dynamodb
         , amazonka-ec2
         , amazonka-s3
         , amazonka-sqs
-        , base          >= 4.7
+        , base                >= 4.7
         , bytestring
         , conduit
         , conduit-extra

--- a/examples/src/Example/DynamoDB.hs
+++ b/examples/src/Example/DynamoDB.hs
@@ -30,11 +30,11 @@ printTables :: Region     -- ^ Region to operate in.
             -> IO ()
 printTables r s h p = do
     lgr <- newLogger Debug stdout
-    env <- newEnv r Discover <&> envLogger .~ lgr
+    env <- newEnv Discover <&> set envLogger lgr
 
     let dynamo = setEndpoint s h p dynamoDB
 
-    runResourceT . runAWST env $ do
+    runResourceT . runAWST env . within r $ do
         -- Scoping the endpoint change using 'reconfigure':
         reconfigure dynamo $ do
             say $ "Listing all tables in region " <> toText r

--- a/examples/src/Example/EC2.hs
+++ b/examples/src/Example/EC2.hs
@@ -24,7 +24,7 @@ import           System.IO
 instanceOverview :: Region -> IO ()
 instanceOverview r = do
     lgr <- newLogger Info stdout
-    env <- newEnv r Discover <&> envLogger .~ lgr
+    env <- newEnv Discover <&> set envLogger lgr
 
     let pp x = mconcat
           [ "[instance:" <> build (x ^. insInstanceId) <> "] {"
@@ -34,7 +34,7 @@ instanceOverview r = do
           , "\n}\n"
           ]
 
-    runResourceT . runAWST env $
+    runResourceT . runAWST env . within r $
         paginate describeInstances
             =$= CL.concatMap (view dirsReservations)
             =$= CL.concatMap (view rInstances)

--- a/examples/src/Example/ExceptionSemantics.hs
+++ b/examples/src/Example/ExceptionSemantics.hs
@@ -31,12 +31,12 @@ exceptions :: Region -- ^ Region to operate in.
            -> IO ()
 exceptions r n = do
     lgr <- newLogger Info stdout
-    env <- newEnv r Discover <&> envLogger .~ lgr
+    env <- newEnv Discover <&> set envLogger lgr
 
     let scan' = scan n & sAttributesToGet ?~ "foo" :| []
 
     runResourceT $ do
-        runAWST env $ do
+        runAWST env . within r $ do
             sayLn $ "Listing all tables in region " <> toText r
             paginate listTables
                 =$= CL.concatMap (view ltrsTableNames)

--- a/examples/src/Example/SQS.hs
+++ b/examples/src/Example/SQS.hs
@@ -21,16 +21,17 @@ import qualified Data.Text.IO            as Text
 import           Network.AWS.SQS
 import           System.IO
 
-roundTrip :: Text   -- ^ Name of the queue to create.
+roundTrip :: Region -- ^ Region to operate in.
+          -> Text   -- ^ Name of the queue to create.
           -> [Text] -- ^ Contents of the messages to send.
           -> IO ()
-roundTrip name xs = do
+roundTrip r name xs = do
     lgr <- newLogger Debug stdout
-    env <- newEnv Ireland Discover <&> envLogger .~ lgr
+    env <- newEnv Discover <&> set envLogger lgr
 
     let say = liftIO . Text.putStrLn
 
-    runResourceT . runAWST env $ do
+    runResourceT . runAWST env . within r $ do
         void $ send (createQueue name)
         url <- view gqursQueueURL <$> send (getQueueURL name)
         say  $ "Received Queue URL: " <> url


### PR DESCRIPTION
This follows the official SDK(s) behaviour by retrieving the current region from either the environment variable `AWS_REGION` or by retrieving the [Instance Identity Document](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html).

* **Breaking change**: Region is now longer a parameter to `newEnv`. The region will be discovered in the fashion described above or will default to `us-east-1` per other SDK behaviour. The region can be explicitly specified via the `envRegion` lens or the `within` modifier. The examples and documentation have been updated to use the latter.
* **New function**: Instance Identity Documents are now directly retrievable in a deserialised form via `Network.AWS.EC2.Metadata.identity`.