### PR TITLE
Support building amazonka-gen on GHC 8.4, and the new unexceptionalio lib.

### DIFF
--- a/gen/amazonka-gen.cabal
+++ b/gen/amazonka-gen.cabal
@@ -99,6 +99,6 @@ executable amazonka-gen
         , text-regex-replace
         , time                 >= 1.5
         , transformers
-        , unexceptionalio
+        , unexceptionalio      == 0.4.*
         , unordered-containers
         , xml-conduit

--- a/gen/amazonka-gen.cabal
+++ b/gen/amazonka-gen.cabal
@@ -99,6 +99,6 @@ executable amazonka-gen
         , text-regex-replace
         , time                 >= 1.5
         , transformers
-        , unexceptionalio      == 0.4.*
+        , unexceptionalio      <  0.4
         , unordered-containers
         , xml-conduit

--- a/gen/src/Gen/IO.hs
+++ b/gen/src/Gen/IO.hs
@@ -30,7 +30,7 @@ import Gen.Types
 
 import System.IO
 
-import UnexceptionalIO (fromIO, runUIO)
+import qualified UnexceptionalIO as UIO
 
 import qualified Data.Text         as Text
 import qualified Data.Text.Lazy    as LText
@@ -42,7 +42,7 @@ run :: ExceptT Error IO a -> IO a
 run = runScript . fmapLT LText.toStrict
 
 io :: MonadIO m => IO a -> ExceptT Error m a
-io = ExceptT . fmap (first (LText.pack . show)) . liftIO . runUIO . fromIO
+io = ExceptT . fmap (first (LText.pack . show)) . liftIO . UIO.run . UIO.fromIO
 
 title :: MonadIO m => Format (ExceptT Error m ()) a -> a
 title m = runFormat m (io . LText.putStrLn . toLazyText)

--- a/gen/src/Gen/IO.hs
+++ b/gen/src/Gen/IO.hs
@@ -30,7 +30,7 @@ import Gen.Types
 
 import System.IO
 
-import qualified UnexceptionalIO as UIO
+import UnexceptionalIO (fromIO, runUIO)
 
 import qualified Data.Text         as Text
 import qualified Data.Text.Lazy    as LText
@@ -42,7 +42,7 @@ run :: ExceptT Error IO a -> IO a
 run = runScript . fmapLT LText.toStrict
 
 io :: MonadIO m => IO a -> ExceptT Error m a
-io = ExceptT . fmap (first (LText.pack . show)) . liftIO . UIO.run . UIO.fromIO
+io = ExceptT . fmap (first (LText.pack . show)) . liftIO . runUIO . fromIO
 
 title :: MonadIO m => Format (ExceptT Error m ()) a -> a
 title m = runFormat m (io . LText.putStrLn . toLazyText)

--- a/gen/src/Gen/Types/Ann.hs
+++ b/gen/src/Gen/Types/Ann.hs
@@ -26,6 +26,7 @@ import Data.Aeson
 import Data.Function (on)
 import Data.Hashable
 import Data.Monoid
+import Data.Semigroup (Semigroup)
 import Data.Text     (Text)
 
 import Gen.TH

--- a/gen/src/Gen/Types/Ann.hs
+++ b/gen/src/Gen/Types/Ann.hs
@@ -50,11 +50,14 @@ data Mode
     | Uni !Direction
       deriving (Eq, Show)
 
-instance Monoid Mode where
-    mempty                  = Bi
-    mappend (Uni i) (Uni o)
+instance Semigroup Mode where
+    (Uni i) <> (Uni o)
         | i == o            = Uni o
-    mappend _       _       = Bi
+    _ <> _       = Bi
+
+instance Monoid Mode where
+    mempty  = Bi
+    mappend = (<>)
 
 data Relation = Relation
     { _relShared :: !Int -- FIXME: get around to using something more sensible.
@@ -63,14 +66,17 @@ data Relation = Relation
 
 makeClassy ''Relation
 
-instance Monoid Relation where
-    mempty      = Relation 0 mempty
-    mappend a b = Relation (on add _relShared b a) (on (<>) _relMode b a)
+instance Semigroup Relation where
+    a <> b = Relation (on add _relShared b a) (on (<>) _relMode b a)
       where
         add 0 0 = 2
         add 1 0 = 2
         add 0 1 = 2
         add x y = x + y
+
+instance Monoid Relation where
+    mempty = Relation 0 mempty
+    mappend = (<>)
 
 instance (Functor f, HasRelation a) => HasRelation (Cofree f a) where
     relation = lens extract (flip (:<) . unwrap) . relation

--- a/gen/src/Gen/Types/Help.hs
+++ b/gen/src/Gen/Types/Help.hs
@@ -33,7 +33,7 @@ import qualified Text.HTML.DOM        as DOM
 import qualified Text.XML             as XML
 
 newtype Help = Help Text
-    deriving (Eq, Monoid)
+    deriving (Eq, Semigroup, Monoid)
 
 -- | Empty Show instance to avoid verbose debugging output.
 instance Show Help where

--- a/gen/src/Gen/Types/Help.hs
+++ b/gen/src/Gen/Types/Help.hs
@@ -19,6 +19,7 @@ module Gen.Types.Help
 
 import Data.Aeson
 import Data.Monoid ((<>))
+import Data.Semigroup (Semigroup)
 import Data.String
 import Data.Text   (Text)
 

--- a/gen/src/Gen/Types/NS.hs
+++ b/gen/src/Gen/Types/NS.hs
@@ -36,12 +36,15 @@ instance IsString NS where
     fromString "" = mempty
     fromString s  = mkNS (fromString s)
 
-instance Monoid NS where
-    mempty = NS []
-    mappend (NS xs) (NS ys)
+instance Semigroup NS where
+    (NS xs) <> (NS ys)
         | null xs   = NS ys
         | null ys   = NS xs
         | otherwise = NS (xs <> ys)
+
+instance Monoid NS where
+    mempty = NS []
+    mappend = (<>)
 
 instance FromJSON NS where
     parseJSON = withText "namespace" (pure . mkNS)


### PR DESCRIPTION
The mappend = (<>) lines are redundant on GHC 8.4.
The migration pages suggests to conditionally add them with CPP, but the
other PR upgrading things to GHC 8.4 didn't do that either.
https://prime.haskell.org/wiki/Libraries/Proposals/SemigroupMonoid#Writingcompatiblecode