### PR TITLE
Set startedAt as optional in AWS batch

### DIFF
--- a/gen/config/batch.json
+++ b/gen/config/batch.json
@@ -1,3 +1,10 @@
 {
-    "libraryName": "amazonka-batch"
+    "libraryName": "amazonka-batch",
+    "typeOverrides": {
+        "JobDetail": {
+            "optionalFields": [
+                "startedAt"
+            ]
+        }
+    }
 }


### PR DESCRIPTION
The `startedAt` field is not present in the job detail until the job is started, causing a parse error.
This should fix that.