### PR TITLE
remove the content-length header when doing V4 streaming signatures

### DIFF
--- a/core/src/Network/AWS/Sign/V4/Base.hs
+++ b/core/src/Network/AWS/Sign/V4/Base.hs
@@ -267,3 +267,4 @@ normaliseHeaders = Tag
     . nubBy  ((==)    `on` fst)
     . sortBy (compare `on` fst)
     . filter ((/= "authorization") . fst)
+    . filter ((/= "content-length") . fst)


### PR DESCRIPTION
Addresses https://github.com/brendanhay/amazonka/issues/546 and possibly https://github.com/brendanhay/amazonka/issues/537

Thanks to @jchia for noticing the difference with the other aws library and @Kheldar noticing something similar in boto3.

Simply removes `content-length` from the signature calculation. The header is still sent with the request.