### PR TITLE
AWS signer for V2 Header authentication

### DIFF
--- a/core/amazonka-core.cabal
+++ b/core/amazonka-core.cabal
@@ -61,6 +61,8 @@ library
         , Network.AWS.Prelude
         , Network.AWS.Request
         , Network.AWS.Response
+        , Network.AWS.Sign.V2Header
+        , Network.AWS.Sign.V2Header.Base
         , Network.AWS.Sign.V2
         , Network.AWS.Sign.V4
         , Network.AWS.Types
@@ -128,6 +130,7 @@ test-suite tests
         , Test.AWS.Data.Path
         , Test.AWS.Data.Time
         , Test.AWS.Error
+        , Test.AWS.Sign.V2Header.BaseSpec
         , Test.AWS.Sign.V4
         , Test.AWS.Util
 
@@ -137,12 +140,14 @@ test-suite tests
         , base
         , bytestring
         , case-insensitive
+        , data-ordlist
         , http-types
+        , lens
+        , QuickCheck
+        , quickcheck-unicode
         , tasty
         , tasty-hunit
         , tasty-quickcheck
         , template-haskell
         , text
         , time
-        , QuickCheck
-        , quickcheck-unicode

--- a/core/src/Network/AWS/Data/Crypto.hs
+++ b/core/src/Network/AWS/Data/Crypto.hs
@@ -18,6 +18,7 @@ module Network.AWS.Data.Crypto
     , digestToBase
 
     -- * Algorithms
+    , hmacSHA1
     , hmacSHA256
     , hashSHA256
     , hashMD5
@@ -49,6 +50,11 @@ digestToBS = convert
 
 digestToBase :: ByteArrayAccess a => Base -> a -> ByteString
 digestToBase = convertToBase
+
+
+-- | Apply an HMAC sha1 with the given secret to the given value.
+hmacSHA1 :: (ByteArrayAccess a, ByteArray b) => a -> b -> HMAC SHA1
+hmacSHA1 = hmac
 
 hmacSHA256 :: (ByteArrayAccess a, ByteArray b) => a -> b -> HMAC SHA256
 hmacSHA256 = hmac

--- a/core/src/Network/AWS/Sign/V2Header.hs
+++ b/core/src/Network/AWS/Sign/V2Header.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+
+-- |
+-- Module      : Network.AWS.Sign.V2Header
+-- Description : This module provides an AWS compliant V2 Header request signer. It is based heavily on boto (https://github.com/boto/boto)
+--               Specifically boto's HmacAuthV1Handler AWS capable signer. Documentation in http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html
+--               Notice: Limitations include inability to sign with a security token and inability to overwrite Date header with expiry.
+-- Stability   : experimental
+-- Portability : non-portable (GHC extensions)
+--
+module Network.AWS.Sign.V2Header
+    ( v2Header
+    ) where
+
+import qualified Data.ByteString.Char8       as BS8
+import           Data.Monoid
+import           Data.Time
+import           Network.AWS.Data.Body
+import           Network.AWS.Data.ByteString
+import           Network.AWS.Data.Crypto
+import           Network.AWS.Data.Headers
+import           Network.AWS.Data.Log
+import           Network.AWS.Data.Path
+import           Network.AWS.Data.Time
+import           Network.AWS.Types
+import qualified Network.HTTP.Conduit        as Client
+import           Network.HTTP.Types
+
+import qualified Network.AWS.Sign.V2Header.Base as VB
+
+data V2Header = V2Header
+    { metaTime      :: !UTCTime
+    , metaEndpoint  :: !Endpoint
+    , metaSignature :: !ByteString
+    , headers       :: !Network.HTTP.Types.RequestHeaders
+    , signer        :: !ByteString
+    }
+
+instance ToLog V2Header where
+    build V2Header{..} = buildLines
+        [ "[Version 2 Header Metadata] {"
+        , "  time      = " <> build metaTime
+        , "  endpoint  = " <> build (_endpointHost metaEndpoint)
+        , "  signature = " <> build metaSignature
+        , "  headers = " <> build headers
+        , "  signer = " <> build signer
+        , "}"
+        ]
+
+v2Header :: Signer
+v2Header = Signer sign (const sign)
+
+sign :: Algorithm a
+sign Request{..} AuthEnv{..} r t = Signed meta rq
+  where
+    meta = Meta (V2Header t end signature headers signer)
+
+    signer = VB.constructHeaderSigner headers meth path' _rqQuery
+
+    rq = (clientRequest end _svcTimeout)
+        { Client.method         = meth
+        , Client.path           = path'
+        , Client.queryString    = toBS _rqQuery
+        , Client.requestHeaders = headers
+        , Client.requestBody    = toRequestBody _rqBody
+        }
+
+    meth  = toBS _rqMethod
+    path' = toBS (escapePath _rqPath)
+
+    end@Endpoint{..} = _svcEndpoint r
+
+    Service{..} = _rqService
+
+    signature = digestToBase Base64
+        . hmacSHA1 (toBS _authSecret) $ signer
+
+    headers = hdr hDate time _rqHeaders ++ [(hAuthorization, BS8.append "AWS " (BS8.append (toBS _authAccess) (BS8.append ":" signature)))]
+
+    time = toBS (Time t :: RFC822)

--- a/core/src/Network/AWS/Sign/V2Header/Base.hs
+++ b/core/src/Network/AWS/Sign/V2Header/Base.hs
@@ -1,0 +1,159 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE ViewPatterns      #-}
+
+-- |
+-- Module      : Network.AWS.Sign.V2Header.Base
+-- Description : This module provides auxiliary functions necessary for the AWS compliant V2 Header request signer.
+--               See also Network.AWS.Sign.V2Header
+-- Stability   : experimental
+-- Portability : non-portable (GHC extensions)
+--
+
+module Network.AWS.Sign.V2Header.Base
+  (
+  constructHeaderSigner
+  , constructFullPath
+  , constructHeaderStringForSigning
+  , constructQueryStringForSigning
+  , filterHeaders
+  , sortHeaders
+  , toSignerQBS
+  , unionNecessaryHeaders
+  ) where
+
+
+import           Data.ByteString.Builder     (Builder)
+import           Network.HTTP.Types.URI      (urlEncode)
+
+import qualified Data.ByteString.Builder      as Build
+import qualified Data.ByteString.Char8        as DBC
+import qualified Data.ByteString.Lazy         as LBS
+import qualified Data.CaseInsensitive         as DC
+import qualified Data.List                    as DL
+import           Data.Monoid                  ((<>), mempty)
+
+import qualified Network.AWS.Data.ByteString  as NADB
+import qualified Network.AWS.Data.Query       as NADQ
+import qualified Network.HTTP.Types           as NHT
+
+-- | Filter for 'interesting' keys within a QueryString
+isInterestingQueryKey :: NADB.ByteString -> Bool
+isInterestingQueryKey key
+  | key == "acl" = True
+  | key == "cors" = True
+  | key == "defaultObjectAcl" = True
+  | key == "location" = True
+  | key == "logging" = True
+  | key == "partNumber" = True
+  | key == "policy" = True
+  | key == "requestPayment" = True
+  | key == "torrent" = True
+  | key == "versioning" = True
+  | key == "versionId" = True
+  | key == "versions" = True
+  | key == "website" = True
+  | key == "uploads" = True
+  | key == "uploadId" = True
+  | key == "response-content-type" = True
+  | key == "response-content-language" = True
+  | key == "response-expires" = True
+  | key == "response-cache-control" = True
+  | key == "response-content-disposition" = True
+  | key == "response-content-encoding" = True
+  | key == "delete" = True
+  | key == "lifecycle" = True
+  | key == "tagging" = True
+  | key == "restore" = True
+  | key == "storageClass" = True
+  | key == "websiteConfig" = True
+  | key == "compose" = True
+  | otherwise = False
+
+-- | Filter for 'interesting' header fields
+isInterestingHeader :: NHT.Header -> Bool
+isInterestingHeader header
+  | headerName == NHT.hDate = True
+  | headerName == NHT.hContentMD5 = True
+  | headerName == NHT.hContentType = True
+  | "aws-" `DBC.isPrefixOf` DC.foldedCase headerName = True
+  | otherwise = False
+  where headerName = fst header
+
+-- | Constructs a query string for signing
+constructQueryStringForSigning :: NADQ.QueryString -> NADQ.QueryString
+constructQueryStringForSigning (NADQ.QValue _) = NADQ.QValue Nothing
+constructQueryStringForSigning (NADQ.QList qList) = NADQ.QList filtered
+  where
+    filtered = map constructQueryStringForSigning qList
+constructQueryStringForSigning (NADQ.QPair key value)
+  | isInterestingQueryKey key = NADQ.QPair key value
+  | otherwise = NADQ.QValue Nothing
+
+-- | Construct a header string for signing
+constructHeaderStringForSigning :: NHT.Header -> NADB.ByteString
+constructHeaderStringForSigning header
+  | "aws-" `DBC.isPrefixOf` DC.foldedCase headerName = DBC.append (DC.foldedCase headerName) $ DBC.append ":" headerValue
+  | otherwise = headerValue
+  where
+    headerName = fst header
+    headerValue = snd header
+
+filterHeaders :: [NHT.Header] -> [NHT.Header]
+filterHeaders = filter isInterestingHeader
+
+unionNecessaryHeaders :: [NHT.Header] -> [NHT.Header]
+unionNecessaryHeaders headers = DL.unionBy (\x y -> fst x == fst y) headers [(NHT.hContentMD5, ""), (NHT.hContentType, "")]
+
+sortHeaders :: [NHT.Header] -> [NHT.Header]
+sortHeaders = DL.sort
+
+-- | The following function mostly follows the toBS in amazonka QueryString
+--   except for single QValue or single QPair keys not being suffixed with
+--   an equals.
+toSignerQBS :: NADQ.QueryString -> NADB.ByteString
+toSignerQBS = LBS.toStrict . Build.toLazyByteString . cat . DL.sort . enc Nothing
+  where
+    enc :: Maybe NADB.ByteString -> NADQ.QueryString -> [NADB.ByteString]
+    enc p = \case
+      NADQ.QList xs          -> concatMap (enc p) xs
+
+      NADQ.QPair (urlEncode True -> k) x
+        | Just n <- p -> enc (Just (n <> kdelim <> k)) x -- <prev>.key <recur>
+        | otherwise   -> enc (Just k)                  x -- key <recur>
+
+      NADQ.QValue (Just (urlEncode True -> v))
+        | Just n <- p -> [n <> vsep <> v] -- key=value
+        | otherwise   -> [v]
+
+      _   | Just n <- p -> [n]
+          | otherwise   -> []
+
+    cat :: [NADB.ByteString] -> Builder
+    cat []     = mempty
+    cat [x]    = Build.byteString x
+    cat (x:xs) = Build.byteString x <> ksep <> cat xs
+
+    kdelim = "."
+    ksep   = "&"
+    vsep   = "="
+
+constructFullPath :: NADB.ByteString -> NADB.ByteString -> NADB.ByteString
+constructFullPath path q
+  | q == "" = path
+  | otherwise = path `DBC.append` "?" `DBC.append` q
+
+-- | Construct a full header signer following the V2 Header scheme
+constructHeaderSigner :: NHT.RequestHeaders -> NADB.ByteString -> NADB.ByteString -> NADQ.QueryString -> NADB.ByteString
+constructHeaderSigner headers method path query = signer
+  where
+
+    signer = DBC.intercalate "\n" $ [method] ++ map constructHeaderStringForSigning sortedHeaders ++ [constructFullPath path (toSignerQBS filteredQuery)]
+
+    sortedHeaders = sortHeaders allInterestingHeaders
+
+    allInterestingHeaders = unionNecessaryHeaders filterList
+
+    filterList = filterHeaders headers
+
+    filteredQuery = constructQueryStringForSigning query

--- a/core/test/Main.hs
+++ b/core/test/Main.hs
@@ -10,14 +10,16 @@
 --
 module Main (main) where
 
-import qualified Test.AWS.Data.Base64  as Base64
-import qualified Test.AWS.Data.List    as List
-import qualified Test.AWS.Data.Maybe   as Maybe
-import qualified Test.AWS.Data.Numeric as Numeric
-import qualified Test.AWS.Data.Path    as Path
-import qualified Test.AWS.Data.Time    as Time
-import qualified Test.AWS.Error        as Error
-import qualified Test.AWS.Sign.V4      as V4
+import qualified Test.AWS.Data.Base64            as Base64
+import qualified Test.AWS.Data.List              as List
+import qualified Test.AWS.Data.Maybe             as Maybe
+import qualified Test.AWS.Data.Numeric           as Numeric
+import qualified Test.AWS.Data.Path              as Path
+import qualified Test.AWS.Data.Time              as Time
+import qualified Test.AWS.Error                  as Error
+import qualified Test.AWS.Sign.V4                as V4
+import qualified Test.AWS.Sign.V2Header.BaseSpec as V2Header
+
 import           Test.Tasty
 
 main :: IO ()
@@ -39,7 +41,8 @@ main = defaultMain $
             ]
 
         , testGroup "signing"
-            [ V4.tests
+            [ V2Header.tests
+            , V4.tests
             ]
 
         , Error.tests

--- a/core/test/Test/AWS/Sign/V2Header/BaseSpec.hs
+++ b/core/test/Test/AWS/Sign/V2Header/BaseSpec.hs
@@ -1,0 +1,175 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module      : Test.AWS.Sign.V2Header.BaseSpec
+-- Stability   : experimental
+-- Portability : non-portable (GHC extensions)
+--
+module Test.AWS.Sign.V2Header.BaseSpec (tests) where
+
+import           Control.Applicative
+
+import qualified Data.ByteString.Char8       as DBC
+import qualified Data.CaseInsensitive        as DC
+import qualified Data.Text                   as DT
+import           Data.List.Ordered
+
+import qualified Network.AWS.Data.Query      as NADQ
+import qualified Network.HTTP.Types          as NHT
+
+import qualified Test.Tasty                  as TT
+import qualified Test.Tasty.QuickCheck       as TTQ
+
+-- unqualified to more natural test case flow
+import           Test.Tasty.HUnit
+
+import           Network.AWS.Sign.V2Header.Base
+
+--- Generators for Text / QueryValues
+
+nonEmptyString :: TTQ.Gen String
+nonEmptyString = TTQ.listOf validChars
+  where validChars = TTQ.frequency[(1, TTQ.choose('A','Z')), (1, TTQ.choose ('a', 'z'))]
+
+nonEmptyText :: TTQ.Gen DT.Text
+nonEmptyText = DT.pack <$> nonEmptyString
+  
+nonEmptyByteString :: TTQ.Gen DBC.ByteString
+nonEmptyByteString = DBC.pack <$> nonEmptyString
+
+uninterestingQValues :: TTQ.Gen NADQ.QueryString
+uninterestingQValues = NADQ.toQuery <$> nonEmptyText
+
+--- Properties for non-empty QValues
+
+prop_QValueEmpty :: TTQ.Property
+prop_QValueEmpty = TTQ.forAll uninterestingQValues $ \qv -> constructQueryStringForSigning qv ==  (NADQ.QValue(Nothing :: Maybe(DBC.ByteString)))
+
+--- Generators / properties for uninteresting query pairs
+
+uninterestingQPairs  :: TTQ.Gen NADQ.QueryString
+uninterestingQPairs = NADQ.toQuery <$> ((,) <$> nonEmptyText <*> uninterestingQValues)
+
+prop_UninterestingQPairs :: TTQ.Property
+prop_UninterestingQPairs = TTQ.forAll uninterestingQPairs $ \qpair -> constructQueryStringForSigning qpair == NADQ.QValue Nothing
+
+--- Generators / properties for interesting query pairs
+
+interestingQueryKey :: TTQ.Gen DBC.ByteString
+interestingQueryKey = TTQ.elements $ map DBC.pack ["acl","cors","defaultObjectAcl","location","logging","partNumber","policy","requestPayment","torrent","versioning","versionId","versions","website","uploads","uploadId","response-content-type","response-content-language","response-expires","response-cache-control","response-content-disposition","response-content-encoding","delete","lifecycle","tagging","restore","storageClass","websiteConfig","compose"]
+
+interestingQPairs :: TTQ.Gen NADQ.QueryString
+interestingQPairs = NADQ.toQuery <$> ((,) <$> interestingQueryKey <*> uninterestingQValues)
+
+prop_InterestingQPairs :: TTQ.Property
+prop_InterestingQPairs = TTQ.forAll interestingQPairs $ \qpair -> not (constructQueryStringForSigning qpair == NADQ.QValue Nothing)
+
+--- Generators / properties for query lists
+
+uninterestingQLists :: TTQ.Gen NADQ.QueryString
+uninterestingQLists = NADQ.toQueryList <$> nonEmptyByteString <*> (TTQ.listOf $ TTQ.frequency [(1, uninterestingQPairs), (1, uninterestingQValues), (1, uninterestingQLists)])
+
+containsAnything :: NADQ.QueryString -> Bool
+containsAnything (NADQ.QValue (Just _)) = True
+containsAnything (NADQ.QPair _ _) = True
+containsAnything (NADQ.QList qlist) = any containsAnything qlist
+containsAnything (NADQ.QValue Nothing) = False 
+
+prop_UninterestingQLists :: TTQ.Property
+prop_UninterestingQLists = TTQ.forAll uninterestingQLists $ \qlist -> not $ containsAnything $ constructQueryStringForSigning qlist
+
+interestingQLists :: TTQ.Gen NADQ.QueryString
+interestingQLists = NADQ.toQueryList <$> interestingQueryKey <*> (TTQ.listOf $ TTQ.frequency [(1, interestingQLists), (1, uninterestingQPairs), (1, uninterestingQValues), (1, uninterestingQLists)])
+
+-- this property should probably be expanded to check that all qpairs actually contain interesting query keys AND that uninteresting
+-- query keys are actually preserved underneath an interesting one
+prop_InterestingQLists :: TTQ.Property
+prop_InterestingQLists = TTQ.forAll interestingQLists $ \qlist -> containsAnything $ constructQueryStringForSigning qlist
+
+-- Generator / Property for headers
+randomHeaderGenerator :: TTQ.Gen NHT.Header
+randomHeaderGenerator = (,) <$> (DC.mk <$> nonEmptyByteString) <*> nonEmptyByteString
+
+interestingAwsHeaderName :: TTQ.Gen NHT.HeaderName
+interestingAwsHeaderName = DC.mk <$> DBC.pack <$> (("aws-" ++) <$> nonEmptyString)
+
+interestingHeaderName :: TTQ.Gen NHT.HeaderName
+interestingHeaderName = TTQ.elements [NHT.hContentMD5, NHT.hContentType, NHT.hDate]
+
+interestingHeaderGenerator :: TTQ.Gen NHT.Header
+interestingHeaderGenerator = (,) <$> interestingHeaderName <*> nonEmptyByteString
+
+interestingAwsHeaderGenerator :: TTQ.Gen NHT.Header
+interestingAwsHeaderGenerator = (,) <$> interestingAwsHeaderName <*> nonEmptyByteString
+
+prop_RandomHeaders :: TTQ.Property
+prop_RandomHeaders = TTQ.forAll randomHeaderGenerator $ \randomHeader -> constructHeaderStringForSigning randomHeader == snd randomHeader 
+
+prop_InterestingHeaders :: TTQ.Property
+prop_InterestingHeaders = TTQ.forAll interestingHeaderGenerator $ \interestingHeader -> constructHeaderStringForSigning interestingHeader == snd interestingHeader 
+
+prop_InterestingAwsHeaders :: TTQ.Property
+prop_InterestingAwsHeaders = TTQ.forAll interestingAwsHeaderGenerator $ \interestingHeader -> constructHeaderStringForSigning interestingHeader == (DBC.append (DC.foldedCase $ fst interestingHeader) $ DBC.append ":" (snd interestingHeader))
+
+-- Generators / Properties for auxiliary header functions
+allHeadersGenerator :: TTQ.Gen [NHT.Header]
+allHeadersGenerator = TTQ.listOf $ TTQ.frequency[(1, interestingHeaderGenerator), (1, interestingAwsHeaderGenerator)]
+
+allIncreasing :: [NHT.Header] -> Bool
+allIncreasing xs = and $ zipWith (<=) mapped $ drop 1 mapped
+  where mapped = map (\x -> fst x) xs
+
+testHeaders :: [NHT.Header] -> Bool
+testHeaders headers = (length sortedHeaders == length sortedHeaders) && allIncreasing sortedHeaders
+  where
+    sortedHeaders = sortHeaders headers
+
+prop_SortedHeaders :: TTQ.Property
+prop_SortedHeaders = TTQ.forAll allHeadersGenerator $ \allHeaders -> testHeaders allHeaders
+
+
+tests :: TT.TestTree
+tests = TT.testGroup "v2Header.BaseSpec"
+
+  [ TT.testGroup "constructQueryStringForSigning"
+
+    [ TTQ.testProperty "should always convert set QValues to Nothing" prop_QValueEmpty
+    , testCase "should keep an unset QValue" $ constructQueryStringForSigning (NADQ.QValue (Nothing :: Maybe(DBC.ByteString))) @?= (NADQ.QValue (Nothing :: Maybe(DBC.ByteString)))
+    , TTQ.testProperty "should discard QPairs that are not interesting to AWS" prop_UninterestingQPairs
+    , TTQ.testProperty "should keep all QPairs that are interesting to AWS" prop_InterestingQPairs
+    , testCase "should keep an empty QList" $ constructQueryStringForSigning (NADQ.QList []) @?= (NADQ.QList [])
+    , testCase "should keep a list of Nothing QValues" $ constructQueryStringForSigning (NADQ.QList [(NADQ.QValue Nothing)]) @?= (NADQ.QList [(NADQ.QValue Nothing)])
+    , TTQ.testProperty "should discard the contents of an unintersting QList" prop_UninterestingQLists
+    , TTQ.testProperty "should not discard all elements in interesting QLists" prop_InterestingQLists
+    ]
+    
+  , TT.testGroup "constructHeaderStringForSigning"
+    [ TTQ.testProperty "should convert random headers to their header value" prop_RandomHeaders
+    , TTQ.testProperty "should convert interesting headers to their header value" prop_InterestingHeaders
+    , TTQ.testProperty "should convert aws headers to a canonical string" prop_InterestingAwsHeaders 
+    ]
+
+  , TT.testGroup "auxiliary headers functions"
+    [ TTQ.testProperty "should sort and preserve headers" prop_SortedHeaders
+    , testCase "should contain empty md5 and empty content type headers if not present" $ [(NHT.hContentMD5, ""), (NHT.hContentType, "")] `subset` (unionNecessaryHeaders []) @?= True
+    , testCase "should preserve a set md5 and contain an empty content type header if not present" $ [(NHT.hContentMD5, "123"), (NHT.hContentType, "")] `subset` (unionNecessaryHeaders [(NHT.hContentMD5, "123")]) @?= True
+    , testCase "should preserve a set content type and preserve an empty md5 header if not present" $ [(NHT.hContentType, "123"), (NHT.hContentMD5, "")] `subset` (unionNecessaryHeaders [(NHT.hContentType, "123")]) @?= True
+    , testCase "should preserve md5 and content type headers if set" $ [(NHT.hContentType, "123"), (NHT.hContentMD5, "456")] `subset` unionNecessaryHeaders [(NHT.hContentType, "123"), (NHT.hContentMD5, "456")] @?= True
+    ]
+
+  , TT.testGroup "toSingerQBS"
+    [ testCase "should convert an empty query string" $ toSignerQBS (NADQ.QValue Nothing) @?= ""
+    , testCase "should convert an empty value of QPair to just the key" $ toSignerQBS (NADQ.QPair "key" (NADQ.QValue Nothing)) @?= "key"
+    , testCase "should convert an empty value of QPair followed by QValue to just the key and just the value" $ toSignerQBS (NADQ.QList [(NADQ.QPair "key" (NADQ.QValue Nothing)), (NADQ.QValue $ Just "key2")]) @?= "key&key2"
+    ]
+
+  , TT.testGroup "constructFullPath"
+    [ testCase "should convert an empty queryString to just the path" $ constructFullPath "path" "" @?= "path"
+    , testCase "should convert an empty value of QPair and a path to just the path and the key" $ constructFullPath "path" (toSignerQBS (NADQ.QPair "key" (NADQ.QValue Nothing))) @?= "path?key"
+    ]
+
+  , TT.testGroup "should construct canonical headers"
+    [ testCase "should construct a canonical header from a base string" $ constructHeaderSigner [] "GET" "\\" "" @?= "GET\n\n\n\\"
+    ]
+
+  ]


### PR DESCRIPTION
#382 - Implementation of V2 header signer given specifications outlined in issue and closely aligned with boto.
Note: 
- Expiry header is not honored.
- Temporary security token is not honored.