### PR TITLE
Fix aws-lambda auth errors

### DIFF
--- a/core/src/Network/AWS/Sign/V4/Base.hs
+++ b/core/src/Network/AWS/Sign/V4/Base.hs
@@ -267,3 +267,4 @@ normaliseHeaders = Tag
     . nubBy  ((==)    `on` fst)
     . sortBy (compare `on` fst)
     . filter ((/= "authorization") . fst)
+    . filter ((/= "expect") . fst)


### PR DESCRIPTION
When there is a `Expect: 100-continue` header sent to aws lambda servers, the signature somehow contains only `Expect:` and it thus fails to validate. The solution seems to be removing the `Expect:` header from the list of signed headers.