### PR TITLE
Add an instance for PrimMonad m => PrimMonad (AWST' r m)

### DIFF
--- a/amazonka/amazonka.cabal
+++ b/amazonka/amazonka.cabal
@@ -74,6 +74,7 @@ library
         , mmorph              >= 1
         , monad-control       >= 1
         , mtl                 >= 2.1.3.1
+        , primitive           >= 0.6
         , resourcet           >= 1.1
         , retry               >= 0.7
         , text                >= 1.1

--- a/amazonka/src/Control/Monad/Trans/AWS.hs
+++ b/amazonka/src/Control/Monad/Trans/AWS.hs
@@ -273,7 +273,7 @@ instance MFunctor (AWST' r) where
 
 instance PrimMonad m => PrimMonad (AWST' r m) where
     type PrimState (AWST' r m) = PrimState m
-    primitive f = AWST' (primitive f)
+    primitive = AWST' . primitive
 
 -- | Run an 'AWST' action with the specified environment.
 runAWST :: HasEnv r => r -> AWST' r m a -> m a

--- a/amazonka/src/Control/Monad/Trans/AWS.hs
+++ b/amazonka/src/Control/Monad/Trans/AWS.hs
@@ -163,6 +163,7 @@ import Control.Monad.Catch
 import Control.Monad.Error.Class    (MonadError (..))
 import Control.Monad.IO.Unlift
 import Control.Monad.Morph
+import Control.Monad.Primitive
 import Control.Monad.Reader
 import Control.Monad.State.Class
 import Control.Monad.Trans.Control
@@ -269,6 +270,10 @@ instance MonadState s m => MonadState s (AWST' r m) where
 
 instance MFunctor (AWST' r) where
     hoist nat = AWST' . hoist nat . unAWST
+
+instance PrimMonad m => PrimMonad (AWST' r m) where
+    type PrimState (AWST' r m) = PrimState m
+    primitive f = AWST' (primitive f)
 
 -- | Run an 'AWST' action with the specified environment.
 runAWST :: HasEnv r => r -> AWST' r m a -> m a


### PR DESCRIPTION
Adds an instance for PrimMonad AWST', which is used for low level memory access when IO or ST is the base monad in a transformer stack. The particular use case we came across was after the release of conduit 1.3 ~broke everything~ changed how IO is handled by using MonadUnliftIO, the conduit-extra changed its Zlib compression functions from needing

```Haskell
(MonadBaseControl b m, PrimMonad b) => ...
```

to needing 

```Haskell
PrimMonad m => ...
```

This change doesn't actually change the packages needed to compile `amazonka` as primitive was already a transitive dependency.