### PR TITLE
ReplicationStatus parser: should be '"COMPLETED" instead of "COMPLETE"

### DIFF
--- a/amazonka-s3/gen/Network/AWS/S3/Types/Sum.hs
+++ b/amazonka-s3/gen/Network/AWS/S3/Types/Sum.hs
@@ -737,16 +737,16 @@ data ReplicationStatus
 
 instance FromText ReplicationStatus where
     parser = takeLowerText >>= \case
-        "complete" -> pure Complete
-        "failed" -> pure Failed
-        "pending" -> pure Pending
-        "replica" -> pure Replica
+        "completed" -> pure Complete
+        "failed"    -> pure Failed
+        "pending"   -> pure Pending
+        "replica"   -> pure Replica
         e -> fromTextError $ "Failure parsing ReplicationStatus from value: '" <> e
-           <> "'. Accepted values: complete, failed, pending, replica"
+           <> "'. Accepted values: completed, failed, pending, replica"
 
 instance ToText ReplicationStatus where
     toText = \case
-        Complete -> "COMPLETE"
+        Complete -> "COMPLETED"
         Failed -> "FAILED"
         Pending -> "PENDING"
         Replica -> "REPLICA"


### PR DESCRIPTION
Hi,

As mentioned here http://docs.aws.amazon.com/AmazonS3/latest/dev/crr-status.html.
Without this I get an exception when getting an object from a replicated bucket.

Cheers,
Alberto