### PR TITLE
Add Nix expressions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,20 @@ core:
 
 $(SERVICES):
 	stack build --fast $@
+
+# Nix
+define clean-nix
+	rm -f $(strip $1)/default.nix;
+endef
+
+.PHONY: nix-clean
+nix-clean:
+	$(foreach l,$(LIBRARIES),$(call clean-nix, $l))
+
+define mk-nix
+  cd $(strip $1); make nix; cd ..;
+endef
+
+.PHONY: nix
+nix:
+	$(foreach l,$(LIBRARIES),$(call mk-nix, $l))

--- a/amazonka-alexa-business/default.nix
+++ b/amazonka-alexa-business/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-alexa-business";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Alexa For Business SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-apigateway/default.nix
+++ b/amazonka-apigateway/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-apigateway";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon API Gateway SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-application-autoscaling/default.nix
+++ b/amazonka-application-autoscaling/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-application-autoscaling";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Application Auto Scaling SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-appstream/default.nix
+++ b/amazonka-appstream/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-appstream";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon AppStream SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-appsync/default.nix
+++ b/amazonka-appsync/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-appsync";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon AppSync SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-athena/default.nix
+++ b/amazonka-athena/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-athena";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Athena SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-autoscaling-plans/default.nix
+++ b/amazonka-autoscaling-plans/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-autoscaling-plans";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Auto Scaling Plans SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-autoscaling/default.nix
+++ b/amazonka-autoscaling/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-autoscaling";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Auto Scaling SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-batch/default.nix
+++ b/amazonka-batch/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-batch";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Batch SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-budgets/default.nix
+++ b/amazonka-budgets/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-budgets";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Budgets SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-certificatemanager-pca/default.nix
+++ b/amazonka-certificatemanager-pca/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-certificatemanager-pca";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Certificate Manager Private Certificate Authority SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-certificatemanager/default.nix
+++ b/amazonka-certificatemanager/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-certificatemanager";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Certificate Manager SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-cloud9/default.nix
+++ b/amazonka-cloud9/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-cloud9";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Cloud9 SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-clouddirectory/default.nix
+++ b/amazonka-clouddirectory/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-clouddirectory";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon CloudDirectory SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-cloudformation/default.nix
+++ b/amazonka-cloudformation/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-cloudformation";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon CloudFormation SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-cloudfront/default.nix
+++ b/amazonka-cloudfront/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-cloudfront";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon CloudFront SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-cloudhsm/default.nix
+++ b/amazonka-cloudhsm/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-cloudhsm";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon CloudHSM SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-cloudhsmv2/default.nix
+++ b/amazonka-cloudhsmv2/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-cloudhsmv2";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon CloudHSM V2 SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-cloudsearch-domains/default.nix
+++ b/amazonka-cloudsearch-domains/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-cloudsearch-domains";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon CloudSearch Domain SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-cloudsearch/default.nix
+++ b/amazonka-cloudsearch/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-cloudsearch";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon CloudSearch SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-cloudtrail/default.nix
+++ b/amazonka-cloudtrail/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-cloudtrail";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon CloudTrail SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-cloudwatch-events/default.nix
+++ b/amazonka-cloudwatch-events/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-cloudwatch-events";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon CloudWatch Events SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-cloudwatch-logs/default.nix
+++ b/amazonka-cloudwatch-logs/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-cloudwatch-logs";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon CloudWatch Logs SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-cloudwatch/default.nix
+++ b/amazonka-cloudwatch/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-cloudwatch";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon CloudWatch SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-codebuild/default.nix
+++ b/amazonka-codebuild/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-codebuild";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon CodeBuild SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-codecommit/default.nix
+++ b/amazonka-codecommit/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-codecommit";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon CodeCommit SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-codedeploy/default.nix
+++ b/amazonka-codedeploy/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-codedeploy";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon CodeDeploy SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-codepipeline/default.nix
+++ b/amazonka-codepipeline/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-codepipeline";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon CodePipeline SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-codestar/default.nix
+++ b/amazonka-codestar/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-codestar";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon CodeStar SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-cognito-identity/default.nix
+++ b/amazonka-cognito-identity/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-cognito-identity";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Cognito Identity SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-cognito-idp/default.nix
+++ b/amazonka-cognito-idp/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-cognito-idp";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Cognito Identity Provider SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-cognito-sync/default.nix
+++ b/amazonka-cognito-sync/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-cognito-sync";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Cognito Sync SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-comprehend/default.nix
+++ b/amazonka-comprehend/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-comprehend";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Comprehend SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-config/default.nix
+++ b/amazonka-config/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-config";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Config SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-connect/default.nix
+++ b/amazonka-connect/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-connect";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Connect Service SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-cost-explorer/default.nix
+++ b/amazonka-cost-explorer/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-cost-explorer";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Cost Explorer Service SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-cur/default.nix
+++ b/amazonka-cur/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-cur";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Cost and Usage Report Service SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-datapipeline/default.nix
+++ b/amazonka-datapipeline/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-datapipeline";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Data Pipeline SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-devicefarm/default.nix
+++ b/amazonka-devicefarm/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-devicefarm";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Device Farm SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-directconnect/default.nix
+++ b/amazonka-directconnect/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-directconnect";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Direct Connect SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-discovery/default.nix
+++ b/amazonka-discovery/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-discovery";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Application Discovery Service SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-dms/default.nix
+++ b/amazonka-dms/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-dms";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Database Migration Service SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-ds/default.nix
+++ b/amazonka-ds/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-ds";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Directory Service SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-dynamodb-dax/default.nix
+++ b/amazonka-dynamodb-dax/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-dynamodb-dax";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon DynamoDB Accelerator (DAX) SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-dynamodb-streams/default.nix
+++ b/amazonka-dynamodb-streams/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-dynamodb-streams";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon DynamoDB Streams SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-dynamodb/default.nix
+++ b/amazonka-dynamodb/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-dynamodb";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon DynamoDB SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-ec2/default.nix
+++ b/amazonka-ec2/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-ec2";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Elastic Compute Cloud SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-ecr/default.nix
+++ b/amazonka-ecr/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-ecr";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon EC2 Container Registry SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-ecs/default.nix
+++ b/amazonka-ecs/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-ecs";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon EC2 Container Service SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-efs/default.nix
+++ b/amazonka-efs/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-efs";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Elastic File System SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-elasticache/default.nix
+++ b/amazonka-elasticache/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-elasticache";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon ElastiCache SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-elasticbeanstalk/default.nix
+++ b/amazonka-elasticbeanstalk/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-elasticbeanstalk";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Elastic Beanstalk SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-elasticsearch/default.nix
+++ b/amazonka-elasticsearch/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-elasticsearch";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Elasticsearch Service SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-elastictranscoder/default.nix
+++ b/amazonka-elastictranscoder/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-elastictranscoder";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Elastic Transcoder SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-elb/default.nix
+++ b/amazonka-elb/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-elb";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Elastic Load Balancing SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-elbv2/default.nix
+++ b/amazonka-elbv2/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-elbv2";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Elastic Load Balancing SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-emr/default.nix
+++ b/amazonka-emr/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-emr";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Elastic MapReduce SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-fms/default.nix
+++ b/amazonka-fms/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-fms";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Firewall Management Service SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-gamelift/default.nix
+++ b/amazonka-gamelift/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-gamelift";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon GameLift SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-glacier/default.nix
+++ b/amazonka-glacier/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-glacier";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Glacier SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-glue/default.nix
+++ b/amazonka-glue/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-glue";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Glue SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-greengrass/default.nix
+++ b/amazonka-greengrass/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-greengrass";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Greengrass SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-guardduty/default.nix
+++ b/amazonka-guardduty/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-guardduty";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon GuardDuty SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-health/default.nix
+++ b/amazonka-health/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-health";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Health APIs and Notifications SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-iam/default.nix
+++ b/amazonka-iam/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-iam";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Identity and Access Management SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-importexport/default.nix
+++ b/amazonka-importexport/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-importexport";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Import/Export SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-inspector/default.nix
+++ b/amazonka-inspector/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-inspector";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Inspector SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-iot-analytics/default.nix
+++ b/amazonka-iot-analytics/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-iot-analytics";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon IoT Analytics SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-iot-dataplane/default.nix
+++ b/amazonka-iot-dataplane/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-iot-dataplane";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon IoT Data Plane SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-iot-jobs-dataplane/default.nix
+++ b/amazonka-iot-jobs-dataplane/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-iot-jobs-dataplane";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon IoT Jobs Data Plane SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-iot/default.nix
+++ b/amazonka-iot/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-iot";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon IoT SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-kinesis-analytics/default.nix
+++ b/amazonka-kinesis-analytics/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-kinesis-analytics";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Kinesis Analytics SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-kinesis-firehose/default.nix
+++ b/amazonka-kinesis-firehose/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-kinesis-firehose";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Kinesis Firehose SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-kinesis-video-archived-media/default.nix
+++ b/amazonka-kinesis-video-archived-media/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-kinesis-video-archived-media";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Kinesis Video Streams Archived Media SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-kinesis-video-media/default.nix
+++ b/amazonka-kinesis-video-media/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-kinesis-video-media";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Kinesis Video Streams Media SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-kinesis-video/default.nix
+++ b/amazonka-kinesis-video/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-kinesis-video";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Kinesis Video Streams SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-kinesis/default.nix
+++ b/amazonka-kinesis/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-kinesis";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Kinesis SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-kms/default.nix
+++ b/amazonka-kms/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-kms";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Key Management Service SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-lambda/default.nix
+++ b/amazonka-lambda/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-lambda";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Lambda SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-lex-models/default.nix
+++ b/amazonka-lex-models/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-lex-models";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Lex Model Building Service SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-lex-runtime/default.nix
+++ b/amazonka-lex-runtime/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-lex-runtime";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Lex Runtime Service SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-lightsail/default.nix
+++ b/amazonka-lightsail/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-lightsail";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Lightsail SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-marketplace-analytics/default.nix
+++ b/amazonka-marketplace-analytics/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-marketplace-analytics";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Marketplace Commerce Analytics SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-marketplace-entitlement/default.nix
+++ b/amazonka-marketplace-entitlement/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-marketplace-entitlement";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Marketplace Entitlement Service SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-marketplace-metering/default.nix
+++ b/amazonka-marketplace-metering/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-marketplace-metering";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Marketplace Metering SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-mechanicalturk/default.nix
+++ b/amazonka-mechanicalturk/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-mechanicalturk";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Mechanical Turk SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-mediaconvert/default.nix
+++ b/amazonka-mediaconvert/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-mediaconvert";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Elemental MediaConvert SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-medialive/default.nix
+++ b/amazonka-medialive/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-medialive";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Elemental MediaLive SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-mediapackage/default.nix
+++ b/amazonka-mediapackage/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-mediapackage";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Elemental MediaPackage SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-mediastore-dataplane/default.nix
+++ b/amazonka-mediastore-dataplane/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-mediastore-dataplane";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Elemental MediaStore Data Plane SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-mediastore/default.nix
+++ b/amazonka-mediastore/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-mediastore";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Elemental MediaStore SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-migrationhub/default.nix
+++ b/amazonka-migrationhub/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-migrationhub";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Migration Hub SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-ml/default.nix
+++ b/amazonka-ml/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-ml";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Machine Learning SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-mobile/default.nix
+++ b/amazonka-mobile/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-mobile";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Mobile SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-mq/default.nix
+++ b/amazonka-mq/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-mq";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon MQ SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-opsworks-cm/default.nix
+++ b/amazonka-opsworks-cm/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-opsworks-cm";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon OpsWorks for Chef Automate SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-opsworks/default.nix
+++ b/amazonka-opsworks/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-opsworks";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon OpsWorks SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-organizations/default.nix
+++ b/amazonka-organizations/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-organizations";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Organizations SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-pinpoint/default.nix
+++ b/amazonka-pinpoint/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-pinpoint";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Pinpoint SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-polly/default.nix
+++ b/amazonka-polly/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-polly";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Polly SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-pricing/default.nix
+++ b/amazonka-pricing/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-pricing";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Price List Service SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-rds/default.nix
+++ b/amazonka-rds/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-rds";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Relational Database Service SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-redshift/default.nix
+++ b/amazonka-redshift/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-redshift";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Redshift SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-rekognition/default.nix
+++ b/amazonka-rekognition/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-rekognition";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Rekognition SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-resourcegroups/default.nix
+++ b/amazonka-resourcegroups/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-resourcegroups";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Resource Groups SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-resourcegroupstagging/default.nix
+++ b/amazonka-resourcegroupstagging/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-resourcegroupstagging";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Resource Groups Tagging API SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-route53-autonaming/default.nix
+++ b/amazonka-route53-autonaming/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-route53-autonaming";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Route 53 Auto Naming SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-route53-domains/default.nix
+++ b/amazonka-route53-domains/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-route53-domains";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Route 53 Domains SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-route53/default.nix
+++ b/amazonka-route53/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-route53";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base text ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Route 53 SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-s3-encryption/default.nix
+++ b/amazonka-s3-encryption/default.nix
@@ -1,0 +1,18 @@
+{ mkDerivation, aeson, amazonka, amazonka-core, amazonka-kms
+, amazonka-s3, base, bytestring, case-insensitive, conduit
+, cryptonite, exceptions, lens, memory, mtl, stdenv, text
+, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-s3-encryption";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [
+    aeson amazonka amazonka-core amazonka-kms amazonka-s3 base
+    bytestring case-insensitive conduit cryptonite exceptions lens
+    memory mtl text unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Simple Storage Service SDK - Client-Side Encryption";
+  license = "unknown";
+}

--- a/amazonka-s3/default.nix
+++ b/amazonka-s3/default.nix
@@ -1,0 +1,17 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, lens, stdenv, tasty, tasty-hunit, text, time
+, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-s3";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base lens text ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Simple Storage Service SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-sagemaker-runtime/default.nix
+++ b/amazonka-sagemaker-runtime/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-sagemaker-runtime";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon SageMaker Runtime SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-sagemaker/default.nix
+++ b/amazonka-sagemaker/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-sagemaker";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon SageMaker Service SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-sdb/default.nix
+++ b/amazonka-sdb/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-sdb";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon SimpleDB SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-secretsmanager/default.nix
+++ b/amazonka-secretsmanager/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-secretsmanager";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Secrets Manager SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-serverlessrepo/default.nix
+++ b/amazonka-serverlessrepo/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-serverlessrepo";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon ServerlessApplicationRepository SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-servicecatalog/default.nix
+++ b/amazonka-servicecatalog/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-servicecatalog";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Service Catalog SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-ses/default.nix
+++ b/amazonka-ses/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-ses";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Simple Email Service SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-shield/default.nix
+++ b/amazonka-shield/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-shield";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Shield SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-sms/default.nix
+++ b/amazonka-sms/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-sms";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Server Migration Service SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-snowball/default.nix
+++ b/amazonka-snowball/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-snowball";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Import/Export Snowball SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-sns/default.nix
+++ b/amazonka-sns/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-sns";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Simple Notification Service SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-sqs/default.nix
+++ b/amazonka-sqs/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-sqs";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Simple Queue Service SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-ssm/default.nix
+++ b/amazonka-ssm/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-ssm";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Simple Systems Manager (SSM) SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-stepfunctions/default.nix
+++ b/amazonka-stepfunctions/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-stepfunctions";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Step Functions SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-storagegateway/default.nix
+++ b/amazonka-storagegateway/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-storagegateway";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Storage Gateway SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-sts/default.nix
+++ b/amazonka-sts/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-sts";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Security Token Service SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-support/default.nix
+++ b/amazonka-support/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-support";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Support SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-swf/default.nix
+++ b/amazonka-swf/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-swf";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Simple Workflow Service SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-transcribe/default.nix
+++ b/amazonka-transcribe/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-transcribe";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Transcribe Service SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-translate/default.nix
+++ b/amazonka-translate/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-translate";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon Translate SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-waf-regional/default.nix
+++ b/amazonka-waf-regional/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-waf-regional";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon WAF Regional SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-waf/default.nix
+++ b/amazonka-waf/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-waf";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon WAF SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-workdocs/default.nix
+++ b/amazonka-workdocs/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-workdocs";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon WorkDocs SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-workmail/default.nix
+++ b/amazonka-workmail/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-workmail";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon WorkMail SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-workspaces/default.nix
+++ b/amazonka-workspaces/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-workspaces";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon WorkSpaces SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka-xray/default.nix
+++ b/amazonka-xray/default.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, amazonka-core, amazonka-test, base, bytestring
+, stdenv, tasty, tasty-hunit, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "amazonka-xray";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [ amazonka-core base ];
+  testHaskellDepends = [
+    amazonka-core amazonka-test base bytestring tasty tasty-hunit text
+    time unordered-containers
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Amazon X-Ray SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/amazonka/default.nix
+++ b/amazonka/default.nix
@@ -1,0 +1,21 @@
+{ mkDerivation, amazonka-core, base, bytestring, conduit
+, conduit-extra, directory, exceptions, http-client, http-conduit
+, http-types, ini, mmorph, monad-control, mtl, resourcet, retry
+, stdenv, tasty, tasty-hunit, text, time, transformers
+, transformers-base, transformers-compat, unliftio-core, void
+}:
+mkDerivation {
+  pname = "amazonka";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [
+    amazonka-core base bytestring conduit conduit-extra directory
+    exceptions http-client http-conduit http-types ini mmorph
+    monad-control mtl resourcet retry text time transformers
+    transformers-base transformers-compat unliftio-core void
+  ];
+  testHaskellDepends = [ base tasty tasty-hunit ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Comprehensive Amazon Web Services SDK";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/core/default.nix
+++ b/core/default.nix
@@ -1,0 +1,29 @@
+{ mkDerivation, aeson, attoparsec, base, bifunctors, bytestring
+, case-insensitive, conduit, conduit-extra, cryptonite
+, data-ordlist, deepseq, exceptions, hashable, http-client
+, http-conduit, http-types, lens, memory, mtl, QuickCheck
+, quickcheck-unicode, resourcet, scientific, semigroups, stdenv
+, tagged, tasty, tasty-hunit, tasty-quickcheck, template-haskell
+, text, time, transformers, transformers-compat
+, unordered-containers, xml-conduit, xml-types
+}:
+mkDerivation {
+  pname = "amazonka-core";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [
+    aeson attoparsec base bifunctors bytestring case-insensitive
+    conduit conduit-extra cryptonite deepseq exceptions hashable
+    http-client http-conduit http-types lens memory mtl resourcet
+    scientific semigroups tagged text time transformers
+    transformers-compat unordered-containers xml-conduit xml-types
+  ];
+  testHaskellDepends = [
+    aeson base bytestring case-insensitive conduit data-ordlist
+    http-conduit http-types lens QuickCheck quickcheck-unicode tasty
+    tasty-hunit tasty-quickcheck template-haskell text time
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Core data types and functionality for Amazonka libraries";
+  license = stdenv.lib.licenses.mpl20;
+}

--- a/share/library.mk
+++ b/share/library.mk
@@ -8,3 +8,6 @@ upload:
 
 upload-docs:
 	PACKAGE=$(NAME) ../script/hackage-documentation
+
+nix:
+	cabal2nix . > default.nix

--- a/test/default.nix
+++ b/test/default.nix
@@ -1,0 +1,20 @@
+{ mkDerivation, aeson, amazonka-core, base, bifunctors, bytestring
+, case-insensitive, conduit, conduit-extra, groom, http-client
+, http-types, process, resourcet, stdenv, tasty, tasty-hunit
+, template-haskell, temporary, text, time, unordered-containers
+, yaml
+}:
+mkDerivation {
+  pname = "amazonka-test";
+  version = "1.6.0";
+  src = ./.;
+  libraryHaskellDepends = [
+    aeson amazonka-core base bifunctors bytestring case-insensitive
+    conduit conduit-extra groom http-client http-types process
+    resourcet tasty tasty-hunit template-haskell temporary text time
+    unordered-containers yaml
+  ];
+  homepage = "https://github.com/brendanhay/amazonka";
+  description = "Common functionality for Amazonka library test-suites";
+  license = stdenv.lib.licenses.mpl20;
+}


### PR DESCRIPTION
- Add commands for generating Nix expressions for Amazonka to the Makefile.
- Use "make nix" to generate all the Nix files and "make nix-clean" to remove
  all the Nix files. "make nix-clean" and "make nix" should be run when changing
  the cabal file for a package, and probably should be run before submitting a 
  PR.
- This PR is very useful for people using Nix who want to easily target specific
  commits. For example grabbing a bugfix while waiting for the next stable
  release.
