### PR TITLE
Add a `MonadUnliftIO` instance for `AWST'`

### DIFF
--- a/amazonka/amazonka.cabal
+++ b/amazonka/amazonka.cabal
@@ -81,6 +81,7 @@ library
         , transformers        >= 0.2
         , transformers-base   >= 0.4
         , transformers-compat >= 0.3
+        , unliftio-core       >= 0.1
         , void                >= 0.1
 
 test-suite tests

--- a/amazonka/src/Control/Monad/Trans/AWS.hs
+++ b/amazonka/src/Control/Monad/Trans/AWS.hs
@@ -160,6 +160,7 @@ import Control.Applicative
 import Control.Monad.Base
 import Control.Monad.Catch
 import Control.Monad.Error.Class    (MonadError (..))
+import Control.Monad.IO.Unlift
 import Control.Monad.Morph
 import Control.Monad.Reader
 import Control.Monad.State.Class
@@ -229,6 +230,10 @@ instance MonadBaseControl b m => MonadBaseControl b (AWST' r m) where
 
     liftBaseWith = defaultLiftBaseWith
     restoreM     = defaultRestoreM
+
+instance MonadUnliftIO m => MonadUnliftIO (AWST' r m) where
+    askUnliftIO = AWST' $ (\(UnliftIO f) -> UnliftIO $ f . unAWST)
+        <$> askUnliftIO
 
 instance MonadResource m => MonadResource (AWST' r m) where
     liftResourceT = lift . liftResourceT


### PR DESCRIPTION
This is needed to make it work with a more recent version of conduit.