### PR TITLE
Correctly catch exceptions in perform

### DIFF
--- a/amazonka/src/Control/Monad/Trans/AWS.hs
+++ b/amazonka/src/Control/Monad/Trans/AWS.hs
@@ -268,6 +268,7 @@ runAWST r (AWST' m) = runReaderT m r
 -- which 'AWST' implicitly fulfils.
 type AWSConstraint r m =
     ( MonadThrow     m
+    , MonadCatch     m
     , MonadResource  m
     , MonadReader  r m
     , HasEnv       r
@@ -291,7 +292,7 @@ paginate :: (AWSConstraint r m, AWSPager a)
 paginate = go
   where
     go !x = do
-        !y <- send x
+        !y <- lift $ send x
         yield y
         maybe (pure ()) go (page x y)
 

--- a/amazonka/src/Network/AWS/Internal/HTTP.hs
+++ b/amazonka/src/Network/AWS/Internal/HTTP.hs
@@ -147,7 +147,7 @@ perform Env{..} x = catches go handlers
 #else
         rs'         <- liftResourceT (http rq _envManager)
         let resSrc   = responseBody rs'
-        (src', fin) <- unwrapResumable resSrc
+        (src', fin) <- liftResourceT (unwrapResumable resSrc)
         let src = addCleanup (const fin) src'
         let rs  = src <$ rs'
 #endif

--- a/stack-7.10.3.yaml
+++ b/stack-7.10.3.yaml
@@ -17,6 +17,7 @@ extra-deps:
   - http-client-0.5.0.1
   - http-client-tls-0.3.0
   - xml-conduit-1.7.0.1
+  - unliftio-core-0.1.1.0
 
 packages:
   - core


### PR DESCRIPTION
In `perform`, we don't want to finalize resources yet, but `runResourceT` does just that.

This patch reintroduces `MonadCatch` to `AWSConstraint`, and uses `catches` from `MonadCatch` instead of manually lifting/running `ResourceT`.

Fixes #463.
