### PR TITLE
Mark appropriate fields as required on multipart glacier uploads.

### DIFF
--- a/gen/annex/glacier.json
+++ b/gen/annex/glacier.json
@@ -1,5 +1,32 @@
 {
     "metadata": {
         "serviceAbbreviation": "Glacier"
+    },
+    "shapes": {
+      "InitiateMultipartUploadInput": {
+        "required": [
+          "accountId",
+          "vaultName",
+          "partSize"
+        ]
+      },
+      "UploadMultipartPartInput": {
+        "required": [
+          "accountId",
+          "vaultName",
+          "uploadId",
+          "range",
+          "checksum"
+        ]
+      },
+      "CompleteMultipartUploadInput": {
+        "required": [
+          "accountId",
+          "vaultName",
+          "uploadId",
+          "archiveSize",
+          "checksum"
+        ]
+      }
     }
 }


### PR DESCRIPTION
These are apparently not marked as required in the service file, but
they are marked as required in the docs for these things, e.g.
https://docs.aws.amazon.com/amazonglacier/latest/dev/api-multipart-initiate-upload.html

I don't know the difference between marking a field as required in the
shapes of gen/annex/foo.json, vs marking it as required in the
typeOverrides of gen/config/foo.json. This current approach seems to
give the desired effect, though.

There's likely plenty of other request types where the service files are
not entirely accurate, but I just did this for the types I'm currently
working with (the ones necessary to do multipart uploads).