### PR TITLE
Handle Route53 Identifiers Similarly to Other SDKs

### DIFF
--- a/amazonka-route53/amazonka-route53.cabal
+++ b/amazonka-route53/amazonka-route53.cabal
@@ -100,6 +100,7 @@ library
     build-depends:
           amazonka-core == 1.4.4.*
         , base          >= 4.7     && < 5
+        , text >= 1.1
 
 test-suite amazonka-route53-test
     type:              exitcode-stdio-1.0

--- a/amazonka-route53/gen/Network/AWS/Route53/AssociateVPCWithHostedZone.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/AssociateVPCWithHostedZone.hs
@@ -57,7 +57,7 @@ import           Network.AWS.Route53.Types.Product
 -- /See:/ 'associateVPCWithHostedZone' smart constructor.
 data AssociateVPCWithHostedZone = AssociateVPCWithHostedZone'
     { _avwhzComment      :: !(Maybe Text)
-    , _avwhzHostedZoneId :: !Text
+    , _avwhzHostedZoneId :: !ResourceId
     , _avwhzVPC          :: !VPC
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
@@ -71,7 +71,7 @@ data AssociateVPCWithHostedZone = AssociateVPCWithHostedZone'
 --
 -- * 'avwhzVPC' - A complex type that contains information about the VPC that you want to associate with a private hosted zone.
 associateVPCWithHostedZone
-    :: Text -- ^ 'avwhzHostedZoneId'
+    :: ResourceId -- ^ 'avwhzHostedZoneId'
     -> VPC -- ^ 'avwhzVPC'
     -> AssociateVPCWithHostedZone
 associateVPCWithHostedZone pHostedZoneId_ pVPC_ =
@@ -86,7 +86,7 @@ avwhzComment :: Lens' AssociateVPCWithHostedZone (Maybe Text)
 avwhzComment = lens _avwhzComment (\ s a -> s{_avwhzComment = a});
 
 -- | The ID of the private hosted zone that you want to associate an Amazon VPC with. Note that you can't associate a VPC with a hosted zone that doesn't have an existing VPC association.
-avwhzHostedZoneId :: Lens' AssociateVPCWithHostedZone Text
+avwhzHostedZoneId :: Lens' AssociateVPCWithHostedZone ResourceId
 avwhzHostedZoneId = lens _avwhzHostedZoneId (\ s a -> s{_avwhzHostedZoneId = a});
 
 -- | A complex type that contains information about the VPC that you want to associate with a private hosted zone.

--- a/amazonka-route53/gen/Network/AWS/Route53/ChangeResourceRecordSets.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/ChangeResourceRecordSets.hs
@@ -109,7 +109,7 @@ import           Network.AWS.Route53.Types.Product
 --
 -- /See:/ 'changeResourceRecordSets' smart constructor.
 data ChangeResourceRecordSets = ChangeResourceRecordSets'
-    { _crrsHostedZoneId :: !Text
+    { _crrsHostedZoneId :: !ResourceId
     , _crrsChangeBatch  :: !ChangeBatch
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
@@ -121,7 +121,7 @@ data ChangeResourceRecordSets = ChangeResourceRecordSets'
 --
 -- * 'crrsChangeBatch' - A complex type that contains an optional comment and the @Changes@ element.
 changeResourceRecordSets
-    :: Text -- ^ 'crrsHostedZoneId'
+    :: ResourceId -- ^ 'crrsHostedZoneId'
     -> ChangeBatch -- ^ 'crrsChangeBatch'
     -> ChangeResourceRecordSets
 changeResourceRecordSets pHostedZoneId_ pChangeBatch_ =
@@ -131,7 +131,7 @@ changeResourceRecordSets pHostedZoneId_ pChangeBatch_ =
     }
 
 -- | The ID of the hosted zone that contains the resource record sets that you want to change.
-crrsHostedZoneId :: Lens' ChangeResourceRecordSets Text
+crrsHostedZoneId :: Lens' ChangeResourceRecordSets ResourceId
 crrsHostedZoneId = lens _crrsHostedZoneId (\ s a -> s{_crrsHostedZoneId = a});
 
 -- | A complex type that contains an optional comment and the @Changes@ element.

--- a/amazonka-route53/gen/Network/AWS/Route53/CreateHostedZone.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/CreateHostedZone.hs
@@ -78,7 +78,7 @@ import           Network.AWS.Route53.Types.Product
 --
 -- /See:/ 'createHostedZone' smart constructor.
 data CreateHostedZone = CreateHostedZone'
-    { _chzDelegationSetId  :: !(Maybe Text)
+    { _chzDelegationSetId  :: !(Maybe ResourceId)
     , _chzVPC              :: !(Maybe VPC)
     , _chzHostedZoneConfig :: !(Maybe HostedZoneConfig)
     , _chzName             :: !Text
@@ -112,7 +112,7 @@ createHostedZone pName_ pCallerReference_ =
     }
 
 -- | If you want to associate a reusable delegation set with this hosted zone, the ID that Amazon Route 53 assigned to the reusable delegation set when you created it. For more information about reusable delegation sets, see 'CreateReusableDelegationSet' .     * Type    * String     * Default    * None     * Parent    * @CreatedHostedZoneRequest@
-chzDelegationSetId :: Lens' CreateHostedZone (Maybe Text)
+chzDelegationSetId :: Lens' CreateHostedZone (Maybe ResourceId)
 chzDelegationSetId = lens _chzDelegationSetId (\ s a -> s{_chzDelegationSetId = a});
 
 -- | The VPC that you want your hosted zone to be associated with. By providing this parameter, your newly created hosted can't be resolved anywhere other than the given VPC.

--- a/amazonka-route53/gen/Network/AWS/Route53/CreateReusableDelegationSet.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/CreateReusableDelegationSet.hs
@@ -52,7 +52,7 @@ import           Network.AWS.Route53.Types.Product
 
 -- | /See:/ 'createReusableDelegationSet' smart constructor.
 data CreateReusableDelegationSet = CreateReusableDelegationSet'
-    { _crdsHostedZoneId    :: !(Maybe Text)
+    { _crdsHostedZoneId    :: !(Maybe ResourceId)
     , _crdsCallerReference :: !Text
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
@@ -73,7 +73,7 @@ createReusableDelegationSet pCallerReference_ =
     }
 
 -- | If you want to mark the delegation set for an existing hosted zone as reusable, the ID for that hosted zone.
-crdsHostedZoneId :: Lens' CreateReusableDelegationSet (Maybe Text)
+crdsHostedZoneId :: Lens' CreateReusableDelegationSet (Maybe ResourceId)
 crdsHostedZoneId = lens _crdsHostedZoneId (\ s a -> s{_crdsHostedZoneId = a});
 
 -- | A unique string that identifies the request, and that allows you to retry failed @CreateReusableDelegationSet@ requests without the risk of executing the operation twice. You must use a unique @CallerReference@ string every time you submit a @CreateReusableDelegationSet@ request. @CallerReference@ can be any unique string, for example a date/time stamp.

--- a/amazonka-route53/gen/Network/AWS/Route53/CreateTrafficPolicyInstance.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/CreateTrafficPolicyInstance.hs
@@ -57,7 +57,7 @@ import           Network.AWS.Route53.Types.Product
 --
 -- /See:/ 'createTrafficPolicyInstance' smart constructor.
 data CreateTrafficPolicyInstance = CreateTrafficPolicyInstance'
-    { _ctpiHostedZoneId         :: !Text
+    { _ctpiHostedZoneId         :: !ResourceId
     , _ctpiName                 :: !Text
     , _ctpiTTL                  :: !Nat
     , _ctpiTrafficPolicyId      :: !Text
@@ -78,7 +78,7 @@ data CreateTrafficPolicyInstance = CreateTrafficPolicyInstance'
 --
 -- * 'ctpiTrafficPolicyVersion' - The version of the traffic policy that you want to use to create resource record sets in the specified hosted zone.
 createTrafficPolicyInstance
-    :: Text -- ^ 'ctpiHostedZoneId'
+    :: ResourceId -- ^ 'ctpiHostedZoneId'
     -> Text -- ^ 'ctpiName'
     -> Natural -- ^ 'ctpiTTL'
     -> Text -- ^ 'ctpiTrafficPolicyId'
@@ -94,7 +94,7 @@ createTrafficPolicyInstance pHostedZoneId_ pName_ pTTL_ pTrafficPolicyId_ pTraff
     }
 
 -- | The ID of the hosted zone in which you want Amazon Route 53 to create resource record sets by using the configuration in a traffic policy.
-ctpiHostedZoneId :: Lens' CreateTrafficPolicyInstance Text
+ctpiHostedZoneId :: Lens' CreateTrafficPolicyInstance ResourceId
 ctpiHostedZoneId = lens _ctpiHostedZoneId (\ s a -> s{_ctpiHostedZoneId = a});
 
 -- | The domain name (such as example.com) or subdomain name (such as www.example.com) for which Amazon Route 53 responds to DNS queries by using the resource record sets that Amazon Route 53 creates for this traffic policy instance.

--- a/amazonka-route53/gen/Network/AWS/Route53/CreateVPCAssociationAuthorization.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/CreateVPCAssociationAuthorization.hs
@@ -54,7 +54,7 @@ import           Network.AWS.Route53.Types.Product
 --
 -- /See:/ 'createVPCAssociationAuthorization' smart constructor.
 data CreateVPCAssociationAuthorization = CreateVPCAssociationAuthorization'
-    { _cvaaHostedZoneId :: !Text
+    { _cvaaHostedZoneId :: !ResourceId
     , _cvaaVPC          :: !VPC
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
@@ -66,7 +66,7 @@ data CreateVPCAssociationAuthorization = CreateVPCAssociationAuthorization'
 --
 -- * 'cvaaVPC' - A complex type that contains the VPC ID and region for the VPC that you want to authorize associating with your hosted zone.
 createVPCAssociationAuthorization
-    :: Text -- ^ 'cvaaHostedZoneId'
+    :: ResourceId -- ^ 'cvaaHostedZoneId'
     -> VPC -- ^ 'cvaaVPC'
     -> CreateVPCAssociationAuthorization
 createVPCAssociationAuthorization pHostedZoneId_ pVPC_ =
@@ -76,7 +76,7 @@ createVPCAssociationAuthorization pHostedZoneId_ pVPC_ =
     }
 
 -- | The ID of the private hosted zone that you want to authorize associating a VPC with.
-cvaaHostedZoneId :: Lens' CreateVPCAssociationAuthorization Text
+cvaaHostedZoneId :: Lens' CreateVPCAssociationAuthorization ResourceId
 cvaaHostedZoneId = lens _cvaaHostedZoneId (\ s a -> s{_cvaaHostedZoneId = a});
 
 -- | A complex type that contains the VPC ID and region for the VPC that you want to authorize associating with your hosted zone.
@@ -132,7 +132,7 @@ instance ToXML CreateVPCAssociationAuthorization
 -- /See:/ 'createVPCAssociationAuthorizationResponse' smart constructor.
 data CreateVPCAssociationAuthorizationResponse = CreateVPCAssociationAuthorizationResponse'
     { _cvaarsResponseStatus :: !Int
-    , _cvaarsHostedZoneId   :: !Text
+    , _cvaarsHostedZoneId   :: !ResourceId
     , _cvaarsVPC            :: !VPC
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
@@ -147,7 +147,7 @@ data CreateVPCAssociationAuthorizationResponse = CreateVPCAssociationAuthorizati
 -- * 'cvaarsVPC' - The VPC that you authorized associating with a hosted zone.
 createVPCAssociationAuthorizationResponse
     :: Int -- ^ 'cvaarsResponseStatus'
-    -> Text -- ^ 'cvaarsHostedZoneId'
+    -> ResourceId -- ^ 'cvaarsHostedZoneId'
     -> VPC -- ^ 'cvaarsVPC'
     -> CreateVPCAssociationAuthorizationResponse
 createVPCAssociationAuthorizationResponse pResponseStatus_ pHostedZoneId_ pVPC_ =
@@ -162,7 +162,7 @@ cvaarsResponseStatus :: Lens' CreateVPCAssociationAuthorizationResponse Int
 cvaarsResponseStatus = lens _cvaarsResponseStatus (\ s a -> s{_cvaarsResponseStatus = a});
 
 -- | The ID of the hosted zone that you authorized associating a VPC with.
-cvaarsHostedZoneId :: Lens' CreateVPCAssociationAuthorizationResponse Text
+cvaarsHostedZoneId :: Lens' CreateVPCAssociationAuthorizationResponse ResourceId
 cvaarsHostedZoneId = lens _cvaarsHostedZoneId (\ s a -> s{_cvaarsHostedZoneId = a});
 
 -- | The VPC that you authorized associating with a hosted zone.

--- a/amazonka-route53/gen/Network/AWS/Route53/DeleteHostedZone.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/DeleteHostedZone.hs
@@ -52,7 +52,7 @@ import           Network.AWS.Route53.Types.Product
 --
 -- /See:/ 'deleteHostedZone' smart constructor.
 newtype DeleteHostedZone = DeleteHostedZone'
-    { _dhzId :: Text
+    { _dhzId :: ResourceId
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
 -- | Creates a value of 'DeleteHostedZone' with the minimum fields required to make a request.
@@ -61,7 +61,7 @@ newtype DeleteHostedZone = DeleteHostedZone'
 --
 -- * 'dhzId' - The ID of the hosted zone you want to delete.
 deleteHostedZone
-    :: Text -- ^ 'dhzId'
+    :: ResourceId -- ^ 'dhzId'
     -> DeleteHostedZone
 deleteHostedZone pId_ =
     DeleteHostedZone'
@@ -69,7 +69,7 @@ deleteHostedZone pId_ =
     }
 
 -- | The ID of the hosted zone you want to delete.
-dhzId :: Lens' DeleteHostedZone Text
+dhzId :: Lens' DeleteHostedZone ResourceId
 dhzId = lens _dhzId (\ s a -> s{_dhzId = a});
 
 instance AWSRequest DeleteHostedZone where

--- a/amazonka-route53/gen/Network/AWS/Route53/DeleteReusableDelegationSet.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/DeleteReusableDelegationSet.hs
@@ -53,7 +53,7 @@ import           Network.AWS.Route53.Types.Product
 --
 -- /See:/ 'deleteReusableDelegationSet' smart constructor.
 newtype DeleteReusableDelegationSet = DeleteReusableDelegationSet'
-    { _drdsId :: Text
+    { _drdsId :: ResourceId
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
 -- | Creates a value of 'DeleteReusableDelegationSet' with the minimum fields required to make a request.
@@ -62,7 +62,7 @@ newtype DeleteReusableDelegationSet = DeleteReusableDelegationSet'
 --
 -- * 'drdsId' - The ID of the reusable delegation set you want to delete.
 deleteReusableDelegationSet
-    :: Text -- ^ 'drdsId'
+    :: ResourceId -- ^ 'drdsId'
     -> DeleteReusableDelegationSet
 deleteReusableDelegationSet pId_ =
     DeleteReusableDelegationSet'
@@ -70,7 +70,7 @@ deleteReusableDelegationSet pId_ =
     }
 
 -- | The ID of the reusable delegation set you want to delete.
-drdsId :: Lens' DeleteReusableDelegationSet Text
+drdsId :: Lens' DeleteReusableDelegationSet ResourceId
 drdsId = lens _drdsId (\ s a -> s{_drdsId = a});
 
 instance AWSRequest DeleteReusableDelegationSet where

--- a/amazonka-route53/gen/Network/AWS/Route53/DeleteVPCAssociationAuthorization.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/DeleteVPCAssociationAuthorization.hs
@@ -54,7 +54,7 @@ import           Network.AWS.Route53.Types.Product
 --
 -- /See:/ 'deleteVPCAssociationAuthorization' smart constructor.
 data DeleteVPCAssociationAuthorization = DeleteVPCAssociationAuthorization'
-    { _dvaaHostedZoneId :: !Text
+    { _dvaaHostedZoneId :: !ResourceId
     , _dvaaVPC          :: !VPC
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
@@ -66,7 +66,7 @@ data DeleteVPCAssociationAuthorization = DeleteVPCAssociationAuthorization'
 --
 -- * 'dvaaVPC' - When removing authorization to associate a VPC that was created by one AWS account with a hosted zone that was created with a different AWS account, a complex type that includes the ID and region of the VPC.
 deleteVPCAssociationAuthorization
-    :: Text -- ^ 'dvaaHostedZoneId'
+    :: ResourceId -- ^ 'dvaaHostedZoneId'
     -> VPC -- ^ 'dvaaVPC'
     -> DeleteVPCAssociationAuthorization
 deleteVPCAssociationAuthorization pHostedZoneId_ pVPC_ =
@@ -76,7 +76,7 @@ deleteVPCAssociationAuthorization pHostedZoneId_ pVPC_ =
     }
 
 -- | When removing authorization to associate a VPC that was created by one AWS account with a hosted zone that was created with a different AWS account, the ID of the hosted zone.
-dvaaHostedZoneId :: Lens' DeleteVPCAssociationAuthorization Text
+dvaaHostedZoneId :: Lens' DeleteVPCAssociationAuthorization ResourceId
 dvaaHostedZoneId = lens _dvaaHostedZoneId (\ s a -> s{_dvaaHostedZoneId = a});
 
 -- | When removing authorization to associate a VPC that was created by one AWS account with a hosted zone that was created with a different AWS account, a complex type that includes the ID and region of the VPC.

--- a/amazonka-route53/gen/Network/AWS/Route53/DisassociateVPCFromHostedZone.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/DisassociateVPCFromHostedZone.hs
@@ -57,7 +57,7 @@ import           Network.AWS.Route53.Types.Product
 -- /See:/ 'disassociateVPCFromHostedZone' smart constructor.
 data DisassociateVPCFromHostedZone = DisassociateVPCFromHostedZone'
     { _dvfhzComment      :: !(Maybe Text)
-    , _dvfhzHostedZoneId :: !Text
+    , _dvfhzHostedZoneId :: !ResourceId
     , _dvfhzVPC          :: !VPC
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
@@ -71,7 +71,7 @@ data DisassociateVPCFromHostedZone = DisassociateVPCFromHostedZone'
 --
 -- * 'dvfhzVPC' - A complex type that contains information about the VPC that you're disassociating from the specified hosted zone.
 disassociateVPCFromHostedZone
-    :: Text -- ^ 'dvfhzHostedZoneId'
+    :: ResourceId -- ^ 'dvfhzHostedZoneId'
     -> VPC -- ^ 'dvfhzVPC'
     -> DisassociateVPCFromHostedZone
 disassociateVPCFromHostedZone pHostedZoneId_ pVPC_ =
@@ -86,7 +86,7 @@ dvfhzComment :: Lens' DisassociateVPCFromHostedZone (Maybe Text)
 dvfhzComment = lens _dvfhzComment (\ s a -> s{_dvfhzComment = a});
 
 -- | The ID of the private hosted zone that you want to disassociate a VPC from.
-dvfhzHostedZoneId :: Lens' DisassociateVPCFromHostedZone Text
+dvfhzHostedZoneId :: Lens' DisassociateVPCFromHostedZone ResourceId
 dvfhzHostedZoneId = lens _dvfhzHostedZoneId (\ s a -> s{_dvfhzHostedZoneId = a});
 
 -- | A complex type that contains information about the VPC that you're disassociating from the specified hosted zone.

--- a/amazonka-route53/gen/Network/AWS/Route53/GetChange.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/GetChange.hs
@@ -56,7 +56,7 @@ import           Network.AWS.Route53.Types.Product
 --
 -- /See:/ 'getChange' smart constructor.
 newtype GetChange = GetChange'
-    { _gcId :: Text
+    { _gcId :: ResourceId
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
 -- | Creates a value of 'GetChange' with the minimum fields required to make a request.
@@ -65,7 +65,7 @@ newtype GetChange = GetChange'
 --
 -- * 'gcId' - The ID of the change batch request. The value that you specify here is the value that @ChangeResourceRecordSets@ returned in the Id element when you submitted the request.
 getChange
-    :: Text -- ^ 'gcId'
+    :: ResourceId -- ^ 'gcId'
     -> GetChange
 getChange pId_ =
     GetChange'
@@ -73,7 +73,7 @@ getChange pId_ =
     }
 
 -- | The ID of the change batch request. The value that you specify here is the value that @ChangeResourceRecordSets@ returned in the Id element when you submitted the request.
-gcId :: Lens' GetChange Text
+gcId :: Lens' GetChange ResourceId
 gcId = lens _gcId (\ s a -> s{_gcId = a});
 
 instance AWSRequest GetChange where

--- a/amazonka-route53/gen/Network/AWS/Route53/GetHostedZone.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/GetHostedZone.hs
@@ -52,7 +52,7 @@ import           Network.AWS.Route53.Types.Product
 --
 -- /See:/ 'getHostedZone' smart constructor.
 newtype GetHostedZone = GetHostedZone'
-    { _ghzId :: Text
+    { _ghzId :: ResourceId
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
 -- | Creates a value of 'GetHostedZone' with the minimum fields required to make a request.
@@ -61,7 +61,7 @@ newtype GetHostedZone = GetHostedZone'
 --
 -- * 'ghzId' - The ID of the hosted zone for which you want to get a list of the name servers in the delegation set.
 getHostedZone
-    :: Text -- ^ 'ghzId'
+    :: ResourceId -- ^ 'ghzId'
     -> GetHostedZone
 getHostedZone pId_ =
     GetHostedZone'
@@ -69,7 +69,7 @@ getHostedZone pId_ =
     }
 
 -- | The ID of the hosted zone for which you want to get a list of the name servers in the delegation set.
-ghzId :: Lens' GetHostedZone Text
+ghzId :: Lens' GetHostedZone ResourceId
 ghzId = lens _ghzId (\ s a -> s{_ghzId = a});
 
 instance AWSRequest GetHostedZone where

--- a/amazonka-route53/gen/Network/AWS/Route53/GetReusableDelegationSet.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/GetReusableDelegationSet.hs
@@ -50,7 +50,7 @@ import           Network.AWS.Route53.Types.Product
 --
 -- /See:/ 'getReusableDelegationSet' smart constructor.
 newtype GetReusableDelegationSet = GetReusableDelegationSet'
-    { _grdsId :: Text
+    { _grdsId :: ResourceId
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
 -- | Creates a value of 'GetReusableDelegationSet' with the minimum fields required to make a request.
@@ -59,7 +59,7 @@ newtype GetReusableDelegationSet = GetReusableDelegationSet'
 --
 -- * 'grdsId' - The ID of the reusable delegation set for which you want to get a list of the name server.
 getReusableDelegationSet
-    :: Text -- ^ 'grdsId'
+    :: ResourceId -- ^ 'grdsId'
     -> GetReusableDelegationSet
 getReusableDelegationSet pId_ =
     GetReusableDelegationSet'
@@ -67,7 +67,7 @@ getReusableDelegationSet pId_ =
     }
 
 -- | The ID of the reusable delegation set for which you want to get a list of the name server.
-grdsId :: Lens' GetReusableDelegationSet Text
+grdsId :: Lens' GetReusableDelegationSet ResourceId
 grdsId = lens _grdsId (\ s a -> s{_grdsId = a});
 
 instance AWSRequest GetReusableDelegationSet where

--- a/amazonka-route53/gen/Network/AWS/Route53/ListHostedZones.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/ListHostedZones.hs
@@ -89,7 +89,7 @@ import           Network.AWS.Route53.Types.Product
 --
 -- /See:/ 'listHostedZones' smart constructor.
 data ListHostedZones = ListHostedZones'
-    { _lhzDelegationSetId :: !(Maybe Text)
+    { _lhzDelegationSetId :: !(Maybe ResourceId)
     , _lhzMarker          :: !(Maybe Text)
     , _lhzMaxItems        :: !(Maybe Text)
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
@@ -113,7 +113,7 @@ listHostedZones =
     }
 
 -- | If you're using reusable delegation sets and you want to list all of the hosted zones that are associated with a reusable delegation set, specify the ID of that reusable delegation set.
-lhzDelegationSetId :: Lens' ListHostedZones (Maybe Text)
+lhzDelegationSetId :: Lens' ListHostedZones (Maybe ResourceId)
 lhzDelegationSetId = lens _lhzDelegationSetId (\ s a -> s{_lhzDelegationSetId = a});
 
 -- | (Optional) If you have more hosted zones than the value of @maxitems@ , @ListHostedZones@ returns only the first @maxitems@ hosted zones. To get the next group of @maxitems@ hosted zones, submit another request to @ListHostedZones@ . For the value of marker, specify the value of the @NextMarker@ element that was returned in the previous response. Hosted zones are listed in the order in which they were created.

--- a/amazonka-route53/gen/Network/AWS/Route53/ListHostedZonesByName.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/ListHostedZonesByName.hs
@@ -108,7 +108,7 @@ import           Network.AWS.Route53.Types.Product
 --
 -- /See:/ 'listHostedZonesByName' smart constructor.
 data ListHostedZonesByName = ListHostedZonesByName'
-    { _lhzbnHostedZoneId :: !(Maybe Text)
+    { _lhzbnHostedZoneId :: !(Maybe ResourceId)
     , _lhzbnMaxItems     :: !(Maybe Text)
     , _lhzbnDNSName      :: !(Maybe Text)
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
@@ -132,7 +132,7 @@ listHostedZonesByName =
     }
 
 -- | (Optional) For your first request to @ListHostedZonesByName@ , do not include the @hostedzoneid@ parameter. If you have more hosted zones than the value of @maxitems@ , @ListHostedZonesByName@ returns only the first @maxitems@ hosted zones. To get the next group of @maxitems@ hosted zones, submit another request to @ListHostedZonesByName@ and include both @dnsname@ and @hostedzoneid@ parameters. For the value of @hostedzoneid@ , specify the value of the @NextHostedZoneId@ element from the previous response.
-lhzbnHostedZoneId :: Lens' ListHostedZonesByName (Maybe Text)
+lhzbnHostedZoneId :: Lens' ListHostedZonesByName (Maybe ResourceId)
 lhzbnHostedZoneId = lens _lhzbnHostedZoneId (\ s a -> s{_lhzbnHostedZoneId = a});
 
 -- | The maximum number of hosted zones to be included in the response body for this request. If you have more than @maxitems@ hosted zones, then the value of the @IsTruncated@ element in the response is true, and the values of @NextDNSName@ and @NextHostedZoneId@ specify the first hosted zone in the next group of @maxitems@ hosted zones.
@@ -184,8 +184,8 @@ instance ToQuery ListHostedZonesByName where
 --
 -- /See:/ 'listHostedZonesByNameResponse' smart constructor.
 data ListHostedZonesByNameResponse = ListHostedZonesByNameResponse'
-    { _lhzbnrsHostedZoneId     :: !(Maybe Text)
-    , _lhzbnrsNextHostedZoneId :: !(Maybe Text)
+    { _lhzbnrsHostedZoneId     :: !(Maybe ResourceId)
+    , _lhzbnrsNextHostedZoneId :: !(Maybe ResourceId)
     , _lhzbnrsDNSName          :: !(Maybe Text)
     , _lhzbnrsNextDNSName      :: !(Maybe Text)
     , _lhzbnrsResponseStatus   :: !Int
@@ -231,11 +231,11 @@ listHostedZonesByNameResponse pResponseStatus_ pIsTruncated_ pMaxItems_ =
     }
 
 -- | The ID that Amazon Route 53 assigned to the hosted zone when you created it.
-lhzbnrsHostedZoneId :: Lens' ListHostedZonesByNameResponse (Maybe Text)
+lhzbnrsHostedZoneId :: Lens' ListHostedZonesByNameResponse (Maybe ResourceId)
 lhzbnrsHostedZoneId = lens _lhzbnrsHostedZoneId (\ s a -> s{_lhzbnrsHostedZoneId = a});
 
 -- | If @IsTruncated@ is @true@ , the value of @NextHostedZoneId@ identifies the first hosted zone in the next group of @maxitems@ hosted zones. Call @ListHostedZonesByName@ again and specify the value of @NextDNSName@ and @NextHostedZoneId@ in the @dnsname@ and @hostedzoneid@ parameters, respectively. This element is present only if @IsTruncated@ is @true@ .
-lhzbnrsNextHostedZoneId :: Lens' ListHostedZonesByNameResponse (Maybe Text)
+lhzbnrsNextHostedZoneId :: Lens' ListHostedZonesByNameResponse (Maybe ResourceId)
 lhzbnrsNextHostedZoneId = lens _lhzbnrsNextHostedZoneId (\ s a -> s{_lhzbnrsNextHostedZoneId = a});
 
 -- | For the second and subsequent calls to @ListHostedZonesByName@ , @DNSName@ is the value that you specified for the @dnsname@ parameter in the request that produced the current response.

--- a/amazonka-route53/gen/Network/AWS/Route53/ListResourceRecordSets.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/ListResourceRecordSets.hs
@@ -90,7 +90,7 @@ data ListResourceRecordSets = ListResourceRecordSets'
     , _lrrsStartRecordType       :: !(Maybe RecordType)
     , _lrrsStartRecordIdentifier :: !(Maybe Text)
     , _lrrsMaxItems              :: !(Maybe Text)
-    , _lrrsHostedZoneId          :: !Text
+    , _lrrsHostedZoneId          :: !ResourceId
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
 -- | Creates a value of 'ListResourceRecordSets' with the minimum fields required to make a request.
@@ -107,7 +107,7 @@ data ListResourceRecordSets = ListResourceRecordSets'
 --
 -- * 'lrrsHostedZoneId' - The ID of the hosted zone that contains the resource record sets that you want to get.
 listResourceRecordSets
-    :: Text -- ^ 'lrrsHostedZoneId'
+    :: ResourceId -- ^ 'lrrsHostedZoneId'
     -> ListResourceRecordSets
 listResourceRecordSets pHostedZoneId_ =
     ListResourceRecordSets'
@@ -135,7 +135,7 @@ lrrsMaxItems :: Lens' ListResourceRecordSets (Maybe Text)
 lrrsMaxItems = lens _lrrsMaxItems (\ s a -> s{_lrrsMaxItems = a});
 
 -- | The ID of the hosted zone that contains the resource record sets that you want to get.
-lrrsHostedZoneId :: Lens' ListResourceRecordSets Text
+lrrsHostedZoneId :: Lens' ListResourceRecordSets ResourceId
 lrrsHostedZoneId = lens _lrrsHostedZoneId (\ s a -> s{_lrrsHostedZoneId = a});
 
 instance AWSPager ListResourceRecordSets where

--- a/amazonka-route53/gen/Network/AWS/Route53/ListTrafficPolicyInstances.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/ListTrafficPolicyInstances.hs
@@ -84,7 +84,7 @@ import           Network.AWS.Route53.Types.Product
 data ListTrafficPolicyInstances = ListTrafficPolicyInstances'
     { _ltpiTrafficPolicyInstanceTypeMarker :: !(Maybe RecordType)
     , _ltpiMaxItems                        :: !(Maybe Text)
-    , _ltpiHostedZoneIdMarker              :: !(Maybe Text)
+    , _ltpiHostedZoneIdMarker              :: !(Maybe ResourceId)
     , _ltpiTrafficPolicyInstanceNameMarker :: !(Maybe Text)
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
@@ -118,7 +118,7 @@ ltpiMaxItems :: Lens' ListTrafficPolicyInstances (Maybe Text)
 ltpiMaxItems = lens _ltpiMaxItems (\ s a -> s{_ltpiMaxItems = a});
 
 -- | For the first request to @ListTrafficPolicyInstances@ , omit this value. If the value of @IsTruncated@ in the previous response was @true@ , you have more traffic policy instances. To get the next group of @MaxItems@ traffic policy instances, submit another @ListTrafficPolicyInstances@ request. For the value of @HostedZoneIdMarker@ , specify the value of @HostedZoneIdMarker@ from the previous response, which is the hosted zone ID of the first traffic policy instance in the next group of @MaxItems@ traffic policy instances. If the value of @IsTruncated@ in the previous response was @false@ , there are no more traffic policy instances to get.
-ltpiHostedZoneIdMarker :: Lens' ListTrafficPolicyInstances (Maybe Text)
+ltpiHostedZoneIdMarker :: Lens' ListTrafficPolicyInstances (Maybe ResourceId)
 ltpiHostedZoneIdMarker = lens _ltpiHostedZoneIdMarker (\ s a -> s{_ltpiHostedZoneIdMarker = a});
 
 -- | For the first request to @ListTrafficPolicyInstances@ , omit this value. If the value of @IsTruncated@ in the previous response was @true@ , @TrafficPolicyInstanceNameMarker@ is the name of the first traffic policy instance in the next group of @MaxItems@ traffic policy instances. If the value of @IsTruncated@ in the previous response was @false@ , there are no more traffic policy instances to get.
@@ -170,7 +170,7 @@ instance ToQuery ListTrafficPolicyInstances where
 -- /See:/ 'listTrafficPolicyInstancesResponse' smart constructor.
 data ListTrafficPolicyInstancesResponse = ListTrafficPolicyInstancesResponse'
     { _ltpirsTrafficPolicyInstanceTypeMarker :: !(Maybe RecordType)
-    , _ltpirsHostedZoneIdMarker              :: !(Maybe Text)
+    , _ltpirsHostedZoneIdMarker              :: !(Maybe ResourceId)
     , _ltpirsTrafficPolicyInstanceNameMarker :: !(Maybe Text)
     , _ltpirsResponseStatus                  :: !Int
     , _ltpirsTrafficPolicyInstances          :: ![TrafficPolicyInstance]
@@ -216,7 +216,7 @@ ltpirsTrafficPolicyInstanceTypeMarker :: Lens' ListTrafficPolicyInstancesRespons
 ltpirsTrafficPolicyInstanceTypeMarker = lens _ltpirsTrafficPolicyInstanceTypeMarker (\ s a -> s{_ltpirsTrafficPolicyInstanceTypeMarker = a});
 
 -- | If @IsTruncated@ is @true@ , @HostedZoneIdMarker@ is the ID of the hosted zone of the first traffic policy instance in the next group of @MaxItems@ traffic policy instances.
-ltpirsHostedZoneIdMarker :: Lens' ListTrafficPolicyInstancesResponse (Maybe Text)
+ltpirsHostedZoneIdMarker :: Lens' ListTrafficPolicyInstancesResponse (Maybe ResourceId)
 ltpirsHostedZoneIdMarker = lens _ltpirsHostedZoneIdMarker (\ s a -> s{_ltpirsHostedZoneIdMarker = a});
 
 -- | If @IsTruncated@ is @true@ , @TrafficPolicyInstanceNameMarker@ is the name of the first traffic policy instance in the next group of @MaxItems@ traffic policy instances.

--- a/amazonka-route53/gen/Network/AWS/Route53/ListTrafficPolicyInstancesByHostedZone.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/ListTrafficPolicyInstancesByHostedZone.hs
@@ -84,7 +84,7 @@ data ListTrafficPolicyInstancesByHostedZone = ListTrafficPolicyInstancesByHosted
     { _ltpibhzTrafficPolicyInstanceTypeMarker :: !(Maybe RecordType)
     , _ltpibhzMaxItems                        :: !(Maybe Text)
     , _ltpibhzTrafficPolicyInstanceNameMarker :: !(Maybe Text)
-    , _ltpibhzHostedZoneId                    :: !Text
+    , _ltpibhzHostedZoneId                    :: !ResourceId
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
 -- | Creates a value of 'ListTrafficPolicyInstancesByHostedZone' with the minimum fields required to make a request.
@@ -99,7 +99,7 @@ data ListTrafficPolicyInstancesByHostedZone = ListTrafficPolicyInstancesByHosted
 --
 -- * 'ltpibhzHostedZoneId' - The ID of the hosted zone for which you want to list traffic policy instances.
 listTrafficPolicyInstancesByHostedZone
-    :: Text -- ^ 'ltpibhzHostedZoneId'
+    :: ResourceId -- ^ 'ltpibhzHostedZoneId'
     -> ListTrafficPolicyInstancesByHostedZone
 listTrafficPolicyInstancesByHostedZone pHostedZoneId_ =
     ListTrafficPolicyInstancesByHostedZone'
@@ -122,7 +122,7 @@ ltpibhzTrafficPolicyInstanceNameMarker :: Lens' ListTrafficPolicyInstancesByHost
 ltpibhzTrafficPolicyInstanceNameMarker = lens _ltpibhzTrafficPolicyInstanceNameMarker (\ s a -> s{_ltpibhzTrafficPolicyInstanceNameMarker = a});
 
 -- | The ID of the hosted zone for which you want to list traffic policy instances.
-ltpibhzHostedZoneId :: Lens' ListTrafficPolicyInstancesByHostedZone Text
+ltpibhzHostedZoneId :: Lens' ListTrafficPolicyInstancesByHostedZone ResourceId
 ltpibhzHostedZoneId = lens _ltpibhzHostedZoneId (\ s a -> s{_ltpibhzHostedZoneId = a});
 
 instance AWSRequest

--- a/amazonka-route53/gen/Network/AWS/Route53/ListTrafficPolicyInstancesByPolicy.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/ListTrafficPolicyInstancesByPolicy.hs
@@ -86,7 +86,7 @@ import           Network.AWS.Route53.Types.Product
 data ListTrafficPolicyInstancesByPolicy = ListTrafficPolicyInstancesByPolicy'
     { _ltpibpTrafficPolicyInstanceTypeMarker :: !(Maybe RecordType)
     , _ltpibpMaxItems                        :: !(Maybe Text)
-    , _ltpibpHostedZoneIdMarker              :: !(Maybe Text)
+    , _ltpibpHostedZoneIdMarker              :: !(Maybe ResourceId)
     , _ltpibpTrafficPolicyInstanceNameMarker :: !(Maybe Text)
     , _ltpibpTrafficPolicyId                 :: !Text
     , _ltpibpTrafficPolicyVersion            :: !Nat
@@ -130,7 +130,7 @@ ltpibpMaxItems :: Lens' ListTrafficPolicyInstancesByPolicy (Maybe Text)
 ltpibpMaxItems = lens _ltpibpMaxItems (\ s a -> s{_ltpibpMaxItems = a});
 
 -- | For the first request to @ListTrafficPolicyInstancesByPolicy@ , omit this value. If the value of @IsTruncated@ in the previous response was @true@ , @HostedZoneIdMarker@ is the ID of the hosted zone for the first traffic policy instance in the next group of @MaxItems@ traffic policy instances. If the value of @IsTruncated@ in the previous response was @false@ , there are no more traffic policy instances to get for this hosted zone. If the value of @IsTruncated@ in the previous response was @false@ , omit this value.
-ltpibpHostedZoneIdMarker :: Lens' ListTrafficPolicyInstancesByPolicy (Maybe Text)
+ltpibpHostedZoneIdMarker :: Lens' ListTrafficPolicyInstancesByPolicy (Maybe ResourceId)
 ltpibpHostedZoneIdMarker = lens _ltpibpHostedZoneIdMarker (\ s a -> s{_ltpibpHostedZoneIdMarker = a});
 
 -- | For the first request to @ListTrafficPolicyInstancesByPolicy@ , omit this value. If the value of @IsTruncated@ in the previous response was @true@ , @TrafficPolicyInstanceNameMarker@ is the name of the first traffic policy instance in the next group of @MaxItems@ traffic policy instances. If the value of @IsTruncated@ in the previous response was @false@ , there are no more traffic policy instances to get for this hosted zone. If the value of @IsTruncated@ in the previous response was @false@ , omit this value.
@@ -198,7 +198,7 @@ instance ToQuery ListTrafficPolicyInstancesByPolicy
 -- /See:/ 'listTrafficPolicyInstancesByPolicyResponse' smart constructor.
 data ListTrafficPolicyInstancesByPolicyResponse = ListTrafficPolicyInstancesByPolicyResponse'
     { _ltpibprsTrafficPolicyInstanceTypeMarker :: !(Maybe RecordType)
-    , _ltpibprsHostedZoneIdMarker              :: !(Maybe Text)
+    , _ltpibprsHostedZoneIdMarker              :: !(Maybe ResourceId)
     , _ltpibprsTrafficPolicyInstanceNameMarker :: !(Maybe Text)
     , _ltpibprsResponseStatus                  :: !Int
     , _ltpibprsTrafficPolicyInstances          :: ![TrafficPolicyInstance]
@@ -244,7 +244,7 @@ ltpibprsTrafficPolicyInstanceTypeMarker :: Lens' ListTrafficPolicyInstancesByPol
 ltpibprsTrafficPolicyInstanceTypeMarker = lens _ltpibprsTrafficPolicyInstanceTypeMarker (\ s a -> s{_ltpibprsTrafficPolicyInstanceTypeMarker = a});
 
 -- | If @IsTruncated@ is @true@ , @HostedZoneIdMarker@ is the ID of the hosted zone of the first traffic policy instance in the next group of @MaxItems@ traffic policy instances.
-ltpibprsHostedZoneIdMarker :: Lens' ListTrafficPolicyInstancesByPolicyResponse (Maybe Text)
+ltpibprsHostedZoneIdMarker :: Lens' ListTrafficPolicyInstancesByPolicyResponse (Maybe ResourceId)
 ltpibprsHostedZoneIdMarker = lens _ltpibprsHostedZoneIdMarker (\ s a -> s{_ltpibprsHostedZoneIdMarker = a});
 
 -- | If @IsTruncated@ is @true@ , @TrafficPolicyInstanceNameMarker@ is the name of the first traffic policy instance in the next group of @MaxItems@ traffic policy instances.

--- a/amazonka-route53/gen/Network/AWS/Route53/ListVPCAssociationAuthorizations.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/ListVPCAssociationAuthorizations.hs
@@ -66,7 +66,7 @@ import           Network.AWS.Route53.Types.Product
 data ListVPCAssociationAuthorizations = ListVPCAssociationAuthorizations'
     { _lvaaNextToken    :: !(Maybe Text)
     , _lvaaMaxResults   :: !(Maybe Text)
-    , _lvaaHostedZoneId :: !Text
+    , _lvaaHostedZoneId :: !ResourceId
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
 -- | Creates a value of 'ListVPCAssociationAuthorizations' with the minimum fields required to make a request.
@@ -79,7 +79,7 @@ data ListVPCAssociationAuthorizations = ListVPCAssociationAuthorizations'
 --
 -- * 'lvaaHostedZoneId' - The ID of the hosted zone for which you want a list of VPCs that can be associated with the hosted zone.
 listVPCAssociationAuthorizations
-    :: Text -- ^ 'lvaaHostedZoneId'
+    :: ResourceId -- ^ 'lvaaHostedZoneId'
     -> ListVPCAssociationAuthorizations
 listVPCAssociationAuthorizations pHostedZoneId_ =
     ListVPCAssociationAuthorizations'
@@ -97,7 +97,7 @@ lvaaMaxResults :: Lens' ListVPCAssociationAuthorizations (Maybe Text)
 lvaaMaxResults = lens _lvaaMaxResults (\ s a -> s{_lvaaMaxResults = a});
 
 -- | The ID of the hosted zone for which you want a list of VPCs that can be associated with the hosted zone.
-lvaaHostedZoneId :: Lens' ListVPCAssociationAuthorizations Text
+lvaaHostedZoneId :: Lens' ListVPCAssociationAuthorizations ResourceId
 lvaaHostedZoneId = lens _lvaaHostedZoneId (\ s a -> s{_lvaaHostedZoneId = a});
 
 instance AWSRequest ListVPCAssociationAuthorizations
@@ -144,7 +144,7 @@ instance ToQuery ListVPCAssociationAuthorizations
 data ListVPCAssociationAuthorizationsResponse = ListVPCAssociationAuthorizationsResponse'
     { _lvaarsNextToken      :: !(Maybe Text)
     , _lvaarsResponseStatus :: !Int
-    , _lvaarsHostedZoneId   :: !Text
+    , _lvaarsHostedZoneId   :: !ResourceId
     , _lvaarsVPCs           :: !(List1 VPC)
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
@@ -161,7 +161,7 @@ data ListVPCAssociationAuthorizationsResponse = ListVPCAssociationAuthorizations
 -- * 'lvaarsVPCs' - The list of VPCs that are authorized to be associated with the specified hosted zone.
 listVPCAssociationAuthorizationsResponse
     :: Int -- ^ 'lvaarsResponseStatus'
-    -> Text -- ^ 'lvaarsHostedZoneId'
+    -> ResourceId -- ^ 'lvaarsHostedZoneId'
     -> NonEmpty VPC -- ^ 'lvaarsVPCs'
     -> ListVPCAssociationAuthorizationsResponse
 listVPCAssociationAuthorizationsResponse pResponseStatus_ pHostedZoneId_ pVPCs_ =
@@ -181,7 +181,7 @@ lvaarsResponseStatus :: Lens' ListVPCAssociationAuthorizationsResponse Int
 lvaarsResponseStatus = lens _lvaarsResponseStatus (\ s a -> s{_lvaarsResponseStatus = a});
 
 -- | The ID of the hosted zone that you can associate the listed VPCs with.
-lvaarsHostedZoneId :: Lens' ListVPCAssociationAuthorizationsResponse Text
+lvaarsHostedZoneId :: Lens' ListVPCAssociationAuthorizationsResponse ResourceId
 lvaarsHostedZoneId = lens _lvaarsHostedZoneId (\ s a -> s{_lvaarsHostedZoneId = a});
 
 -- | The list of VPCs that are authorized to be associated with the specified hosted zone.

--- a/amazonka-route53/gen/Network/AWS/Route53/TestDNSAnswer.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/TestDNSAnswer.hs
@@ -79,7 +79,7 @@ data TestDNSAnswer = TestDNSAnswer'
     { _tdaResolverIP            :: !(Maybe Text)
     , _tdaEDNS0ClientSubnetIP   :: !(Maybe Text)
     , _tdaEDNS0ClientSubnetMask :: !(Maybe Text)
-    , _tdaHostedZoneId          :: !Text
+    , _tdaHostedZoneId          :: !ResourceId
     , _tdaRecordName            :: !Text
     , _tdaRecordType            :: !RecordType
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
@@ -100,7 +100,7 @@ data TestDNSAnswer = TestDNSAnswer'
 --
 -- * 'tdaRecordType' - The type of the resource record set.
 testDNSAnswer
-    :: Text -- ^ 'tdaHostedZoneId'
+    :: ResourceId -- ^ 'tdaHostedZoneId'
     -> Text -- ^ 'tdaRecordName'
     -> RecordType -- ^ 'tdaRecordType'
     -> TestDNSAnswer
@@ -127,7 +127,7 @@ tdaEDNS0ClientSubnetMask :: Lens' TestDNSAnswer (Maybe Text)
 tdaEDNS0ClientSubnetMask = lens _tdaEDNS0ClientSubnetMask (\ s a -> s{_tdaEDNS0ClientSubnetMask = a});
 
 -- | The ID of the hosted zone that you want Amazon Route 53 to simulate a query for.
-tdaHostedZoneId :: Lens' TestDNSAnswer Text
+tdaHostedZoneId :: Lens' TestDNSAnswer ResourceId
 tdaHostedZoneId = lens _tdaHostedZoneId (\ s a -> s{_tdaHostedZoneId = a});
 
 -- | The name of the resource record set that you want Amazon Route 53 to simulate a query for.

--- a/amazonka-route53/gen/Network/AWS/Route53/Types/Product.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/Types/Product.hs
@@ -86,7 +86,7 @@ instance ToXML AlarmIdentifier where
 --
 -- /See:/ 'aliasTarget' smart constructor.
 data AliasTarget = AliasTarget'
-    { _atHostedZoneId         :: !Text
+    { _atHostedZoneId         :: !ResourceId
     , _atDNSName              :: !Text
     , _atEvaluateTargetHealth :: !Bool
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
@@ -101,7 +101,7 @@ data AliasTarget = AliasTarget'
 --
 -- * 'atEvaluateTargetHealth' - /Applies only to alias, weighted alias, latency alias, and failover alias record sets:/ If you set the value of @EvaluateTargetHealth@ to @true@ for the resource record set or sets in an alias, weighted alias, latency alias, or failover alias resource record set, and if you specify a value for @'HealthCheck$Id' @ for every resource record set that is referenced by these alias resource record sets, the alias resource record sets inherit the health of the referenced resource record sets. In this configuration, when Amazon Route 53 receives a DNS query for an alias resource record set:     * Amazon Route 53 looks at the resource record sets that are referenced by the alias resource record sets to determine which health checks they're using.     * Amazon Route 53 checks the current status of each health check. (Amazon Route 53 periodically checks the health of the endpoint that is specified in a health check; it doesn't perform the health check when the DNS query arrives.)     * Based on the status of the health checks, Amazon Route 53 determines which resource record sets are healthy. Unhealthy resource record sets are immediately removed from consideration. In addition, if all of the resource record sets that are referenced by an alias resource record set are unhealthy, that alias resource record set also is immediately removed from consideration.     * Based on the configuration of the alias resource record sets (weighted alias or latency alias, for example) and the configuration of the resource record sets that they reference, Amazon Route 53 chooses a resource record set from the healthy resource record sets, and responds to the query. Note the following:     * You can't set @EvaluateTargetHealth@ to @true@ when the alias target is a CloudFront distribution.     * If the AWS resource that you specify in @AliasTarget@ is a resource record set or a group of resource record sets (for example, a group of weighted resource record sets), but it is not another alias resource record set, we recommend that you associate a health check with all of the resource record sets in the alias target.For more information, see <http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-complex-configs.html#dns-failover-complex-configs-hc-omitting What Happens When You Omit Health Checks?> in the /Amazon Route 53 Developer Guide/ .     * If you specify an Elastic Beanstalk environment in @HostedZoneId@ and @DNSName@ , and if the environment contains an ELB load balancer, Elastic Load Balancing routes queries only to the healthy Amazon EC2 instances that are registered with the load balancer. (An environment automatically contains an ELB load balancer if it includes more than one EC2 instance.) If you set @EvaluateTargetHealth@ to @true@ and either no EC2 instances are healthy or the load balancer itself is unhealthy, Amazon Route 53 routes queries to other available resources that are healthy, if any. If the environment contains a single EC2 instance, there are no special requirements.     * If you specify an ELB load balancer in @'AliasTarget' @ , Elastic Load Balancing routes queries only to the healthy EC2 instances that are registered with the load balancer. If no EC2 instances are healthy or if the load balancer itself is unhealthy, and if @EvaluateTargetHealth@ is true for the corresponding alias resource record set, Amazon Route 53 routes queries to other resources. When you create a load balancer, you configure settings for Elastic Load Balancing health checks; they're not Amazon Route 53 health checks, but they perform a similar function. Do not create Amazon Route 53 health checks for the EC2 instances that you register with an ELB load balancer. For more information, see <http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover-complex-configs.html How Health Checks Work in More Complex Amazon Route 53 Configurations> in the /Amazon Route 53 Developers Guide/ .     * We recommend that you set @EvaluateTargetHealth@ to true only when you have enough idle capacity to handle the failure of one or more endpoints. For more information and examples, see <http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover.html Amazon Route 53 Health Checks and DNS Failover> in the /Amazon Route 53 Developer Guide/ .
 aliasTarget
-    :: Text -- ^ 'atHostedZoneId'
+    :: ResourceId -- ^ 'atHostedZoneId'
     -> Text -- ^ 'atDNSName'
     -> Bool -- ^ 'atEvaluateTargetHealth'
     -> AliasTarget
@@ -113,7 +113,7 @@ aliasTarget pHostedZoneId_ pDNSName_ pEvaluateTargetHealth_ =
     }
 
 -- | /Alias resource records sets only/ : The value used depends on where the queries are routed:     * A CloudFront distribution    * Specify @Z2FDTNDATAQYW2@ .     * Elastic Beanstalk environment    * Specify the hosted zone ID for the region in which you created the environment. The environment must have a regionalized subdomain. For a list of regions and the corresponding hosted zone IDs, see <http://docs.aws.amazon.com/general/latest/gr/rande.html#elasticbeanstalk_region AWS Elastic Beanstalk> in the Regions and Endpoints chapter of the /Amazon Web Services General Reference/ .     * ELB load balancer    * Specify the value of the hosted zone ID for the load balancer. Use the following methods to get the hosted zone ID:     * AWS Management Console: Go to the Amazon EC2 page, click __Load Balancers__ in the navigation pane, select the load balancer, and get the value of the __Hosted Zone ID__ field on the __Description__ tab. Use the same process to get the value of __DNS Name__ . See 'HostedZone$Name' .     * Elastic Load Balancing API: Use @DescribeLoadBalancers@ to get the value of @CanonicalHostedZoneNameID@ . Use the same process to get the @CanonicalHostedZoneName@ . See 'HostedZone$Name' .     * AWS CLI: Use @<http://docs.aws.amazon.com/cli/latest/reference/elb/describe-load-balancers.html describe-load-balancers> @ to get the value of @CanonicalHostedZoneNameID@ . Use the same process to get the @CanonicalHostedZoneName@ . See 'HostedZone$Name' .     * An Amazon S3 bucket configured as a static website    * Specify the hosted zone ID for the Amazon S3 website endpoint in which you created the bucket. For more information about valid values, see the table <http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region Amazon S3 (S3) Website Endpoints> in the /Amazon Web Services General Reference/ .     * Another Amazon Route 53 resource record set in your hosted zone    * Specify the hosted zone ID of your hosted zone. (An alias resource record set can't reference a resource record set in a different hosted zone.)
-atHostedZoneId :: Lens' AliasTarget Text
+atHostedZoneId :: Lens' AliasTarget ResourceId
 atHostedZoneId = lens _atHostedZoneId (\ s a -> s{_atHostedZoneId = a});
 
 -- | /Alias resource record sets only:/ The value that you specify depends on where you want to route queries:     * __A CloudFront distribution:__ Specify the domain name that CloudFront assigned when you created your distribution. Your CloudFront distribution must include an alternate domain name that matches the name of the resource record set. For example, if the name of the resource record set is /acme.example.com/ , your CloudFront distribution must include /acme.example.com/ as one of the alternate domain names. For more information, see <http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html Using Alternate Domain Names (CNAMEs)> in the /Amazon CloudFront Developer Guide/ .     * __Elastic Beanstalk environment__ : Specify the @CNAME@ attribute for the environment. (The environment must have a regionalized domain name.) You can use the following methods to get the value of the CNAME attribute:     * /AWS Managment Console/ : For information about how to get the value by using the console, see <http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/customdomains.html Using Custom Domains with AWS Elastic Beanstalk> in the /AWS Elastic Beanstalk Developer Guide/ .     * /Elastic Load Balancing API/ : Use the @DescribeEnvironments@ action to get the value of the @CNAME@ attribute. For more information, see <http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/API_DescribeEnvironments.html DescribeEnvironments> in the /AWS Elastic Beanstalk API Reference/ .     * /AWS CLI/ : Use the describe-environments command to get the value of the @CNAME@ attribute. For more information, see <http://docs.aws.amazon.com/cli/latest/reference/elasticbeanstalk/describe-environments.html describe-environments> in the /AWS Command Line Interface Reference/ .     * __An ELB load balancer:__ Specify the DNS name associated with the load balancer. Get the DNS name by using the AWS Management Console, the ELB API, or the AWS CLI. Use the same method to get values for @HostedZoneId@ and @DNSName@ . If you get one value from the console and the other value from the API or the CLI, creating the resource record set will fail.     * /AWS Management Console/ : Go to the EC2 page, click __Load Balancers__ in the navigation pane, choose the load balancer, choose the __Description__ tab, and get the value of the __DNS Name__ field that begins with dualstack. Use the same process to get the __Hosted Zone ID__ . See 'HostedZone$Id' .     * /Elastic Load Balancing API/ : Use @<http://docs.aws.amazon.com/ElasticLoadBalancing/latest/APIReference/API_DescribeLoadBalancers.html DescribeLoadBalancers> @ to get the value of @CanonicalHostedZoneName@ . Use the same process to get the @CanonicalHostedZoneNameId@ . See 'HostedZone$Id' .     * /AWS CLI/ : Use @<http://docs.aws.amazon.com/ElasticLoadBalancing/latest/APIReference/API_DescribeLoadBalancers.html describe-load-balancers> @ to get the value of @CanonicalHostedZoneName@ . Use the same process to get the @CanonicalHostedZoneNameId@ . See HostedZoneId.     * __An Amazon S3 bucket that is configured as a static website:__ Specify the domain name of the Amazon S3 website endpoint in which you created the bucket; for example, @s3-website-us-east-1.amazonaws.com@ . For more information about valid values, see the table <http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region Amazon Simple Storage Service (S3) Website Endpoints> in the /Amazon Web Services General Reference/ . For more information about using S3 buckets for websites, see <http://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html Hosting a Static Website on Amazon S3> in the /Amazon S3 Developer Guide./      * __Another Amazon Route 53 resource record set__ : Specify the value of the @Name@ element for a resource record set in the current hosted zone.
@@ -237,7 +237,7 @@ instance ToXML ChangeBatch where
 -- /See:/ 'changeInfo' smart constructor.
 data ChangeInfo = ChangeInfo'
     { _ciComment     :: !(Maybe Text)
-    , _ciId          :: !Text
+    , _ciId          :: !ResourceId
     , _ciStatus      :: !ChangeStatus
     , _ciSubmittedAt :: !ISO8601
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
@@ -254,7 +254,7 @@ data ChangeInfo = ChangeInfo'
 --
 -- * 'ciSubmittedAt' - The date and time the change request was submitted, in Coordinated Universal Time (UTC) format: @YYYY-MM-DDThh:mm:ssZ@ . For more information, see the Wikipedia entry <https://en.wikipedia.org/wiki/ISO_8601 ISO 8601> .
 changeInfo
-    :: Text -- ^ 'ciId'
+    :: ResourceId -- ^ 'ciId'
     -> ChangeStatus -- ^ 'ciStatus'
     -> UTCTime -- ^ 'ciSubmittedAt'
     -> ChangeInfo
@@ -271,7 +271,7 @@ ciComment :: Lens' ChangeInfo (Maybe Text)
 ciComment = lens _ciComment (\ s a -> s{_ciComment = a});
 
 -- | The ID of the request.
-ciId :: Lens' ChangeInfo Text
+ciId :: Lens' ChangeInfo ResourceId
 ciId = lens _ciId (\ s a -> s{_ciId = a});
 
 -- | The current state of the request. @PENDING@ indicates that this request has not yet been applied to all Amazon Route 53 DNS servers.
@@ -403,7 +403,7 @@ instance NFData CloudWatchAlarmConfiguration
 --
 -- /See:/ 'delegationSet' smart constructor.
 data DelegationSet = DelegationSet'
-    { _dsId              :: !(Maybe Text)
+    { _dsId              :: !(Maybe ResourceId)
     , _dsCallerReference :: !(Maybe Text)
     , _dsNameServers     :: !(List1 Text)
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
@@ -428,7 +428,7 @@ delegationSet pNameServers_ =
     }
 
 -- | The ID that Amazon Route 53 assigns to a reusable delegation set.
-dsId :: Lens' DelegationSet (Maybe Text)
+dsId :: Lens' DelegationSet (Maybe ResourceId)
 dsId = lens _dsId (\ s a -> s{_dsId = a});
 
 -- | A unique string that identifies the request, and that allows you to retry failed @CreateReusableDelegationSet@ requests without the risk of executing the operation twice. You must use a unique @CallerReference@ string every time you submit a @CreateReusableDelegationSet@ request. @CallerReference@ can be any unique string, for example, a date/time stamp.
@@ -961,7 +961,7 @@ instance NFData HealthCheckObservation
 data HostedZone = HostedZone'
     { _hzConfig                 :: !(Maybe HostedZoneConfig)
     , _hzResourceRecordSetCount :: !(Maybe Integer)
-    , _hzId                     :: !Text
+    , _hzId                     :: !ResourceId
     , _hzName                   :: !Text
     , _hzCallerReference        :: !Text
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
@@ -980,7 +980,7 @@ data HostedZone = HostedZone'
 --
 -- * 'hzCallerReference' - The value that you specified for @CallerReference@ when you created the hosted zone.
 hostedZone
-    :: Text -- ^ 'hzId'
+    :: ResourceId -- ^ 'hzId'
     -> Text -- ^ 'hzName'
     -> Text -- ^ 'hzCallerReference'
     -> HostedZone
@@ -1002,7 +1002,7 @@ hzResourceRecordSetCount :: Lens' HostedZone (Maybe Integer)
 hzResourceRecordSetCount = lens _hzResourceRecordSetCount (\ s a -> s{_hzResourceRecordSetCount = a});
 
 -- | The ID that Amazon Route 53 assigned to the hosted zone when you created it.
-hzId :: Lens' HostedZone Text
+hzId :: Lens' HostedZone ResourceId
 hzId = lens _hzId (\ s a -> s{_hzId = a});
 
 -- | The name of the domain. For public hosted zones, this is the name that you have registered with your DNS registrar. For information about how to specify characters other than @a-z@ , @0-9@ , and @-@ (hyphen) and how to specify internationalized domain names, see 'CreateHostedZone' .
@@ -1493,7 +1493,7 @@ instance NFData TrafficPolicy
 -- /See:/ 'trafficPolicyInstance' smart constructor.
 data TrafficPolicyInstance = TrafficPolicyInstance'
     { _tpiId                   :: !Text
-    , _tpiHostedZoneId         :: !Text
+    , _tpiHostedZoneId         :: !ResourceId
     , _tpiName                 :: !Text
     , _tpiTTL                  :: !Nat
     , _tpiState                :: !Text
@@ -1526,7 +1526,7 @@ data TrafficPolicyInstance = TrafficPolicyInstance'
 -- * 'tpiTrafficPolicyType' - The DNS type that Amazon Route 53 assigned to all of the resource record sets that it created for this traffic policy instance.
 trafficPolicyInstance
     :: Text -- ^ 'tpiId'
-    -> Text -- ^ 'tpiHostedZoneId'
+    -> ResourceId -- ^ 'tpiHostedZoneId'
     -> Text -- ^ 'tpiName'
     -> Natural -- ^ 'tpiTTL'
     -> Text -- ^ 'tpiState'
@@ -1553,7 +1553,7 @@ tpiId :: Lens' TrafficPolicyInstance Text
 tpiId = lens _tpiId (\ s a -> s{_tpiId = a});
 
 -- | The ID of the hosted zone that Amazon Route 53 created resource record sets in.
-tpiHostedZoneId :: Lens' TrafficPolicyInstance Text
+tpiHostedZoneId :: Lens' TrafficPolicyInstance ResourceId
 tpiHostedZoneId = lens _tpiHostedZoneId (\ s a -> s{_tpiHostedZoneId = a});
 
 -- | The DNS name, such as www.example.com, for which Amazon Route 53 responds to queries by using the resource record sets that are associated with this traffic policy instance.

--- a/amazonka-route53/gen/Network/AWS/Route53/UpdateHostedZoneComment.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53/UpdateHostedZoneComment.hs
@@ -52,7 +52,7 @@ import           Network.AWS.Route53.Types.Product
 -- /See:/ 'updateHostedZoneComment' smart constructor.
 data UpdateHostedZoneComment = UpdateHostedZoneComment'
     { _uhzcComment :: !(Maybe Text)
-    , _uhzcId      :: !Text
+    , _uhzcId      :: !ResourceId
     } deriving (Eq,Read,Show,Data,Typeable,Generic)
 
 -- | Creates a value of 'UpdateHostedZoneComment' with the minimum fields required to make a request.
@@ -63,7 +63,7 @@ data UpdateHostedZoneComment = UpdateHostedZoneComment'
 --
 -- * 'uhzcId' - The ID for the hosted zone for which you want to update the comment.
 updateHostedZoneComment
-    :: Text -- ^ 'uhzcId'
+    :: ResourceId -- ^ 'uhzcId'
     -> UpdateHostedZoneComment
 updateHostedZoneComment pId_ =
     UpdateHostedZoneComment'
@@ -76,7 +76,7 @@ uhzcComment :: Lens' UpdateHostedZoneComment (Maybe Text)
 uhzcComment = lens _uhzcComment (\ s a -> s{_uhzcComment = a});
 
 -- | The ID for the hosted zone for which you want to update the comment.
-uhzcId :: Lens' UpdateHostedZoneComment Text
+uhzcId :: Lens' UpdateHostedZoneComment ResourceId
 uhzcId = lens _uhzcId (\ s a -> s{_uhzcId = a});
 
 instance AWSRequest UpdateHostedZoneComment where

--- a/amazonka-route53/src/Network/AWS/Route53/Internal.hs
+++ b/amazonka-route53/src/Network/AWS/Route53/Internal.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE DeriveDataTypeable         #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
 -- |
 -- Module      : Network.AWS.Route53.Internal
 -- Copyright   : (c) 2013-2016 Brendan Hay
@@ -7,7 +11,47 @@
 -- Portability : non-portable (GHC extensions)
 --
 module Network.AWS.Route53.Internal
-    ( Region (..)
+    ( Region     (..)
+    , ResourceId (..)
     ) where
 
-import           Network.AWS.Types (Region (..))
+import Data.String
+
+import Network.AWS.Data.Log
+import Network.AWS.Data.XML
+import Network.AWS.Prelude
+import Network.AWS.Types    (Region (..))
+
+import qualified Data.Text as Text
+
+-- | A Route53 identifier for resources such as hosted zones and delegation sets.
+--
+-- Since Route53 outputs prefixed resource identifiers such as
+-- @/hostedzone/ABC123@, but expects unprefixed identifiers as inputs, such as
+-- @ABC123@, the @FromXML@ instance will strip this prefix take care to ensure
+-- the correct input format is observed and @decodeXML . encodeXML == id@
+-- holds.
+newtype ResourceId = ResourceId { fromResourceId :: Text }
+    deriving
+        ( Eq
+        , Ord
+        , Read
+        , Show
+        , Data
+        , Typeable
+        , Generic
+        , IsString
+        , FromText
+        , ToText
+        , ToByteString
+        , ToXML
+        , ToQuery
+        , ToLog
+        )
+
+instance Hashable ResourceId
+instance NFData   ResourceId
+
+-- | Handles prefixed Route53 resource identifiers.
+instance FromXML ResourceId where
+    parseXML = fmap (ResourceId . Text.takeWhileEnd (/= '/')) . parseXML

--- a/gen/config/route53.json
+++ b/gen/config/route53.json
@@ -20,6 +20,12 @@
         },
         "ResourceRecordSetFailover": {
             "renamedTo": "Failover"
+        },
+        "ResourceId": {
+            "replacedBy": {
+                "name": "ResourceId",
+                "deriving": []
+            }
         }
     }
 }

--- a/gen/config/route53.json
+++ b/gen/config/route53.json
@@ -1,5 +1,8 @@
 {
     "libraryName": "amazonka-route53",
+    "extraDependencies": [
+        "text >= 1.1"
+    ],
     "typeModules": [
         "Network.AWS.Route53.Internal"
     ],

--- a/script/travis-lifecycle-install
+++ b/script/travis-lifecycle-install
@@ -12,5 +12,5 @@ $path/travis-timeout \
 
 if [ "$LIBRARY" != "documentation" ]; then
     $path/travis-timeout \
-        stack --no-terminal --skip-ghc-check --stack-yaml stack-$GHCVER.yaml build --test --fast --only-snapshot $LIBRARY
+        stack --no-terminal --skip-ghc-check --stack-yaml stack-$GHCVER.yaml build --test --fast -j1 --only-snapshot $LIBRARY
 fi

--- a/script/travis-lifecycle-script
+++ b/script/travis-lifecycle-script
@@ -12,5 +12,5 @@ if [ "$LIBRARY" == "documentation" ]; then
     $path/travis-documentation
 else
     echo "Running tests for ${LIBRARY}..."
-    stack --no-terminal --skip-ghc-check --stack-yaml stack-$GHCVER.yaml build --test --fast $LIBRARY
+    stack --no-terminal --skip-ghc-check --stack-yaml stack-$GHCVER.yaml build --test --fast -j1 $LIBRARY
 fi


### PR DESCRIPTION
This PR adds a `ResourceId` type and specific `FromXML` parsing functionality that removes the prefix from `/<prefix>/<identifier>`. This allows identifiers contained as outputs from parsed responses to be used as inputs without having to massage them at the application level.

This behaviour is taken from the AWS CLI and `botocore`, specifically.

Fixes #318 