### PR TITLE
Strip 'Expect' header when presigning URLs

### DIFF
--- a/amazonka/amazonka.cabal
+++ b/amazonka/amazonka.cabal
@@ -69,6 +69,7 @@ library
         , exceptions          >= 0.6
         , http-client         >= 0.4 && < 0.6
         , http-conduit        >= 2.1.4 && < 3
+        , http-types          >= 0.8
         , ini                 >= 0.3.5
         , mmorph              >= 1
         , monad-control       >= 1

--- a/amazonka/src/Network/AWS/Presign.hs
+++ b/amazonka/src/Network/AWS/Presign.hs
@@ -18,10 +18,12 @@ module Network.AWS.Presign where
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Network.AWS.Data.Time
-import           Network.AWS.Lens       ((%~), (&))
+import           Network.AWS.Lens         ((%~), (&))
 import           Network.AWS.Prelude
-import           Network.AWS.Request    (requestURL)
+import           Network.AWS.Request      (requestURL)
 import           Network.AWS.Types
+import           Network.AWS.Data.Headers (hExpect)
+import           Network.HTTP.Types       (Header)
 
 -- | Presign an URL that is valid from the specified time until the
 -- number of seconds expiry has elapsed.
@@ -39,7 +41,7 @@ presignURL a r e ts = liftM requestURL . presign a r e ts
 -- | Presign an HTTP request that is valid from the specified time until the
 -- number of seconds expiry has elapsed.
 --
--- /See:/ 'presignWith'
+-- /See:/ 'presignWith', 'presignWithHeaders'
 presign :: (MonadIO m, AWSRequest a)
         => Auth
         -> Region
@@ -51,6 +53,8 @@ presign = presignWith id
 
 -- | A variant of 'presign' that allows modifying the default 'Service'
 -- definition used to configure the request.
+--
+-- /See:/ 'presignWithHeaders'
 presignWith :: (MonadIO m, AWSRequest a)
             => (Service -> Service) -- ^ Modify the default service configuration.
             -> Auth
@@ -59,7 +63,25 @@ presignWith :: (MonadIO m, AWSRequest a)
             -> Seconds              -- ^ Expiry time.
             -> a                    -- ^ Request to presign.
             -> m ClientRequest
-presignWith f a r ts ex x =
+presignWith = presignWithHeaders defaultHeaders
+
+-- | Modification to the headers that is applied by default (in 'presignWith');
+-- removes the "Expect" header which is added to every 'PutObject'.
+defaultHeaders :: [Header] -> [Header]
+defaultHeaders = filter ((/= hExpect) . fst)
+
+-- | A variant of 'presign' that allows modifying the default 'Headers'
+-- and the default 'Service' definition used to configure the request.
+presignWithHeaders :: (MonadIO m, AWSRequest a)
+            => ([Header] -> [Header]) -- ^ Modify the default headers.
+            -> (Service -> Service) -- ^ Modify the default service configuration.
+            -> Auth
+            -> Region
+            -> UTCTime              -- ^ Signing time.
+            -> Seconds              -- ^ Expiry time.
+            -> a                    -- ^ Request to presign.
+            -> m ClientRequest
+presignWithHeaders f g a r ts ex x =
     withAuth a $ \ae ->
         return $! sgRequest $
-            rqPresign ex (request x & rqService %~ f) ae r ts
+            rqPresign ex (request x & rqHeaders %~ f & rqService %~ g) ae r ts


### PR DESCRIPTION
Fixes #363.

This is more or less the _simplest_ thing that can be done to make
pre-signed PUT urls work, and it exposes the header transformation
at the lowest level, so that it's possible to build some other
behavior on top of that. However, this is neither as targeted nor
as flexible as the solutions proposed in the issue.

This is the approach from the workaround I posted on that issue, but simpler because I didn't thread the transformation of headers all the way up through the layers. I'm submitting this for feedback; happy to rework this branch to make this more robust, flexible, or whatever.

I've tested it by running the following:

```haskell
main = do
  now <- getCurrentTime
  let expireSeconds = 300
  env <- newEnv Discover
  urlBytes <- runResourceT $ runAWS env $ presignURL now expireSeconds $
    putObject testBucket testKey ""
  putStrLn $ unpack $ decodeUtf8 urlBytes
```

```bash
curl -X PUT "https://s3.amazonaws.com/..." -d "foo"
```

