### PR TITLE
Obtain ELB, Redshift, and HostedZone Ids for S3 Bucket Policies per Region

### DIFF
--- a/amazonka-ec2/gen/Network/AWS/EC2.hs
+++ b/amazonka-ec2/gen/Network/AWS/EC2.hs
@@ -778,7 +778,7 @@ module Network.AWS.EC2
 
     -- * Types
 
-    -- ** Re-exported Types
+    -- ** Common
     , module Network.AWS.EC2.Internal
 
     -- ** AccountAttributeName

--- a/amazonka-elb/amazonka-elb.cabal
+++ b/amazonka-elb/amazonka-elb.cabal
@@ -72,7 +72,8 @@ library
         , Network.AWS.ELB.Waiters
 
     other-modules:
-          Network.AWS.ELB.Types.Product
+          Network.AWS.ELB.Internal
+        , Network.AWS.ELB.Types.Product
         , Network.AWS.ELB.Types.Sum
 
     build-depends:

--- a/amazonka-elb/gen/Network/AWS/ELB.hs
+++ b/amazonka-elb/gen/Network/AWS/ELB.hs
@@ -186,6 +186,9 @@ module Network.AWS.ELB
 
     -- * Types
 
+    -- ** Common
+    , module Network.AWS.ELB.Internal
+
     -- ** AccessLog
     , AccessLog
     , accessLog
@@ -388,6 +391,7 @@ import           Network.AWS.ELB.DescribeTags
 import           Network.AWS.ELB.DetachLoadBalancerFromSubnets
 import           Network.AWS.ELB.DisableAvailabilityZonesForLoadBalancer
 import           Network.AWS.ELB.EnableAvailabilityZonesForLoadBalancer
+import           Network.AWS.ELB.Internal
 import           Network.AWS.ELB.ModifyLoadBalancerAttributes
 import           Network.AWS.ELB.RegisterInstancesWithLoadBalancer
 import           Network.AWS.ELB.RemoveTags

--- a/amazonka-elb/gen/Network/AWS/ELB/Types.hs
+++ b/amazonka-elb/gen/Network/AWS/ELB/Types.hs
@@ -38,6 +38,9 @@ module Network.AWS.ELB.Types
     , _TooManyPoliciesException
     , _CertificateNotFoundException
 
+    -- * Re-exported Types
+    , module Network.AWS.ELB.Internal
+
     -- * AccessLog
     , AccessLog
     , accessLog
@@ -218,6 +221,7 @@ module Network.AWS.ELB.Types
     , tkoKey
     ) where
 
+import           Network.AWS.ELB.Internal
 import           Network.AWS.ELB.Types.Product
 import           Network.AWS.ELB.Types.Sum
 import           Network.AWS.Lens

--- a/amazonka-elb/gen/Network/AWS/ELB/Types/Product.hs
+++ b/amazonka-elb/gen/Network/AWS/ELB/Types/Product.hs
@@ -17,6 +17,7 @@
 --
 module Network.AWS.ELB.Types.Product where
 
+import           Network.AWS.ELB.Internal
 import           Network.AWS.ELB.Types.Sum
 import           Network.AWS.Lens
 import           Network.AWS.Prelude

--- a/amazonka-elb/gen/Network/AWS/ELB/Types/Sum.hs
+++ b/amazonka-elb/gen/Network/AWS/ELB/Types/Sum.hs
@@ -17,4 +17,5 @@
 --
 module Network.AWS.ELB.Types.Sum where
 
+import           Network.AWS.ELB.Internal
 import           Network.AWS.Prelude

--- a/amazonka-elb/src/Network/AWS/ELB/Internal.hs
+++ b/amazonka-elb/src/Network/AWS/ELB/Internal.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+-- |
+-- Module      : Network.AWS.ELB.Internal
+-- Copyright   : (c) 2013-2016 Brendan Hay
+-- License     : Mozilla Public License, v. 2.0.
+-- Maintainer  : Brendan Hay <brendan.g.hay@gmail.com>
+-- Stability   : experimental
+-- Portability : non-portable (GHC extensions)
+--
+module Network.AWS.ELB.Internal
+    ( getAccountId
+    ) where
+
+import Network.AWS.Prelude
+
+-- | This account identifier is used when attaching a policy to your S3 bucket
+-- allowing ELB to upload and write access logs.
+--
+-- /See:/ <http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html#attach-bucket-policy Attach a Policy to Your S3 Bucket>.
+getAccountId :: Region -> Text
+getAccountId = \case
+    NorthVirginia   -> "127311923021"
+    Ohio            -> "033677994240"
+    NorthCalifornia -> "027434742980"
+    Oregon          -> "797873946194"
+    Tokyo           -> "582318560864"
+    Seoul           -> "600734575887"
+    Mumbai          -> "718504428378"
+    Singapore       -> "114774131450"
+    Sydney          -> "783225319266"
+    Ireland         -> "156460612806"
+    Frankfurt       -> "054676820928"
+    SaoPaulo        -> "507241528517"
+    GovCloud        -> "048591011584"
+    GovCloudFIPS    -> "048591011584"
+    Beijing         -> "638102146993"

--- a/amazonka-redshift/amazonka-redshift.cabal
+++ b/amazonka-redshift/amazonka-redshift.cabal
@@ -106,7 +106,8 @@ library
         , Network.AWS.Redshift.Waiters
 
     other-modules:
-          Network.AWS.Redshift.Types.Product
+          Network.AWS.Redshift.Internal
+        , Network.AWS.Redshift.Types.Product
         , Network.AWS.Redshift.Types.Sum
 
     build-depends:

--- a/amazonka-redshift/gen/Network/AWS/Redshift.hs
+++ b/amazonka-redshift/gen/Network/AWS/Redshift.hs
@@ -483,6 +483,9 @@ module Network.AWS.Redshift
 
     -- * Types
 
+    -- ** Common
+    , module Network.AWS.Redshift.Internal
+
     -- ** ParameterApplyType
     , ParameterApplyType (..)
 
@@ -937,6 +940,7 @@ import           Network.AWS.Redshift.DisableLogging
 import           Network.AWS.Redshift.DisableSnapshotCopy
 import           Network.AWS.Redshift.EnableLogging
 import           Network.AWS.Redshift.EnableSnapshotCopy
+import           Network.AWS.Redshift.Internal
 import           Network.AWS.Redshift.ModifyCluster
 import           Network.AWS.Redshift.ModifyClusterIAMRoles
 import           Network.AWS.Redshift.ModifyClusterParameterGroup

--- a/amazonka-redshift/gen/Network/AWS/Redshift/Types.hs
+++ b/amazonka-redshift/gen/Network/AWS/Redshift/Types.hs
@@ -100,6 +100,9 @@ module Network.AWS.Redshift.Types
     , _InsufficientS3BucketPolicyFault
     , _ClusterSubnetGroupQuotaExceededFault
 
+    -- * Re-exported Types
+    , module Network.AWS.Redshift.Internal
+
     -- * ParameterApplyType
     , ParameterApplyType (..)
 
@@ -508,6 +511,7 @@ module Network.AWS.Redshift.Types
 
 import           Network.AWS.Lens
 import           Network.AWS.Prelude
+import           Network.AWS.Redshift.Internal
 import           Network.AWS.Redshift.Types.Product
 import           Network.AWS.Redshift.Types.Sum
 import           Network.AWS.Sign.V4

--- a/amazonka-redshift/gen/Network/AWS/Redshift/Types/Product.hs
+++ b/amazonka-redshift/gen/Network/AWS/Redshift/Types/Product.hs
@@ -19,6 +19,7 @@ module Network.AWS.Redshift.Types.Product where
 
 import           Network.AWS.Lens
 import           Network.AWS.Prelude
+import           Network.AWS.Redshift.Internal
 import           Network.AWS.Redshift.Types.Sum
 
 -- | Describes an AWS customer account authorized to restore a snapshot.

--- a/amazonka-redshift/gen/Network/AWS/Redshift/Types/Sum.hs
+++ b/amazonka-redshift/gen/Network/AWS/Redshift/Types/Sum.hs
@@ -18,6 +18,7 @@
 module Network.AWS.Redshift.Types.Sum where
 
 import           Network.AWS.Prelude
+import           Network.AWS.Redshift.Internal
 
 data ParameterApplyType
     = Dynamic

--- a/amazonka-redshift/src/Network/AWS/Redshift/Internal.hs
+++ b/amazonka-redshift/src/Network/AWS/Redshift/Internal.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+-- |
+-- Module      : Network.AWS.Redshift.Internal
+-- Copyright   : (c) 2013-2016 Brendan Hay
+-- License     : Mozilla Public License, v. 2.0.
+-- Maintainer  : Brendan Hay <brendan.g.hay@gmail.com>
+-- Stability   : experimental
+-- Portability : non-portable (GHC extensions)
+--
+module Network.AWS.Redshift.Internal
+    ( getAccountId
+    ) where
+
+import Network.AWS.Prelude
+
+-- | This account identifier is used when attaching a policy to your S3 bucket
+-- allowing Redshift to upload and write database audit logs.
+--
+-- /See:/ <http://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html#db-auditing-enable-logging Enabling Database Audit Logging>.
+getAccountId :: Region -> Maybe Text
+getAccountId = \case
+    NorthVirginia   -> Just "193672423079"
+    Ohio            -> Just "391106570357"
+    NorthCalifornia -> Just "262260360010"
+    Oregon          -> Just "902366379725"
+    Tokyo           -> Just "404641285394"
+    Seoul           -> Just "760740231472"
+    Mumbai          -> Just "865932855811"
+    Singapore       -> Just "361669875840"
+    Sydney          -> Just "762762565011"
+    SaoPaulo        -> Just "075028567923"
+    Frankfurt       -> Just "053454850223"
+    Ireland         -> Just "210876761215"
+    GovCloud        -> Nothing
+    GovCloudFIPS    -> Nothing
+    Beijing         -> Nothing

--- a/amazonka-route53/gen/Network/AWS/Route53.hs
+++ b/amazonka-route53/gen/Network/AWS/Route53.hs
@@ -313,7 +313,7 @@ module Network.AWS.Route53
 
     -- * Types
 
-    -- ** Re-exported Types
+    -- ** Common
     , module Network.AWS.Route53.Internal
 
     -- ** ChangeAction

--- a/amazonka-route53/src/Network/AWS/Route53/Internal.hs
+++ b/amazonka-route53/src/Network/AWS/Route53/Internal.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE OverloadedStrings          #-}
+
+{-# OPTIONS_GHC -Wall -Werror #-}
 
 -- |
 -- Module      : Network.AWS.Route53.Internal
@@ -13,14 +17,15 @@
 module Network.AWS.Route53.Internal
     ( Region     (..)
     , ResourceId (..)
+
+      -- * Website Endpoints
+    , getHostedZoneId
     ) where
 
-import Data.String
+import Data.String (IsString)
 
-import Network.AWS.Data.Log
-import Network.AWS.Data.XML
+import Network.AWS.Data.Log (ToLog)
 import Network.AWS.Prelude
-import Network.AWS.Types    (Region (..))
 
 import qualified Data.Text as Text
 
@@ -28,7 +33,7 @@ import qualified Data.Text as Text
 --
 -- Since Route53 outputs prefixed resource identifiers such as
 -- @/hostedzone/ABC123@, but expects unprefixed identifiers as inputs, such as
--- @ABC123@, the @FromXML@ instance will strip this prefix take care to ensure
+-- @ABC123@, the 'FromXML' instance will strip this prefix take care to ensure
 -- the correct input format is observed and @decodeXML . encodeXML == id@
 -- holds.
 newtype ResourceId = ResourceId { fromResourceId :: Text }
@@ -55,3 +60,28 @@ instance NFData   ResourceId
 -- | Handles prefixed Route53 resource identifiers.
 instance FromXML ResourceId where
     parseXML = fmap (ResourceId . Text.takeWhileEnd (/= '/')) . parseXML
+
+-- | Get the hosted zone identifier for an S3 website endpoint.
+--
+-- When you configure your bucket as a website, the website is available using
+-- a region-specific website endpoint. This hosted zone identifier is used
+-- adding an alias record to the website to your hosted zone.
+--
+-- /See:/ <http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints Amazon Simple Storage Service Website Endpoints>.
+getHostedZoneId :: Region -> Maybe ResourceId
+getHostedZoneId = \case
+    NorthVirginia   -> Just "Z3AQBSTGFYJSTF"
+    Ohio            -> Just "Z2O1EMRO9K5GLX"
+    NorthCalifornia -> Just "Z2F56UZL2M1ACD"
+    Oregon          -> Just "Z3BJ6K6RIION7M"
+    Tokyo           -> Just "Z2M4EHUR26P7ZW"
+    Seoul           -> Just "Z3W03O7B5YMIYP"
+    Mumbai          -> Just "Z11RGJOFQNVJUP"
+    Singapore       -> Just "Z3O0J2DXBE1FTB"
+    Sydney          -> Just "Z1WCIGYICN2BYD"
+    SaoPaulo        -> Just "Z7KQH4QJS55SO"
+    Ireland         -> Just "Z1BKCTXD74EZPE"
+    Frankfurt       -> Just "Z21DNDUVLTQW6Q"
+    GovCloud        -> Just "Z31GFT0UA1I2HV"
+    GovCloudFIPS    -> Just "Z31GFT0UA1I2HV"
+    Beijing         -> Nothing

--- a/amazonka-s3/gen/Network/AWS/S3.hs
+++ b/amazonka-s3/gen/Network/AWS/S3.hs
@@ -271,7 +271,7 @@ module Network.AWS.S3
 
     -- * Types
 
-    -- ** Re-exported Types
+    -- ** Common
     , module Network.AWS.S3.Internal
 
     -- ** AnalyticsS3ExportFileFormat

--- a/amazonka-s3/src/Network/AWS/S3/Internal.hs
+++ b/amazonka-s3/src/Network/AWS/S3/Internal.hs
@@ -33,16 +33,20 @@ module Network.AWS.S3.Internal
     , keyPrefix
     , keyName
     , keyComponents
+
+    -- * Website Endpoints
+    , getWebsiteEndpoint
     ) where
 
-import           Data.String
-import qualified Data.Text            as Text
-import           Network.AWS.Data.Log
-import           Network.AWS.Data.XML
-import           Network.AWS.Lens     (IndexedTraversal', Iso', Prism',
-                                       Traversal')
-import           Network.AWS.Lens     (iso, prism, traversed, _1, _2)
-import           Network.AWS.Prelude
+import Data.String (IsString)
+
+import Network.AWS.Data.Log
+import Network.AWS.Data.XML
+import Network.AWS.Lens     (IndexedTraversal', Iso', Prism', Traversal')
+import Network.AWS.Lens     (iso, prism, traversed, _1, _2)
+import Network.AWS.Prelude
+
+import qualified Data.Text as Text
 
 newtype BucketName = BucketName Text
     deriving
@@ -250,3 +254,12 @@ _ObjectKeySnoc dir !c = prism (ObjectKey . uncurry cat) split
         | otherwise               = h <> suf <> t
 
     suf = Text.singleton c
+
+-- | Get the S3 website endpoint for a specific region.
+--
+-- When you configure your bucket as a website, the website is available using
+-- this region-specific website endpoint.
+--
+-- /See:/ <http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints Amazon Simple Storage Service Website Endpoints>.
+getWebsiteEndpoint :: Region -> Text
+getWebsiteEndpoint reg = "s3-website-" <> toText reg <> ".amazonaws.com"

--- a/gen/config/elb.json
+++ b/gen/config/elb.json
@@ -1,3 +1,6 @@
 {
-    "libraryName": "amazonka-elb"
+    "libraryName": "amazonka-elb",
+    "typeModules": [
+        "Network.AWS.ELB.Internal"
+    ]
 }

--- a/gen/config/redshift.json
+++ b/gen/config/redshift.json
@@ -1,5 +1,8 @@
 {
     "libraryName": "amazonka-redshift",
+    "typeModules": [
+        "Network.AWS.Redshift.Internal"
+    ],
     "typeOverrides": {
         "DescribeDefaultClusterParametersResult": {
             "requiredFields": [

--- a/gen/template/toc.ede
+++ b/gen/template/toc.ede
@@ -42,7 +42,7 @@ module {{ moduleName }}
   {% for module in typeModules %}
     {% if module.first %}
 
-    -- ** Re-exported Types
+    -- ** Common
     {% endif %}
     , module {{ module.value }}
   {% endfor %}


### PR DESCRIPTION
This PR adds lookup of Account Id and HostedZones for support regions. It also provides `Network.AWS.S3.getWebsiteEndpoint` to obtain the S3 website endpoint for a given region.

See the following reference material for more details:

* ELB - [Enabling Access Logs](http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html#attach-bucket-policy)
* Redshift - [Enabling Database Audit Logs](http://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html#db-auditing-enable-logging)
* Route53 - [S3 Website Endpoints (Alias Records)](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints)