### PR TITLE
Update reference to fast-logger

### DIFF
--- a/amazonka/src/Network/AWS/Internal/Logger.hs
+++ b/amazonka/src/Network/AWS/Internal/Logger.hs
@@ -39,7 +39,7 @@ import           System.IO
 --
 -- /Note:/ A more sophisticated logging library such as
 -- <http://hackage.haskell.org/package/tinylog tinylog> or
--- <http://hackage.haskell.org/package/FastLogger fast-logger>
+-- <http://hackage.haskell.org/package/fast-logger fast-logger>
 -- should be used in production code.
 newLogger :: MonadIO m => LogLevel -> Handle -> m Logger
 newLogger x hd = liftIO $ do


### PR DESCRIPTION
http://hackage.haskell.org/package/fast-logger is the correct package name for 
`System.Log.FastLogger`, not `FastLogger`.