### PR TITLE
Add MonadFail instance for AWST

### DIFF
--- a/amazonka/src/Control/Monad/Trans/AWS.hs
+++ b/amazonka/src/Control/Monad/Trans/AWS.hs
@@ -168,6 +168,9 @@ import Control.Monad.State.Class
 import Control.Monad.Trans.Control
 import Control.Monad.Trans.Resource
 import Control.Monad.Writer.Class
+#if MIN_VERSION_base(4,9,0)
+import Control.Monad.Fail
+#endif
 
 import Data.Conduit      hiding (await)
 import Data.Conduit.Lazy (MonadActive (..))
@@ -202,6 +205,9 @@ newtype AWST' r m a = AWST' { unAWST :: ReaderT r m a }
         , MonadIO
         , MonadActive
         , MonadTrans
+#if MIN_VERSION_base(4,9,0)
+        , MonadFail
+#endif
         )
 
 instance MonadThrow m => MonadThrow (AWST' r m) where


### PR DESCRIPTION
Starting from GHC 8.8, as per [MonadFail proposal](https://prime.haskell.org/wiki/Libraries/Proposals/MonadFail); `Monad` typeclass does not have a `fail` method; which instead is provided by `MonadFail` typeclass.

This PR adds `MonadFail` instance to `AWST` conditionally based on `base` version.