### PR TITLE
Override DynamoDB Query/Scan Pagination

### DIFF
--- a/amazonka-dynamodb/gen/Network/AWS/DynamoDB/Query.hs
+++ b/amazonka-dynamodb/gen/Network/AWS/DynamoDB/Query.hs
@@ -232,9 +232,6 @@ qTableName = lens _qTableName (\ s a -> s{_qTableName = a});
 instance AWSPager Query where
         page rq rs
           | stop (rs ^. qrsLastEvaluatedKey) = Nothing
-          | stop (rs ^. qrsItems) = Nothing
-          | stop (rs ^. qrsCount) = Nothing
-          | stop (rs ^. qrsScannedCount) = Nothing
           | otherwise =
             Just $ rq &
               qExclusiveStartKey .~ rs ^. qrsLastEvaluatedKey

--- a/amazonka-dynamodb/gen/Network/AWS/DynamoDB/Scan.hs
+++ b/amazonka-dynamodb/gen/Network/AWS/DynamoDB/Scan.hs
@@ -221,9 +221,6 @@ sTableName = lens _sTableName (\ s a -> s{_sTableName = a});
 instance AWSPager Scan where
         page rq rs
           | stop (rs ^. srsLastEvaluatedKey) = Nothing
-          | stop (rs ^. srsItems) = Nothing
-          | stop (rs ^. srsCount) = Nothing
-          | stop (rs ^. srsScannedCount) = Nothing
           | otherwise =
             Just $ rq &
               sExclusiveStartKey .~ rs ^. srsLastEvaluatedKey

--- a/gen/annex/dynamodb.json
+++ b/gen/annex/dynamodb.json
@@ -1,0 +1,13 @@
+{
+    "metadata": {
+        "serviceAbbreviation": "DynamoDB"
+    },
+    "pagination": {
+        "Query": {
+            "result_key": []
+        },
+        "Scan": {
+            "result_key": []
+        }
+    }
+}


### PR DESCRIPTION
This fixes the issue where `Items`, `Count`, and `Scanned` were considered for halting the next pagination step.

Fixes #340, closes #373.