### PR TITLE
Drop some MonadThrow and MonadCatch constraints

### DIFF
--- a/amazonka/src/Control/Monad/Trans/AWS.hs
+++ b/amazonka/src/Control/Monad/Trans/AWS.hs
@@ -267,9 +267,7 @@ runAWST r (AWST' m) = runReaderT m r
 -- | An alias for the constraints required to send requests,
 -- which 'AWST' implicitly fulfils.
 type AWSConstraint r m =
-    ( MonadThrow     m
-    , MonadCatch     m
-    , MonadResource  m
+    ( MonadResource  m
     , MonadReader  r m
     , HasEnv       r
     )
@@ -351,7 +349,7 @@ isEC2 = do
 -- | Retrieve the specified 'Dynamic' data.
 --
 -- Throws 'HttpException'.
-dynamic :: (MonadIO m, MonadThrow m, MonadReader r m, HasEnv r)
+dynamic :: (MonadIO m, MonadReader r m, HasEnv r)
         => EC2.Dynamic
         -> m ByteString
 dynamic d = view envManager >>= flip EC2.dynamic d
@@ -359,7 +357,7 @@ dynamic d = view envManager >>= flip EC2.dynamic d
 -- | Retrieve the specified 'Metadata'.
 --
 -- Throws 'HttpException'.
-metadata :: (MonadIO m, MonadThrow m, MonadReader r m, HasEnv r)
+metadata :: (MonadIO m, MonadReader r m, HasEnv r)
          => EC2.Metadata
          -> m ByteString
 metadata m = view envManager >>= flip EC2.metadata m
@@ -368,12 +366,12 @@ metadata m = view envManager >>= flip EC2.metadata m
 -- to the instance.
 --
 -- Throws 'HttpException'.
-userdata :: (MonadIO m, MonadCatch m, MonadReader r m, HasEnv r)
+userdata :: (MonadIO m, MonadReader r m, HasEnv r)
          => m (Maybe ByteString)
 userdata = view envManager >>= EC2.userdata
 
-hoistError :: MonadThrow m => Either Error a -> m a
-hoistError = either (throwingM _Error) return
+hoistError :: MonadIO m => Either Error a -> m a
+hoistError = liftIO . either (throwingM _Error) return
 
 {- $discovery
 AuthN/AuthZ information is handled similarly to other AWS SDKs. You can read

--- a/amazonka/src/Network/AWS.hs
+++ b/amazonka/src/Network/AWS.hs
@@ -154,7 +154,6 @@ module Network.AWS
     , RsBody
     ) where
 
-import Control.Monad.Catch          (MonadCatch)
 import Control.Monad.IO.Class       (MonadIO)
 import Control.Monad.Trans.AWS      (AWST)
 import Control.Monad.Trans.Class    (lift)
@@ -195,7 +194,6 @@ class ( Functor     m
       , Applicative m
       , Monad       m
       , MonadIO     m
-      , MonadCatch  m
       ) => MonadAWS m where
     -- | Lift a computation to the 'AWS' monad.
     liftAWS :: AWS a -> m a

--- a/amazonka/src/Network/AWS/EC2/Metadata.hs
+++ b/amazonka/src/Network/AWS/EC2/Metadata.hs
@@ -314,21 +314,21 @@ isEC2 m = liftIO (req `catch` err)
 -- | Retrieve the specified 'Dynamic' data.
 --
 -- Throws 'HttpException' if HTTP communication fails.
-dynamic :: (MonadIO m, MonadThrow m) => Manager -> Dynamic -> m ByteString
+dynamic :: MonadIO m => Manager -> Dynamic -> m ByteString
 dynamic m = get m . mappend latest . toText
 
 -- | Retrieve the specified 'Metadata'.
 --
 -- Throws 'HttpException' if HTTP communication fails.
-metadata :: (MonadIO m, MonadThrow m) => Manager -> Metadata -> m ByteString
+metadata :: MonadIO m => Manager -> Metadata -> m ByteString
 metadata m = get m . mappend latest . toText
 
 -- | Retrieve the user data. Returns 'Nothing' if no user data is assigned
 -- to the instance.
 --
 -- Throws 'HttpException' if HTTP communication fails.
-userdata :: (MonadIO m, MonadCatch m) => Manager -> m (Maybe ByteString)
-userdata m = do
+userdata :: MonadIO m => Manager -> m (Maybe ByteString)
+userdata m = liftIO $ do
     x <- try $ get m (latest <> "user-data")
     case x of
 #if MIN_VERSION_http_client(0,5,0)
@@ -449,12 +449,12 @@ instance ToJSON IdentityDocument where
 -- 'dynamic' and the 'Document' path.
 --
 -- /See:/ <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html AWS Instance Identity Documents>.
-identity :: (MonadIO m, MonadThrow m)
+identity :: MonadIO m
          => Manager
          -> m (Either String IdentityDocument)
 identity m = (eitherDecode . LBS.fromStrict) `liftM` dynamic m Document
 
-get :: (MonadIO m, MonadThrow m) => Manager -> Text -> m ByteString
+get :: MonadIO m => Manager -> Text -> m ByteString
 get m url = liftIO (strip `liftM` request m url)
   where
     strip bs

--- a/amazonka/src/Network/AWS/Env.hs
+++ b/amazonka/src/Network/AWS/Env.hs
@@ -39,7 +39,6 @@ module Network.AWS.Env
     , retryConnectionFailure
     ) where
 
-import Control.Monad.Catch
 import Control.Monad.IO.Class
 import Control.Monad.Reader
 
@@ -188,7 +187,7 @@ timeout s = local (override (serviceTimeout ?~ s))
 -- Throws 'AuthError' when environment variables or IAM profiles cannot be read.
 --
 -- /See:/ 'newEnvWith'.
-newEnv :: (Applicative m, MonadIO m, MonadCatch m)
+newEnv :: (Applicative m, MonadIO m)
        => Credentials -- ^ Credential discovery mechanism.
        -> m Env
 newEnv c =
@@ -202,7 +201,7 @@ newEnv c =
 -- the check to be skipped and the host treated as an EC2 instance.
 --
 -- Throws 'AuthError' when environment variables or IAM profiles cannot be read.
-newEnvWith :: (Applicative m, MonadIO m, MonadCatch m)
+newEnvWith :: (Applicative m, MonadIO m)
            => Credentials -- ^ Credential discovery mechanism.
            -> Maybe Bool  -- ^ Preload the EC2 instance check.
            -> Manager


### PR DESCRIPTION
This is arguable, and simply closing is acceptable. My argument for
making this change is that, when `MonadIO` is already in the
constraints, adding in either `MonadThrow` or `MonadCatch` simply adds
ambiguity as to where exceptions may end up being thrown. Reducing to
just `MonadIO` makes it clear that all exceptions will be thrown as
runtime exceptions.

There may be other places in the library this approach applies, but this
is where I noticed it.