### PR TITLE
Drop semigroups dep on GHC > 8.0

### DIFF
--- a/core/amazonka-core.cabal
+++ b/core/amazonka-core.cabal
@@ -98,7 +98,6 @@ library
         , mtl                  >= 2.1.3.1
         , resourcet            >= 1.1
         , scientific           >= 0.3
-        , semigroups           >= 0.12
         , tagged               >= 0.7
         , text                 >= 1.1
         , transformers         >= 0.2
@@ -110,6 +109,9 @@ library
     if !impl(ghc>=7.9)
         build-depends:
               nats >= 0.1.3
+    if !impl(ghc >= 8.0)
+        build-depends:
+              semigroups >= 0.12
 
     if flag(old-locale)
         build-depends:

--- a/examples/amazonka-examples.cabal
+++ b/examples/amazonka-examples.cabal
@@ -47,7 +47,6 @@ library
         , conduit-extra
         , exceptions
         , lens
-        , semigroups
         , text
         , time
         , transformers

--- a/gen/amazonka-gen.cabal
+++ b/gen/amazonka-gen.cabal
@@ -89,7 +89,6 @@ executable amazonka-gen
         , optparse-applicative
         , parsec
         , scientific
-        , semigroups
         , system-fileio
         , system-filepath
         , template-haskell
@@ -102,3 +101,5 @@ executable amazonka-gen
         , unexceptionalio
         , unordered-containers
         , xml-conduit
+    if !impl(ghc >= 8.0)
+      build-depends: semigroups >= 0.12


### PR DESCRIPTION
Data.Semigroups has been included in base since GHC 8.0. Installing that
package is (mostly) a no-op since then.
See https://prime.haskell.org/wiki/Libraries/Proposals/SemigroupMonoid#Writingcompatiblecode
The examples project didn't even have the word `Semigroup` in it.