### PR TITLE
Make find command compatible with GNU and BSD find

### DIFF
--- a/gen/Makefile
+++ b/gen/Makefile
@@ -36,12 +36,11 @@ gen: $(MODEL_DIR) $(GENERATE)
 format: $(STYLISH)
 	@echo -e '\nFormatting...'
 	@find \
- $(wildcard $(OUT_DIR)/amazonka-*/gen) \
- $(wildcard $(OUT_DIR)/amazonka-*/test/Test/AWS/Gen) \
- -type f \
- -name '*.hs' \
- -printf ' -> %p\n' \
- -exec $(STYLISH) -i {} \;
+	$(wildcard $(OUT_DIR)/amazonka-*/gen) \
+ 	$(wildcard $(OUT_DIR)/amazonka-*/test/Test/AWS/Gen) \
+	-type f \
+	-name '*.hs' \
+	-exec sh -c "printf ' -> %s\n\' $1 {}; $(STYLISH) -i {}" \;
 
 $(GENERATE): $(BIN_DIR)
 	stack install amazonka-gen


### PR DESCRIPTION
This change uses the more compatible (hopefully) `-exec` option so that you can run this makefile on either Linux or OSX (possibly BSD though I don't have a machine for that available right now)

