### PR TITLE
Add CPP for backwards compatible http-client + http-conduit

### DIFF
--- a/amazonka/amazonka.cabal
+++ b/amazonka/amazonka.cabal
@@ -67,7 +67,8 @@ library
         , conduit-extra       >= 1.1
         , directory           >= 1.2
         , exceptions          >= 0.6
-        , http-conduit        >= 2.2 && < 3
+        , http-client         >= 0.4 && < 0.6
+        , http-conduit        >= 2.1.4 && < 3
         , ini                 >= 0.3.5
         , mmorph              >= 1
         , monad-control       >= 1

--- a/amazonka/src/Network/AWS/Auth.hs
+++ b/amazonka/src/Network/AWS/Auth.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE LambdaCase         #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE TupleSections      #-}
+{-# LANGUAGE CPP      #-}
 
 -- |
 -- Module      : Network.AWS.Auth
@@ -566,7 +567,11 @@ fromContainer m = do
         p  <- maybe (throwM . MissingEnvError $ "Unable to read ENV variable: " <> envContainerCredentialsURI)
                     return
                     mp
+#if MIN_VERSION_http_client(0,4,30)
         parseUrlThrow $ "http://169.254.170.2" <> p
+#else
+        parseUrl $ "http://169.254.170.2" <> p
+#endif
 
     renew :: HTTP.Request -> IO AuthEnv
     renew req = do

--- a/core/amazonka-core.cabal
+++ b/core/amazonka-core.cabal
@@ -90,7 +90,8 @@ library
         , deepseq              >= 1.4
         , exceptions           >= 0.6
         , hashable             >= 1.2
-        , http-conduit         >= 2.2 && < 3
+        , http-client          >= 0.4 && < 0.6
+        , http-conduit         >= 2.1.4 && < 3
         , http-types           >= 0.8
         , lens                 >= 4.4
         , memory               >= 0.6

--- a/core/src/Network/AWS/Data/Log.hs
+++ b/core/src/Network/AWS/Data/Log.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE CPP               #-}
 
 {-# OPTIONS_GHC -fsimpl-tick-factor=110 #-}
 
@@ -120,8 +121,11 @@ instance ToLog RequestBody where
 instance ToLog HttpException where
     build x = "[HttpException] {\n" <> build (show x) <> "\n}"
 
+#if MIN_VERSION_http_client(0,5,0)
 instance ToLog HttpExceptionContent where
     build x = "[HttpExceptionContent] {\n" <> build (show x) <> "\n}"
+#endif
+
 
 instance ToLog Request where
     build x = buildLines
@@ -130,7 +134,11 @@ instance ToLog Request where
         ,  "  secure    = " <> build (secure x)
         ,  "  method    = " <> build (method x)
         ,  "  target    = " <> build target
+#if MIN_VERSION_http_client(0,5,0)
         ,  "  timeout   = " <> build (show (responseTimeout x))
+#else
+        ,  "  timeout   = " <> build (responseTimeout x)
+#endif
         ,  "  redirects = " <> build (redirectCount x)
         ,  "  path      = " <> build (path            x)
         ,  "  query     = " <> build (queryString     x)

--- a/core/src/Network/AWS/Error.hs
+++ b/core/src/Network/AWS/Error.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns      #-}
+{-# LANGUAGE CPP               #-}
 
 -- |
 -- Module      : Network.AWS.Error
@@ -63,10 +64,14 @@ httpStatus :: AsError a => Getting (First Status) a Status
 httpStatus = _Error . f
   where
     f g = \case
+#if MIN_VERSION_http_client(0,5,0)
         TransportError (HttpExceptionRequest rq (StatusCodeException rs b))
             -> (\x -> TransportError (HttpExceptionRequest rq (StatusCodeException (rs { responseStatus = x }) b)))
                <$> g (responseStatus rs)
-
+#else
+        TransportError (StatusCodeException s h c)
+            -> TransportError <$> (StatusCodeException <$> g s <*> pure h <*> pure c)
+#endif
         TransportError e
             -> pure (TransportError e)
 

--- a/core/src/Network/AWS/Types.hs
+++ b/core/src/Network/AWS/Types.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE CPP                        #-}
 
 -- |
 -- Module      : Network.AWS.Types
@@ -167,6 +168,10 @@ import Network.HTTP.Types.Status   (Status)
 
 import qualified Data.Text            as Text
 import qualified Network.HTTP.Conduit as Client
+
+#if ! MIN_VERSION_http_client(0,4,30)
+import           Text.XML                     (def)
+#endif
 
 -- | A convenience alias to avoid type ambiguity.
 type ClientRequest = Client.Request
@@ -451,15 +456,24 @@ serviceRetry = lens _svcRetry (\s a -> s { _svcRetry = a })
 -- | Construct a 'ClientRequest' using common parameters such as TLS and prevent
 -- throwing errors when receiving erroneous status codes in respones.
 clientRequest :: Endpoint -> Maybe Seconds -> ClientRequest
-clientRequest e t = Client.defaultRequest
+clientRequest e t =
+#if MIN_VERSION_http_client(0,4,30)
+  Client.defaultRequest
+#else
+  def
+#endif
     { Client.secure          = _endpointSecure e
     , Client.host            = _endpointHost   e
     , Client.port            = _endpointPort   e
     , Client.redirectCount   = 0
     , Client.responseTimeout =
+#if MIN_VERSION_http_client(0,5,0)
         case t of
             Nothing -> Client.responseTimeoutNone
             Just x  -> Client.responseTimeoutMicro (microseconds x)
+#else
+        microseconds <$> t
+#endif
     }
 
 -- | An unsigned request.


### PR DESCRIPTION
Have tested with

- http-client 0.4.18.1
- http-client 0.4.31.1
- http-client 0.5.7.1

on `amazonka` and `amazonka-core`

Updates based on https://github.com/brendanhay/amazonka/commit/0656b5a12001a1d32cca65cf69f6327d3fcef858