### PR TITLE
Update UnliftIO instance for unliftio-core-0.2

### DIFF
--- a/amazonka/src/Control/Monad/Trans/AWS.hs
+++ b/amazonka/src/Control/Monad/Trans/AWS.hs
@@ -249,8 +249,7 @@ instance MonadBaseControl b m => MonadBaseControl b (AWST' r m) where
     restoreM     = defaultRestoreM
 
 instance MonadUnliftIO m => MonadUnliftIO (AWST' r m) where
-    askUnliftIO = AWST' $ (\(UnliftIO f) -> UnliftIO $ f . unAWST)
-        <$> askUnliftIO
+    withRunInIO inner = AWST' $ withRunInIO $ \run -> inner (run . unAWST)
 
 instance MonadResource m => MonadResource (AWST' r m) where
     liftResourceT = lift . liftResourceT


### PR DESCRIPTION
Since unliftio suddenly moved `askUnliftIO` out of `MonadUnliftIO`, this restores compatibility by implementing `withRunInIO` instead