### PR TITLE
Add conduit < 1.3 bound

### DIFF
--- a/core/amazonka-core.cabal
+++ b/core/amazonka-core.cabal
@@ -84,7 +84,7 @@ library
         , bifunctors           >= 4.1
         , bytestring           >= 0.9
         , case-insensitive     >= 1.2
-        , conduit              >= 1.1
+        , conduit              >= 1.1 && < 1.3
         , conduit-extra        >= 1.1
         , cryptonite           >= 0.4
         , deepseq              >= 1.4


### PR DESCRIPTION
https://hackage.haskell.org/package/conduit-1.3.0/changelog says:
- Replace the Resumable types with SealedConduitT

```
src/Network/AWS/Data/Body.hs:51:22: error:
    Not in scope: type constructor or class ‘ResumableSource’
   |
51 |     { _streamBody :: ResumableSource (ResourceT IO) ByteString
   |
```

I made revisions to: 1.4.5 .. 1.5.0 and 1.0.0 .. 1.3.1 versions.
Versions in between (1.3.2 .. 1.4.3) don't seem to be able to pickup
conduit-1.3.  Also versions before 1.0.0 don't have don't have install
plans with conduit-1.3 (which is base > 4.9 / GHC > 8.0)