### PR TITLE
Remove Implicit Expect HTTP Header From PUT/POST Requests

### DIFF
--- a/amazonka-s3/gen/Network/AWS/S3/DeleteObjects.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/DeleteObjects.hs
@@ -96,7 +96,7 @@ dosDelete = lens _dosDelete (\ s a -> s{_dosDelete = a});
 
 instance AWSRequest DeleteObjects where
         type Rs DeleteObjects = DeleteObjectsResponse
-        request = contentMD5 . postXML s3
+        request = contentMD5Header . postXML s3
         response
           = receiveXML
               (\ s h x ->

--- a/amazonka-s3/gen/Network/AWS/S3/PutBucketPolicy.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/PutBucketPolicy.hs
@@ -82,7 +82,7 @@ pbpPolicy = lens _pbpPolicy (\ s a -> s{_pbpPolicy = a});
 
 instance AWSRequest PutBucketPolicy where
         type Rs PutBucketPolicy = PutBucketPolicyResponse
-        request = contentMD5 . putBody s3
+        request = contentMD5Header . putBody s3
         response = receiveNull PutBucketPolicyResponse'
 
 instance Hashable PutBucketPolicy

--- a/amazonka-s3/gen/Network/AWS/S3/PutBucketTagging.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/PutBucketTagging.hs
@@ -82,7 +82,7 @@ pbtTagging = lens _pbtTagging (\ s a -> s{_pbtTagging = a});
 
 instance AWSRequest PutBucketTagging where
         type Rs PutBucketTagging = PutBucketTaggingResponse
-        request = contentMD5 . putXML s3
+        request = contentMD5Header . putXML s3
         response = receiveNull PutBucketTaggingResponse'
 
 instance Hashable PutBucketTagging

--- a/amazonka-s3/gen/Network/AWS/S3/PutObject.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/PutObject.hs
@@ -300,7 +300,7 @@ poBody = lens _poBody (\ s a -> s{_poBody = a});
 
 instance AWSRequest PutObject where
         type Rs PutObject = PutObjectResponse
-        request = putBody s3
+        request = expectHeader . putBody s3
         response
           = receiveEmpty
               (\ s h x ->

--- a/core/src/Network/AWS/Request.hs
+++ b/core/src/Network/AWS/Request.hs
@@ -36,8 +36,9 @@ module Network.AWS.Request
     -- ** Constructors
     , defaultRequest
 
-    -- ** Hashing
-    , contentMD5
+    -- ** Operation Plugins
+    , contentMD5Header
+    , expectHeader
 
     -- ** Lenses
     , requestHeaders
@@ -98,7 +99,9 @@ postQuery s x = Request
     }
 
 postBody :: (ToRequest a, ToBody a) => Service -> a -> Request a
-postBody s x = putBody s x & rqMethod .~ POST
+postBody s x = defaultRequest s x
+    & rqMethod .~ POST
+    & rqBody   .~ toBody x
 
 putXML :: (ToRequest a, ToElement a) => Service -> a -> Request a
 putXML s x = defaultRequest s x
@@ -112,9 +115,8 @@ putJSON s x = defaultRequest s x
 
 putBody :: (ToRequest a, ToBody a) => Service -> a -> Request a
 putBody s x = defaultRequest s x
-    & rqMethod  .~ PUT
-    & rqBody    .~ toBody x
-    & rqHeaders %~ hdr hExpect "100-continue"
+    & rqMethod .~ PUT
+    & rqBody   .~ toBody x
 
 defaultRequest :: ToRequest a => Service -> a -> Request a
 defaultRequest s x = Request
@@ -125,14 +127,6 @@ defaultRequest s x = Request
     , _rqHeaders = toHeaders x
     , _rqBody    = ""
     }
-
-contentMD5 :: Request a -> Request a
-contentMD5 rq
-    | missing, Just x <- md5 = rq & rqHeaders %~ hdr HTTP.hContentMD5 x
-    | otherwise              = rq
-  where
-    missing = isNothing $ lookup HTTP.hContentMD5 (_rqHeaders rq)
-    md5     = md5Base64 (_rqBody rq)
 
 queryString :: Lens' Client.Request ByteString
 queryString f x =
@@ -159,3 +153,14 @@ requestURL x = scheme
         n            -> ":" <> toBS n
 
     secure = Client.secure x
+
+contentMD5Header :: Request a -> Request a
+contentMD5Header rq
+    | missing, Just x <- md5 = rq & rqHeaders %~ hdr HTTP.hContentMD5 x
+    | otherwise              = rq
+  where
+    missing = isNothing $ lookup HTTP.hContentMD5 (_rqHeaders rq)
+    md5     = md5Base64 (_rqBody rq)
+
+expectHeader :: Request a -> Request a
+expectHeader = rqHeaders %~ hdr hExpect "100-continue"

--- a/gen/config/s3.json
+++ b/gen/config/s3.json
@@ -5,11 +5,12 @@
         "lens >= 4.4"
     ],
     "operationPlugins": {
-        "DeleteObjects": ["contentMD5"],
-        "PutBucketCORS": ["contentMD5"],
-        "PutBucketLifecycle": ["contentMD5"],
-        "PutBucketPolicy": ["contentMD5"],
-        "PutBucketTagging": ["contentMD5"]
+        "DeleteObjects": ["contentMD5Header"],
+        "PutBucketCORS": ["contentMD5Header"],
+        "PutBucketLifecycle": ["contentMD5Header"],
+        "PutBucketPolicy": ["contentMD5Header"],
+        "PutBucketTagging": ["contentMD5Header"],
+        "PutObject": ["expectHeader"]
     },
     "typeModules": [
         "Network.AWS.S3.Internal"


### PR DESCRIPTION
The header is now added to the sole required case of S3 `PutObject` via the generator's `operationPlugins` configuration.

(Why wasn't it done this way originally?!)

Closes #330 