### PR TITLE
Add PrimMonad instance.

### DIFF
--- a/amazonka/amazonka.cabal
+++ b/amazonka/amazonka.cabal
@@ -74,6 +74,7 @@ library
         , mmorph              >= 1
         , monad-control       >= 1
         , mtl                 >= 2.1.3.1
+        , primitive           >= 0.6.0 && < 0.7.0
         , resourcet           >= 1.1
         , retry               >= 0.7
         , text                >= 1.1

--- a/amazonka/src/Control/Monad/Trans/AWS.hs
+++ b/amazonka/src/Control/Monad/Trans/AWS.hs
@@ -161,6 +161,7 @@ import Control.Monad.Base
 import Control.Monad.Catch
 import Control.Monad.Error.Class    (MonadError (..))
 import Control.Monad.IO.Unlift
+import Control.Monad.Primitive      (PrimMonad, PrimState, primitive)
 import Control.Monad.Morph
 import Control.Monad.Reader
 import Control.Monad.State.Class
@@ -234,6 +235,10 @@ instance MonadBaseControl b m => MonadBaseControl b (AWST' r m) where
 instance MonadUnliftIO m => MonadUnliftIO (AWST' r m) where
     askUnliftIO = AWST' $ (\(UnliftIO f) -> UnliftIO $ f . unAWST)
         <$> askUnliftIO
+
+instance PrimMonad m => PrimMonad (AWST' r m) where
+  type PrimState (AWST' r m) = PrimState m
+  primitive = lift . primitive
 
 instance MonadResource m => MonadResource (AWST' r m) where
     liftResourceT = lift . liftResourceT


### PR DESCRIPTION
This way operations of e.g. Vector can be used in AWST.

Not really sure if this instance is the thing to do, but since AWST' is
just a newtype wrapper for ReaderT, I copied the ReaderT instance. It
seems to be working for me.