### PR TITLE
Switch to non-deprecated function from http-conduit

### DIFF
--- a/amazonka/amazonka.cabal
+++ b/amazonka/amazonka.cabal
@@ -68,7 +68,7 @@ library
         , directory           >= 1.2
         , exceptions          >= 0.6
         , http-client         >= 0.4 && < 0.6
-        , http-conduit        >= 2.1.4 && < 3
+        , http-conduit        >= 2.1.7 && < 3
         , http-types          >= 0.8
         , ini                 >= 0.3.5
         , mmorph              >= 1

--- a/amazonka/src/Network/AWS/Env.hs
+++ b/amazonka/src/Network/AWS/Env.hs
@@ -193,7 +193,7 @@ newEnv :: (Applicative m, MonadIO m, MonadCatch m)
        => Credentials -- ^ Credential discovery mechanism.
        -> m Env
 newEnv c =
-    liftIO (newManager conduitManagerSettings)
+    liftIO (newManager tlsManagerSettings)
         >>= newEnvWith c Nothing
 
 -- | /See:/ 'newEnv'


### PR DESCRIPTION
http-conduit 2.3.0 (Released Jan 16, 2018) removed the deprecated function `conduitManagerSettings`. 

Instead we should use `tlsManagerSettings` (which was introduced in http-conduit 2.1.7, released Jul 21, 2015).