### PR TITLE
Add FromText instances for Int64, String and Seconds

### DIFF
--- a/core/src/Network/AWS/Data/Text.hs
+++ b/core/src/Network/AWS/Data/Text.hs
@@ -72,6 +72,9 @@ class FromText a where
 instance FromText Text where
     parser = A.takeText
 
+instance FromText String where
+    parser = Text.pack <$> A.takeText
+
 instance FromText ByteString where
     parser = Text.encodeUtf8 <$> A.takeText
 
@@ -82,6 +85,9 @@ instance FromText Char where
     parser = A.anyChar <* A.endOfInput
 
 instance FromText Int where
+    parser = A.signed A.decimal <* A.endOfInput
+
+instance FromText Int64 where
     parser = A.signed A.decimal <* A.endOfInput
 
 instance FromText Integer where

--- a/core/src/Network/AWS/Types.hs
+++ b/core/src/Network/AWS/Types.hs
@@ -762,6 +762,7 @@ newtype Seconds = Seconds Int
         , ToQuery
         , ToByteString
         , ToText
+        , FromText
         )
 
 instance Hashable Seconds


### PR DESCRIPTION
In `Network.AWS.Data.Text` there are `ToText` instances for `String`, `Int64` and `Seconds`, but there is no corresponding instance for `FromText`.
This simple PR adds those instances.