### PR TITLE
Add support for extra headers as needed by Glacier

### DIFF
--- a/gen/annex/glacier.json
+++ b/gen/annex/glacier.json
@@ -1,5 +1,8 @@
 {
     "metadata": {
-        "serviceAbbreviation": "Glacier"
+        "serviceAbbreviation": "Glacier",
+        "extraHeaders": {
+            "x-amz-glacier-version": "2012-06-01"
+        }
     }
 }

--- a/gen/src/Gen/AST/Data/Instance.hs
+++ b/gen/src/Gen/AST/Data/Instance.hs
@@ -193,11 +193,12 @@ requestInsts m oname h r fs = do
     (listToMaybe -> stream, fields) = partition fieldStream (notLocated fs)
 
     protocolHeaders :: [(Text, Text)]
-    protocolHeaders = case p of
+    protocolHeaders = (case p of
         JSON       -> t ++ c
         RestJSON   -> c
         APIGateway -> j ++ c
-        _          -> []
+        _          -> [])
+        ++ m ^. extraHeaders
       where
         t = maybeToList $ ("X-Amz-Target",) <$> target
         c = maybeToList $ ("Content-Type",) <$> content

--- a/gen/src/Gen/Types/Service.hs
+++ b/gen/src/Gen/Types/Service.hs
@@ -429,12 +429,17 @@ data Metadata f = Metadata
     , _xmlNamespace     :: Maybe Text
     , _jsonVersion      :: Maybe Text
     , _targetPrefix     :: Maybe Text
+    , _extraHeaders     :: [(Text, Text)]
     } deriving (Generic)
 
 deriving instance Show (Metadata Maybe)
 deriving instance Show (Metadata Identity)
 
 $(TH.makeClassy ''Metadata)
+
+extractExtraHeaders :: Maybe JSON.Value -> [(Text,Text)]
+extractExtraHeaders (Just (JSON.Object o)) = [(k,v) | (k, JSON.String v) <- Map.toList o]
+extractExtraHeaders _                      = []
 
 instance FromJSON (Metadata Maybe) where
     parseJSON = JSON.withObject "meta" $ \o -> Metadata
@@ -450,6 +455,7 @@ instance FromJSON (Metadata Maybe) where
         <*> o .:? "xmlNamespace"
         <*> o .:? "jsonVersion"
         <*> o .:? "targetPrefix"
+        <*> (o .:? "extraHeaders" <&> extractExtraHeaders)
 
 instance ToJSON (Metadata Identity) where
     toJSON = gToJSON' camel


### PR DESCRIPTION
Today, the code generated to interact with AWS Glacier does not include the
required header `x-amz-glacier-version: 2012-06-01`, so calls to Glacier fail
with the message `Required parameter missing: API version`. This commit fixes
this by adding support for arbitrary extra headers in the code generator, and
updating the annex for Glacier to include this header.

Fixes #402