### PR TITLE
Fix #449 - Conduit-1.3 support

### DIFF
--- a/amazonka-elasticbeanstalk/test/Test/AWS/ElasticBeanstalk.hs
+++ b/amazonka-elasticbeanstalk/test/Test/AWS/ElasticBeanstalk.hs
@@ -15,8 +15,6 @@ module Test.AWS.ElasticBeanstalk
     , fixtures
     ) where
 
-import           Network.AWS.ElasticBeanstalk
-import           Test.AWS.Gen.ElasticBeanstalk
 import           Test.Tasty
 
 tests :: [TestTree]

--- a/amazonka-s3-encryption/amazonka-s3-encryption.cabal
+++ b/amazonka-s3-encryption/amazonka-s3-encryption.cabal
@@ -66,7 +66,7 @@ library
         , base                 >= 4.7     && < 5
         , bytestring           >= 0.9
         , case-insensitive     >= 1.2
-        , conduit-combinators  >= 0.3
+        , conduit              >= 0.3
         , cryptonite           >= 0.7
         , exceptions           >= 0.6
         , lens                 >= 4.4

--- a/amazonka-s3-encryption/src/Network/AWS/S3/Encryption/Body.hs
+++ b/amazonka-s3-encryption/src/Network/AWS/S3/Encryption/Body.hs
@@ -36,13 +36,13 @@ instance ToChunkedBody RqBody where
 
 enforceChunks :: Integral a
               => a
-              -> Source (ResourceT IO) ByteString
+              -> ConduitM () ByteString (ResourceT IO) ()
               -> ChunkedBody
 enforceChunks sz =
     ChunkedBody defaultChunkSize (fromIntegral sz) . flip fuse go
   where
     go = awaitForever (\i -> leftover i >> sinkLazy >>= yield)
-      =$= takeCE n
-      =$= mapC LBS.toStrict
+      .| takeCE n
+      .| mapC LBS.toStrict
 
     n = fromIntegral defaultChunkSize

--- a/amazonka-s3-encryption/src/Network/AWS/S3/Encryption/Decrypt.hs
+++ b/amazonka-s3-encryption/src/Network/AWS/S3/Encryption/Decrypt.hs
@@ -13,7 +13,7 @@
 --
 module Network.AWS.S3.Encryption.Decrypt where
 
-import           Control.Lens                           hiding (coerce)
+import           Control.Lens (view, (^.), (&), (%~))
 import           Control.Monad.Trans.AWS
 import           Data.Coerce
 import           Data.Proxy

--- a/amazonka-s3-encryption/src/Network/AWS/S3/Encryption/Encrypt.hs
+++ b/amazonka-s3-encryption/src/Network/AWS/S3/Encryption/Encrypt.hs
@@ -14,7 +14,7 @@
 --
 module Network.AWS.S3.Encryption.Encrypt where
 
-import           Control.Lens                           hiding (coerce)
+import           Control.Lens (Setter', lens, view, (&), (%~), (<>~), (^.), to)
 import           Control.Monad
 import           Control.Monad.Trans.AWS
 import           Data.Coerce

--- a/amazonka-s3-encryption/src/Network/AWS/S3/Encryption/Envelope.hs
+++ b/amazonka-s3-encryption/src/Network/AWS/S3/Encryption/Envelope.hs
@@ -59,7 +59,7 @@ newV1 f d = liftIO $ do
         , _v1Description = d
         }
 
-decodeV1 :: MonadResource m
+decodeV1 :: (MonadResource m, MonadThrow m)
          => [(CI Text, Text)]
          -> (ByteString -> IO ByteString)
          -> m Envelope
@@ -94,7 +94,7 @@ data V2Envelope = V2Envelope
       -- description, @x-amz-matdesc, under the key-name @kms_cmk_id@.
     }
 
-newV2 :: MonadResource m => Text -> Description -> Env -> m Envelope
+newV2 :: (MonadResource m, MonadThrow m) => Text -> Description -> Env -> m Envelope
 newV2 kid d e = do
     let ctx = Map.insert "kms_cmk_id" kid (fromDescription d)
     rs <- runAWS e . send $
@@ -113,7 +113,7 @@ newV2 kid d e = do
         , _v2Description   = Description ctx
         }
 
-decodeV2 :: MonadResource m
+decodeV2 :: (MonadResource m, MonadThrow m)
          => [(CI Text, Text)]
          -> Description
          -> Env
@@ -175,14 +175,14 @@ toMetadata = \case
     b64 :: ByteString -> ByteString
     b64 = toBS . Base64
 
-newEnvelope :: MonadResource m => Key -> Env -> m Envelope
+newEnvelope :: (MonadResource m, MonadThrow m) => Key -> Env -> m Envelope
 newEnvelope k e =
     case k of
         Symmetric  c   d -> newV1 (return . ecbEncrypt c) d
         Asymmetric p   d -> newV1 (rsaEncrypt p) d
         KMS        kid d -> newV2 kid d e
 
-decodeEnvelope :: MonadResource m
+decodeEnvelope :: (MonadResource m, MonadThrow m)
                => Key
                -> Env
                -> [(CI Text, Text)]
@@ -193,7 +193,7 @@ decodeEnvelope k e xs =
         Asymmetric p _ -> decodeV1 xs (rsaDecrypt p)
         KMS        _ d -> decodeV2 xs d e
 
-fromMetadata :: MonadResource m => Key -> Env -> HashMap Text Text -> m Envelope
+fromMetadata :: (MonadResource m, MonadThrow m) => Key -> Env -> HashMap Text Text -> m Envelope
 fromMetadata key e = decodeEnvelope key e . map (first CI.mk) . Map.toList
 
 aesKeySize, aesBlockSize :: Int

--- a/amazonka-s3-encryption/src/Network/AWS/S3/Encryption/Instructions.hs
+++ b/amazonka-s3-encryption/src/Network/AWS/S3/Encryption/Instructions.hs
@@ -15,7 +15,7 @@
 module Network.AWS.S3.Encryption.Instructions where
 
 import           Control.Arrow
-import           Control.Lens                       hiding (coerce)
+import           Control.Lens (Lens', lens, view, (&), (%~))
 import           Control.Monad.Trans.AWS
 import           Data.Aeson.Types                   (parseEither)
 import           Data.Coerce

--- a/amazonka/amazonka.cabal
+++ b/amazonka/amazonka.cabal
@@ -81,6 +81,7 @@ library
         , transformers        >= 0.2
         , transformers-base   >= 0.4
         , transformers-compat >= 0.3
+        , void                >= 0.1
 
 test-suite tests
     type:              exitcode-stdio-1.0

--- a/amazonka/src/Control/Monad/Trans/AWS.hs
+++ b/amazonka/src/Control/Monad/Trans/AWS.hs
@@ -282,7 +282,7 @@ send = retrier >=> fmap snd . hoistError
 -- Throws 'Error'.
 paginate :: (AWSConstraint r m, AWSPager a)
          => a
-         -> ConduitT () (Rs a) m ()
+         -> ConduitM () (Rs a) m ()
 paginate = go
   where
     go !x = do

--- a/amazonka/src/Control/Monad/Trans/AWS.hs
+++ b/amazonka/src/Control/Monad/Trans/AWS.hs
@@ -262,7 +262,7 @@ runAWST r (AWST' m) = runReaderT m r
 -- | An alias for the constraints required to send requests,
 -- which 'AWST' implicitly fulfils.
 type AWSConstraint r m =
-    ( MonadCatch     m
+    ( MonadThrow     m
     , MonadResource  m
     , MonadReader  r m
     , HasEnv       r
@@ -282,7 +282,7 @@ send = retrier >=> fmap snd . hoistError
 -- Throws 'Error'.
 paginate :: (AWSConstraint r m, AWSPager a)
          => a
-         -> Source m (Rs a)
+         -> ConduitT () (Rs a) m ()
 paginate = go
   where
     go !x = do

--- a/amazonka/src/Network/AWS.hs
+++ b/amazonka/src/Network/AWS.hs
@@ -165,7 +165,7 @@ import Control.Monad.Trans.Maybe    (MaybeT)
 import Control.Monad.Trans.Reader   (ReaderT)
 import Control.Monad.Trans.Resource
 
-import Data.Conduit (ConduitT, transPipe)
+import Data.Conduit (ConduitM, transPipe)
 
 import Network.AWS.Auth
 import Network.AWS.Env             (Env, HasEnv (..), newEnv)
@@ -262,7 +262,7 @@ send = liftAWS . AWST.send
 
 -- | Repeatedly send a request, automatically setting markers and
 -- paginating over multiple responses while available.
-paginate :: (MonadAWS m, AWSPager a) => a -> ConduitT () (Rs a) m ()
+paginate :: (MonadAWS m, AWSPager a) => a -> ConduitM () (Rs a) m ()
 paginate x = transPipe liftAWS $ AWST.paginate x
 
 -- | Poll the API with the supplied request until a specific 'Wait' condition

--- a/amazonka/src/Network/AWS.hs
+++ b/amazonka/src/Network/AWS.hs
@@ -154,10 +154,8 @@ module Network.AWS
     , RsBody
     ) where
 
-import Control.Applicative
 import Control.Monad.Catch          (MonadCatch)
 import Control.Monad.IO.Class       (MonadIO)
-import Control.Monad.Morph          (hoist)
 import Control.Monad.Trans.AWS      (AWST)
 import Control.Monad.Trans.Class    (lift)
 import Control.Monad.Trans.Except   (ExceptT)
@@ -167,8 +165,7 @@ import Control.Monad.Trans.Maybe    (MaybeT)
 import Control.Monad.Trans.Reader   (ReaderT)
 import Control.Monad.Trans.Resource
 
-import Data.Conduit (Source)
-import Data.Monoid
+import Data.Conduit (ConduitT, transPipe)
 
 import Network.AWS.Auth
 import Network.AWS.Env             (Env, HasEnv (..), newEnv)
@@ -265,8 +262,8 @@ send = liftAWS . AWST.send
 
 -- | Repeatedly send a request, automatically setting markers and
 -- paginating over multiple responses while available.
-paginate :: (MonadAWS m, AWSPager a) => a -> Source m (Rs a)
-paginate = hoist liftAWS . AWST.paginate
+paginate :: (MonadAWS m, AWSPager a) => a -> ConduitT () (Rs a) m ()
+paginate x = transPipe liftAWS $ AWST.paginate x
 
 -- | Poll the API with the supplied request until a specific 'Wait' condition
 -- is fulfilled.

--- a/amazonka/src/Network/AWS/Auth.hs
+++ b/amazonka/src/Network/AWS/Auth.hs
@@ -393,7 +393,7 @@ fromEnvKeys :: (Applicative m, MonadIO m, MonadThrow m)
             -> Maybe Text -- ^ Session token environment variable.
             -> Maybe Text -- ^ Region environment variable.
             -> m (Auth, Maybe Region)
-fromEnvKeys access secret session region =
+fromEnvKeys access secret session region' =
     (,) <$> fmap Auth lookupKeys <*> lookupRegion
   where
     lookupKeys = AuthEnv
@@ -404,8 +404,8 @@ fromEnvKeys access secret session region =
 
     lookupRegion :: (MonadIO m, MonadThrow m) => m (Maybe Region)
     lookupRegion = runMaybeT $ do
-        k <- MaybeT (return region)
-        r <- MaybeT (opt region)
+        k <- MaybeT (return region')
+        r <- MaybeT (opt region')
         case fromText (Text.pack r) of
             Right x -> return x
             Left  e -> throwM . InvalidEnvError $

--- a/amazonka/src/Network/AWS/Env.hs
+++ b/amazonka/src/Network/AWS/Env.hs
@@ -39,7 +39,6 @@ module Network.AWS.Env
     , retryConnectionFailure
     ) where
 
--- import Control.Applicative
 import Control.Monad.Catch
 import Control.Monad.IO.Class
 import Control.Monad.Reader

--- a/amazonka/src/Network/AWS/Env.hs
+++ b/amazonka/src/Network/AWS/Env.hs
@@ -39,7 +39,7 @@ module Network.AWS.Env
     , retryConnectionFailure
     ) where
 
-import Control.Applicative
+-- import Control.Applicative
 import Control.Monad.Catch
 import Control.Monad.IO.Class
 import Control.Monad.Reader
@@ -193,7 +193,7 @@ newEnv :: (Applicative m, MonadIO m, MonadCatch m)
        => Credentials -- ^ Credential discovery mechanism.
        -> m Env
 newEnv c =
-    liftIO (newManager conduitManagerSettings)
+    liftIO (newManager tlsManagerSettings)
         >>= newEnvWith c Nothing
 
 -- | /See:/ 'newEnv'

--- a/amazonka/src/Network/AWS/Internal/Body.hs
+++ b/amazonka/src/Network/AWS/Internal/Body.hs
@@ -19,6 +19,7 @@ import           Data.Conduit
 import qualified Data.Conduit.Binary          as Conduit
 import           Network.AWS.Prelude
 import           System.IO
+import           Data.Void (Void) -- required for < conduit-1.3
 
 -- | Convenience function for obtaining the size of a file.
 getFileSize :: MonadIO m => FilePath -> m Integer

--- a/amazonka/src/Network/AWS/Internal/Body.hs
+++ b/amazonka/src/Network/AWS/Internal/Body.hs
@@ -26,8 +26,8 @@ getFileSize :: MonadIO m => FilePath -> m Integer
 getFileSize path = liftIO (withBinaryFile path ReadMode hFileSize)
 
 -- | Connect a 'Sink' to a response stream.
-sinkBody :: RsBody -> ConduitM ByteString Void (ResourceT IO) r -> IO r
-sinkBody (RsBody body) sink = runConduitRes $ body .| sink
+sinkBody :: MonadIO m => RsBody -> ConduitM ByteString Void (ResourceT IO) a -> m a
+sinkBody (RsBody body) sink = liftIO $ runConduitRes $ body .| sink
 
 -- | Construct a 'HashedBody' from a 'FilePath', calculating the 'SHA256' hash
 -- and file size.

--- a/core/src/Network/AWS/Data/Body.hs
+++ b/core/src/Network/AWS/Data/Body.hs
@@ -48,16 +48,16 @@ default (Builder)
 
 -- | A streaming, exception safe response body.
 newtype RsBody = RsBody
-    { _streamBody :: ResumableSource (ResourceT IO) ByteString
+    { _streamBody :: ConduitT () ByteString (ResourceT IO) ()
     } -- newtype for show/orhpan instance purposes.
 
 instance Show RsBody where
-    show = const "RsBody { ResumableSource (ResourceT IO) ByteString }"
+    show = const "RsBody { ConduitT () ByteString (ResourceT IO) () }"
 
 fuseStream :: RsBody
            -> Conduit ByteString (ResourceT IO) ByteString
            -> RsBody
-fuseStream b f = b { _streamBody = _streamBody b $=+ f }
+fuseStream b f = b { _streamBody = _streamBody b .| f }
 
 -- | Specifies the transmitted size of the 'Transfer-Encoding' chunks.
 --

--- a/core/src/Network/AWS/Data/Body.hs
+++ b/core/src/Network/AWS/Data/Body.hs
@@ -48,14 +48,14 @@ default (Builder)
 
 -- | A streaming, exception safe response body.
 newtype RsBody = RsBody
-    { _streamBody :: ConduitT () ByteString (ResourceT IO) ()
+    { _streamBody :: ConduitM () ByteString (ResourceT IO) ()
     } -- newtype for show/orhpan instance purposes.
 
 instance Show RsBody where
-    show = const "RsBody { ConduitT () ByteString (ResourceT IO) () }"
+    show = const "RsBody { ConduitM () ByteString (ResourceT IO) () }"
 
 fuseStream :: RsBody
-           -> ConduitT ByteString ByteString (ResourceT IO) ()
+           -> ConduitM ByteString ByteString (ResourceT IO) ()
            -> RsBody
 fuseStream b f = b { _streamBody = _streamBody b .| f }
 
@@ -84,7 +84,7 @@ defaultChunkSize = 128 * 1024
 data ChunkedBody = ChunkedBody
     { _chunkedSize   :: !ChunkSize
     , _chunkedLength :: !Integer
-    , _chunkedBody   :: ConduitT () ByteString (ResourceT IO) ()
+    , _chunkedBody   :: ConduitM () ByteString (ResourceT IO) ()
     }
 
 chunkedLength :: Lens' ChunkedBody Integer
@@ -106,7 +106,7 @@ instance Show ChunkedBody where
         <> "}"
 
 fuseChunks :: ChunkedBody
-           -> ConduitT ByteString ByteString (ResourceT IO) ()
+           -> ConduitM ByteString ByteString (ResourceT IO) ()
            -> ChunkedBody
 fuseChunks c f = c { _chunkedBody = _chunkedBody c .| f }
 
@@ -121,7 +121,7 @@ remainderBytes c =
 
 -- | An opaque request body containing a 'SHA256' hash.
 data HashedBody
-    = HashedStream (Digest SHA256) !Integer (ConduitT () ByteString (ResourceT IO) ())
+    = HashedStream (Digest SHA256) !Integer (ConduitM () ByteString (ResourceT IO) ())
     | HashedBytes  (Digest SHA256) ByteString
 
 instance Show HashedBody where

--- a/core/src/Network/AWS/Data/List1.hs
+++ b/core/src/Network/AWS/Data/List1.hs
@@ -15,7 +15,6 @@
 --
 module Network.AWS.Data.List1 where
 
--- import           Control.Applicative
 import           Control.DeepSeq
 import           Control.Monad
 import           Data.Aeson

--- a/core/src/Network/AWS/Data/List1.hs
+++ b/core/src/Network/AWS/Data/List1.hs
@@ -15,7 +15,7 @@
 --
 module Network.AWS.Data.List1 where
 
-import           Control.Applicative
+-- import           Control.Applicative
 import           Control.DeepSeq
 import           Control.Monad
 import           Data.Aeson

--- a/core/src/Network/AWS/Data/Map.hs
+++ b/core/src/Network/AWS/Data/Map.hs
@@ -23,7 +23,6 @@ module Network.AWS.Data.Map
     , toQueryMap
     ) where
 
--- import           Control.Applicative
 import           Control.DeepSeq
 import           Data.Aeson
 import           Data.Bifunctor
@@ -31,14 +30,12 @@ import qualified Data.ByteString             as BS
 import qualified Data.CaseInsensitive        as CI
 import           Data.Coerce
 import           Data.Data                   (Data, Typeable)
--- import           Data.Foldable               hiding (toList)
 import           Data.Hashable
 import           Data.HashMap.Strict         (HashMap)
 import qualified Data.HashMap.Strict         as Map
 import           Data.Maybe
 import           Data.Semigroup
 import qualified Data.Text.Encoding          as Text
--- import           Data.Traversable
 import           GHC.Exts
 import           GHC.Generics                (Generic)
 import           Network.AWS.Data.ByteString

--- a/core/src/Network/AWS/Data/Map.hs
+++ b/core/src/Network/AWS/Data/Map.hs
@@ -23,7 +23,7 @@ module Network.AWS.Data.Map
     , toQueryMap
     ) where
 
-import           Control.Applicative
+-- import           Control.Applicative
 import           Control.DeepSeq
 import           Data.Aeson
 import           Data.Bifunctor
@@ -31,14 +31,14 @@ import qualified Data.ByteString             as BS
 import qualified Data.CaseInsensitive        as CI
 import           Data.Coerce
 import           Data.Data                   (Data, Typeable)
-import           Data.Foldable               hiding (toList)
+-- import           Data.Foldable               hiding (toList)
 import           Data.Hashable
 import           Data.HashMap.Strict         (HashMap)
 import qualified Data.HashMap.Strict         as Map
 import           Data.Maybe
 import           Data.Semigroup
 import qualified Data.Text.Encoding          as Text
-import           Data.Traversable
+-- import           Data.Traversable
 import           GHC.Exts
 import           GHC.Generics                (Generic)
 import           Network.AWS.Data.ByteString

--- a/core/src/Network/AWS/Data/Numeric.hs
+++ b/core/src/Network/AWS/Data/Numeric.hs
@@ -18,7 +18,6 @@ import           Control.Monad
 import           Data.Aeson.Types
 import           Data.Data                   (Data, Typeable)
 import           Data.Hashable
--- import           Data.Monoid
 import           Data.Scientific
 import           GHC.Generics                (Generic)
 import           Network.AWS.Data.ByteString

--- a/core/src/Network/AWS/Data/Numeric.hs
+++ b/core/src/Network/AWS/Data/Numeric.hs
@@ -18,7 +18,7 @@ import           Control.Monad
 import           Data.Aeson.Types
 import           Data.Data                   (Data, Typeable)
 import           Data.Hashable
-import           Data.Monoid
+-- import           Data.Monoid
 import           Data.Scientific
 import           GHC.Generics                (Generic)
 import           Network.AWS.Data.ByteString

--- a/core/src/Network/AWS/Data/Sensitive.hs
+++ b/core/src/Network/AWS/Data/Sensitive.hs
@@ -16,7 +16,6 @@ module Network.AWS.Data.Sensitive where
 import           Control.DeepSeq
 import           Data.Data                   (Data, Typeable)
 import           Data.Hashable
--- import           Data.Monoid
 import           Data.String
 
 import           GHC.Generics                (Generic)

--- a/core/src/Network/AWS/Data/Sensitive.hs
+++ b/core/src/Network/AWS/Data/Sensitive.hs
@@ -16,7 +16,7 @@ module Network.AWS.Data.Sensitive where
 import           Control.DeepSeq
 import           Data.Data                   (Data, Typeable)
 import           Data.Hashable
-import           Data.Monoid
+-- import           Data.Monoid
 import           Data.String
 
 import           GHC.Generics                (Generic)

--- a/core/src/Network/AWS/Data/Text.hs
+++ b/core/src/Network/AWS/Data/Text.hs
@@ -28,7 +28,6 @@ module Network.AWS.Data.Text
     , showText
     ) where
 
--- import           Control.Applicative
 import           Data.Attoparsec.Text              (Parser)
 import qualified Data.Attoparsec.Text              as A
 import           Data.ByteString                   (ByteString)

--- a/core/src/Network/AWS/Data/Text.hs
+++ b/core/src/Network/AWS/Data/Text.hs
@@ -28,7 +28,7 @@ module Network.AWS.Data.Text
     , showText
     ) where
 
-import           Control.Applicative
+-- import           Control.Applicative
 import           Data.Attoparsec.Text              (Parser)
 import qualified Data.Attoparsec.Text              as A
 import           Data.ByteString                   (ByteString)

--- a/core/src/Network/AWS/Data/Time.hs
+++ b/core/src/Network/AWS/Data/Time.hs
@@ -43,7 +43,7 @@ import qualified Data.Attoparsec.Text        as AText
 import qualified Data.ByteString.Char8       as BS
 import           Data.Data                   (Data, Typeable)
 import           Data.Hashable
-import           Data.Monoid
+-- import           Data.Monoid
 import           Data.Scientific
 import           Data.Tagged
 import qualified Data.Text                   as Text

--- a/core/src/Network/AWS/Data/Time.hs
+++ b/core/src/Network/AWS/Data/Time.hs
@@ -43,7 +43,6 @@ import qualified Data.Attoparsec.Text        as AText
 import qualified Data.ByteString.Char8       as BS
 import           Data.Data                   (Data, Typeable)
 import           Data.Hashable
--- import           Data.Monoid
 import           Data.Scientific
 import           Data.Tagged
 import qualified Data.Text                   as Text

--- a/core/src/Network/AWS/Data/XML.hs
+++ b/core/src/Network/AWS/Data/XML.hs
@@ -16,7 +16,6 @@
 --
 module Network.AWS.Data.XML where
 
--- import           Control.Applicative
 import           Control.Monad
 
 import           Data.Bifunctor

--- a/core/src/Network/AWS/Data/XML.hs
+++ b/core/src/Network/AWS/Data/XML.hs
@@ -16,7 +16,7 @@
 --
 module Network.AWS.Data.XML where
 
-import           Control.Applicative
+-- import           Control.Applicative
 import           Control.Monad
 
 import           Data.Bifunctor
@@ -77,9 +77,9 @@ decodeXML lbs =
 --    by the process.'
 encodeXML :: ToElement a => a -> LazyByteString
 encodeXML x = LBS.fromChunks . unsafePerformIO . lazyConsume
-     $  Conduit.sourceList (toEvents doc)
-    =$= Conduit.map rename
-    =$= Stream.renderBytes def
+     $ Conduit.sourceList (toEvents doc)
+    .| Conduit.map rename
+    .| Stream.renderBytes def
   where
     doc = toXMLDocument $ Document
         { documentRoot     = root

--- a/core/src/Network/AWS/Pager.hs
+++ b/core/src/Network/AWS/Pager.hs
@@ -19,7 +19,6 @@ module Network.AWS.Pager
 import           Control.Applicative
 import           Data.HashMap.Strict   (HashMap)
 import qualified Data.HashMap.Strict   as Map
-import           Data.List.NonEmpty    (NonEmpty)
 import           Data.Maybe            (isJust, fromMaybe)
 import           Data.Text             (Text)
 import           Network.AWS.Data.Text (ToText (..))

--- a/core/src/Network/AWS/Response.hs
+++ b/core/src/Network/AWS/Response.hs
@@ -33,7 +33,7 @@ import           Network.HTTP.Conduit         hiding (Proxy, Request, Response)
 import           Network.HTTP.Types
 import           Text.XML                     (Node)
 
-receiveNull :: MonadResource m
+receiveNull :: (MonadResource m, MonadThrow m)
             => Rs a
             -> Logger
             -> Service
@@ -41,9 +41,9 @@ receiveNull :: MonadResource m
             -> ClientResponse
             -> m (Response a)
 receiveNull rs _ = stream $ \_ _ x ->
-    liftResourceT (x $$+- pure (Right rs))
+    liftResourceT (x `connect` pure (Right rs))
 
-receiveEmpty :: MonadResource m
+receiveEmpty :: (MonadResource m, MonadThrow m)
              => (Int -> ResponseHeaders -> () -> Either String (Rs a))
              -> Logger
              -> Service
@@ -51,9 +51,9 @@ receiveEmpty :: MonadResource m
              -> ClientResponse
              -> m (Response a)
 receiveEmpty f _ = stream $ \s h x ->
-    liftResourceT (x $$+- pure (f s h ()))
+    liftResourceT (x `connect` pure (f s h ()))
 
-receiveXMLWrapper :: MonadResource m
+receiveXMLWrapper :: (MonadResource m, MonadThrow m)
                   => Text
                   -> (Int -> ResponseHeaders -> [Node] -> Either String (Rs a))
                   -> Logger
@@ -63,7 +63,7 @@ receiveXMLWrapper :: MonadResource m
                   -> m (Response a)
 receiveXMLWrapper n f = receiveXML (\s h x -> x .@ n >>= f s h)
 
-receiveXML :: MonadResource m
+receiveXML :: (MonadResource m, MonadThrow m)
            => (Int -> ResponseHeaders -> [Node] -> Either String (Rs a))
            -> Logger
            -> Service
@@ -72,7 +72,7 @@ receiveXML :: MonadResource m
            -> m (Response a)
 receiveXML = deserialise decodeXML
 
-receiveJSON :: MonadResource m
+receiveJSON :: (MonadResource m, MonadThrow m)
             => (Int -> ResponseHeaders -> Object -> Either String (Rs a))
             -> Logger
             -> Service
@@ -81,7 +81,7 @@ receiveJSON :: MonadResource m
             -> m (Response a)
 receiveJSON = deserialise eitherDecode'
 
-receiveBody :: MonadResource m
+receiveBody :: (MonadResource m, MonadThrow m)
             => (Int -> ResponseHeaders -> RsBody -> Either String (Rs a))
             -> Logger
             -> Service
@@ -91,7 +91,7 @@ receiveBody :: MonadResource m
 receiveBody f _ = stream $ \s h x -> pure (f s h (RsBody x))
 
 -- | Deserialise an entire response body, such as an XML or JSON payload.
-deserialise :: MonadResource m
+deserialise :: (MonadResource m, MonadThrow m)
             => (LazyByteString -> Either String b)
             -> (Int -> ResponseHeaders -> b -> Either String (Rs a))
             -> Logger
@@ -114,7 +114,7 @@ deserialise g f l Service{..} _ rs = do
                     SerializeError' _svcAbbrev s (Just b) e
 
 -- | Stream a raw response body, such as an S3 object payload.
-stream :: MonadResource m
+stream :: (MonadResource m, MonadThrow m)
        => (Int -> ResponseHeaders -> ResponseBody -> m (Either String (Rs a)))
        -> Service
        -> Proxy a
@@ -133,4 +133,4 @@ stream f Service{..} _ rs = do
                    e
 
 sinkLBS :: MonadResource m => ResponseBody -> m LazyByteString
-sinkLBS bdy = liftResourceT (bdy $$+- Conduit.sinkLbs)
+sinkLBS bdy = liftResourceT (bdy `connect` Conduit.sinkLbs)

--- a/core/src/Network/AWS/Sign/V2.hs
+++ b/core/src/Network/AWS/Sign/V2.hs
@@ -16,7 +16,6 @@ module Network.AWS.Sign.V2
     ( v2
     ) where
 
--- import           Control.Applicative
 import qualified Data.ByteString.Char8       as BS8
 import           Data.Monoid
 import           Data.Time

--- a/core/src/Network/AWS/Sign/V2.hs
+++ b/core/src/Network/AWS/Sign/V2.hs
@@ -16,7 +16,7 @@ module Network.AWS.Sign.V2
     ( v2
     ) where
 
-import           Control.Applicative
+-- import           Control.Applicative
 import qualified Data.ByteString.Char8       as BS8
 import           Data.Monoid
 import           Data.Time

--- a/core/src/Network/AWS/Sign/V4.hs
+++ b/core/src/Network/AWS/Sign/V4.hs
@@ -22,7 +22,6 @@ module Network.AWS.Sign.V4
     , v4
     ) where
 
--- import           Control.Applicative
 import qualified Data.CaseInsensitive        as CI
 import           Data.Monoid
 import           Network.AWS.Data.Body

--- a/core/src/Network/AWS/Sign/V4.hs
+++ b/core/src/Network/AWS/Sign/V4.hs
@@ -22,7 +22,7 @@ module Network.AWS.Sign.V4
     , v4
     ) where
 
-import           Control.Applicative
+-- import           Control.Applicative
 import qualified Data.CaseInsensitive        as CI
 import           Data.Monoid
 import           Network.AWS.Data.Body

--- a/core/src/Network/AWS/Sign/V4/Base.hs
+++ b/core/src/Network/AWS/Sign/V4/Base.hs
@@ -19,8 +19,6 @@
 --
 module Network.AWS.Sign.V4.Base where
 
--- import           Control.Applicative
-
 import           Data.Bifunctor
 import           Data.Function               (on)
 import           Data.List                   (nubBy, sortBy)

--- a/core/src/Network/AWS/Sign/V4/Base.hs
+++ b/core/src/Network/AWS/Sign/V4/Base.hs
@@ -19,7 +19,7 @@
 --
 module Network.AWS.Sign.V4.Base where
 
-import           Control.Applicative
+-- import           Control.Applicative
 
 import           Data.Bifunctor
 import           Data.Function               (on)

--- a/core/src/Network/AWS/Sign/V4/Chunked.hs
+++ b/core/src/Network/AWS/Sign/V4/Chunked.hs
@@ -24,8 +24,6 @@ module Network.AWS.Sign.V4.Chunked
     ( chunked
     ) where
 
--- import Control.Applicative
-
 import Data.ByteString.Builder
 import Data.Conduit
 import Data.Maybe

--- a/core/src/Network/AWS/Sign/V4/Chunked.hs
+++ b/core/src/Network/AWS/Sign/V4/Chunked.hs
@@ -24,7 +24,7 @@ module Network.AWS.Sign.V4.Chunked
     ( chunked
     ) where
 
-import Control.Applicative
+-- import Control.Applicative
 
 import Data.ByteString.Builder
 import Data.Conduit
@@ -62,7 +62,7 @@ chunked c rq a r ts = signRequest meta (toRequestBody body) auth
 
     body = Chunked (c `fuseChunks` sign (metaSignature meta))
 
-    sign :: Monad m => Signature -> Conduit ByteString m ByteString
+    sign :: Monad m => Signature -> ConduitT ByteString ByteString m ()
     sign prev = do
         mx <- await
         let next = chunkSignature prev (fromMaybe mempty mx)

--- a/core/src/Network/AWS/Sign/V4/Chunked.hs
+++ b/core/src/Network/AWS/Sign/V4/Chunked.hs
@@ -62,7 +62,7 @@ chunked c rq a r ts = signRequest meta (toRequestBody body) auth
 
     body = Chunked (c `fuseChunks` sign (metaSignature meta))
 
-    sign :: Monad m => Signature -> ConduitT ByteString ByteString m ()
+    sign :: Monad m => Signature -> ConduitM ByteString ByteString m ()
     sign prev = do
         mx <- await
         let next = chunkSignature prev (fromMaybe mempty mx)

--- a/core/src/Network/AWS/Types.hs
+++ b/core/src/Network/AWS/Types.hs
@@ -132,6 +132,7 @@ import Control.DeepSeq
 import Control.Exception
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Resource
+import Control.Monad.Catch (MonadThrow)
 
 import Data.Aeson              hiding (Error)
 import Data.ByteString.Builder (Builder)
@@ -180,7 +181,7 @@ type ClientRequest = Client.Request
 type ClientResponse = Client.Response ResponseBody
 
 -- | A convenience alias encapsulating the common 'Response' body.
-type ResponseBody = ResumableSource (ResourceT IO) ByteString
+type ResponseBody = ConduitT () ByteString (ResourceT IO) ()
 
 -- | Abbreviated service name.
 newtype Abbrev = Abbrev Text
@@ -518,7 +519,7 @@ class AWSRequest a where
     type Rs a :: *
 
     request  :: a -> Request a
-    response :: MonadResource m
+    response :: (MonadResource m, MonadThrow m)
              => Logger
              -> Service
              -> Proxy a -- For injectivity reasons.

--- a/core/src/Network/AWS/Types.hs
+++ b/core/src/Network/AWS/Types.hs
@@ -132,7 +132,6 @@ import Control.DeepSeq
 import Control.Exception
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Resource
-import Control.Monad.Catch (MonadThrow)
 
 import Data.Aeson              hiding (Error)
 import Data.ByteString.Builder (Builder)
@@ -519,7 +518,7 @@ class AWSRequest a where
     type Rs a :: *
 
     request  :: a -> Request a
-    response :: (MonadResource m, MonadThrow m)
+    response :: MonadResource m
              => Logger
              -> Service
              -> Proxy a -- For injectivity reasons.

--- a/core/src/Network/AWS/Types.hs
+++ b/core/src/Network/AWS/Types.hs
@@ -518,7 +518,7 @@ class AWSRequest a where
     type Rs a :: *
 
     request  :: a -> Request a
-    response :: MonadResource m
+    response :: (MonadResource m, MonadThrow m)
              => Logger
              -> Service
              -> Proxy a -- For injectivity reasons.

--- a/core/src/Network/AWS/Types.hs
+++ b/core/src/Network/AWS/Types.hs
@@ -180,7 +180,7 @@ type ClientRequest = Client.Request
 type ClientResponse = Client.Response ResponseBody
 
 -- | A convenience alias encapsulating the common 'Response' body.
-type ResponseBody = ConduitT () ByteString (ResourceT IO) ()
+type ResponseBody = ConduitM () ByteString (ResourceT IO) ()
 
 -- | Abbreviated service name.
 newtype Abbrev = Abbrev Text

--- a/core/src/Network/AWS/Waiter.hs
+++ b/core/src/Network/AWS/Waiter.hs
@@ -32,7 +32,6 @@ module Network.AWS.Waiter
     , nonEmptyText
     ) where
 
--- import           Control.Applicative
 import           Control.Lens                (Fold, allOf, anyOf, to, (^..),
                                               (^?))
 import           Data.Maybe

--- a/core/src/Network/AWS/Waiter.hs
+++ b/core/src/Network/AWS/Waiter.hs
@@ -32,7 +32,7 @@ module Network.AWS.Waiter
     , nonEmptyText
     ) where
 
-import           Control.Applicative
+-- import           Control.Applicative
 import           Control.Lens                (Fold, allOf, anyOf, to, (^..),
                                               (^?))
 import           Data.Maybe

--- a/gen/amazonka-gen.cabal
+++ b/gen/amazonka-gen.cabal
@@ -80,7 +80,7 @@ executable amazonka-gen
         , formatting
         , free
         , hashable
-        , haskell-src-exts     == 1.19.*
+        , haskell-src-exts     >= 1.19.0 && < 1.21.0
         , hindent
         , html-conduit
         , lens

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -1,19 +1,10 @@
 compiler: ghc-8.2.2
-resolver: lts-10.5
+resolver: lts-11.1
 
 local-bin-path: bin
 
 flags: {}
-
-extra-deps:
-  - text-regex-replace-0.1.1.1
-  - conduit-1.3.0
-  - conduit-combinators-1.3.0
-  - conduit-extra-1.3.0
-  - resourcet-1.2.0
-  - xml-conduit-1.8.0
-  - html-conduit-1.3.0
-  - http-conduit-2.3.0
+extra-deps: []
 
 packages:
   - gen

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -1,5 +1,5 @@
-compiler: ghc-8.2.1
-resolver: nightly-2017-11-01
+compiler: ghc-8.2.2
+resolver: lts-10.5
 
 local-bin-path: bin
 
@@ -7,6 +7,13 @@ flags: {}
 
 extra-deps:
   - text-regex-replace-0.1.1.1
+  - conduit-1.3.0
+  - conduit-combinators-1.3.0
+  - conduit-extra-1.3.0
+  - resourcet-1.2.0
+  - xml-conduit-1.8.0
+  - html-conduit-1.3.0
+  - http-conduit-2.3.0
 
 packages:
   - gen

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -4,7 +4,10 @@ resolver: lts-11.1
 local-bin-path: bin
 
 flags: {}
-extra-deps: []
+
+extra-deps:
+- ede-0.2.8.7 # TODO: replace this with a newer version that fixes: https://github.com/brendanhay/ede/issues/28
+- text-regex-replace-0.1.1.1
 
 packages:
   - gen

--- a/test/src/Test/AWS/Fixture.hs
+++ b/test/src/Test/AWS/Fixture.hs
@@ -97,7 +97,7 @@ testResponse s p lbs = do
         { responseStatus    = status200
         , responseVersion   = http11
         , responseHeaders   = mempty
-        , responseBody      = newResumableSource (Conduit.sourceLbs lbs)
+        , responseBody      = Conduit.sourceLbs lbs
         , responseCookieJar = mempty
         , responseClose'    = ResponseClose (pure ())
         }

--- a/test/src/Test/AWS/Fixture.hs
+++ b/test/src/Test/AWS/Fixture.hs
@@ -23,7 +23,6 @@ import           Control.Monad.Trans.Resource
 import           Data.Aeson
 import           Data.Bifunctor
 import qualified Data.ByteString.Lazy         as LBS
-import           Data.Conduit
 import qualified Data.Conduit.Binary          as Conduit
 import qualified Data.HashMap.Strict          as Map
 import           Data.List                    (sortBy)


### PR DESCRIPTION
Fix https://github.com/brendanhay/amazonka/issues/449

### summary of changes
- Replaced deprecated APIs
  - `Source` -> `ConduitM`
  - `=$=` -> `.|`
  - `$$` -> `connect`
  - `ResumableSource` -> `ConduitM` (since `http-client` now returns `ConduitM`)
  - `MonadCatch` -> `MonadThrow` (since `Conduit` no longer offers the former instance)
  - `hoist` -> `transPipe` (since `Conduit` no longer offers `MFunctor` instance)
- Addressed several compiler warnings re: unused imports and shadow bindings
  - Inadvertently ended up re-implementing: https://github.com/brendanhay/amazonka/pull/441
- Added CPP to `amazonka` to build with `http-client < 2.3.0`