### PR TITLE
Ensures that KerberosAttributes is parsed correctly from an empty response

### DIFF
--- a/gen/config/emr.json
+++ b/gen/config/emr.json
@@ -12,6 +12,12 @@
                 "Name",
                 "Status"
             ]
+        },
+        "KerberosAttributes" :{
+            "optionalFields": [
+                "KdcAdminPassword",
+                "Realm"
+            ]
         }
     }
 }


### PR DESCRIPTION
Simply makes the `Realm` and `KdcAdminPassword` fields optional.

Fixes #485 