### PR TITLE
Remove fractional seconds from serialization of iso8601 timestamps

### DIFF
--- a/core/src/Network/AWS/Data/Time.hs
+++ b/core/src/Network/AWS/Data/Time.hs
@@ -97,7 +97,7 @@ class TimeFormat a where
     format :: Tagged a String
 
 instance TimeFormat RFC822    where format = Tagged "%a, %d %b %Y %H:%M:%S GMT"
-instance TimeFormat ISO8601   where format = Tagged (iso8601DateFormat (Just "%X%6QZ"))
+instance TimeFormat ISO8601   where format = Tagged (iso8601DateFormat (Just "%XZ"))
 instance TimeFormat BasicTime where format = Tagged "%Y%m%d"
 instance TimeFormat AWSTime   where format = Tagged "%Y%m%dT%H%M%SZ"
 


### PR DESCRIPTION
Finally fixing the mess I created with #496 and #497.