### PR TITLE
Generalized MonadAWS instance for AWST beyond ResourceT IO

### DIFF
--- a/amazonka/src/Control/Monad/Trans/AWS.hs
+++ b/amazonka/src/Control/Monad/Trans/AWS.hs
@@ -40,6 +40,7 @@ module Control.Monad.Trans.AWS
     , newEnv
     , Env
     , HasEnv       (..)
+    , askEnv
 
     -- ** Credential Discovery
     , Credentials  (..)
@@ -183,7 +184,7 @@ import Network.AWS.Env
 import Network.AWS.Internal.Body
 import Network.AWS.Internal.HTTP
 import Network.AWS.Internal.Logger
-import Network.AWS.Lens            (catching, throwingM, trying, view)
+import Network.AWS.Lens            (catching, throwingM, trying, view, (^.))
 import Network.AWS.Pager           (AWSPager (..))
 import Network.AWS.Prelude         as AWS
 import Network.AWS.Request         (requestURL)
@@ -284,6 +285,9 @@ instance PrimMonad m => PrimMonad (AWST' r m) where
 -- | Run an 'AWST' action with the specified environment.
 runAWST :: HasEnv r => r -> AWST' r m a -> m a
 runAWST r (AWST' m) = runReaderT m r
+
+askEnv :: (Monad m, HasEnv r) => AWST' r m Env
+askEnv = AWST' (asks (^. environment))
 
 -- | An alias for the constraints required to send requests,
 -- which 'AWST' implicitly fulfils.

--- a/amazonka/src/Network/AWS.hs
+++ b/amazonka/src/Network/AWS.hs
@@ -200,8 +200,10 @@ class ( Functor     m
     -- | Lift a computation to the 'AWS' monad.
     liftAWS :: AWS a -> m a
 
-instance MonadAWS AWS where
-    liftAWS = id
+instance (MonadResource m, MonadCatch m) => MonadAWS (AWST m) where
+    liftAWS action = do
+        env <- AWST.askEnv
+        liftResourceT (AWST.runAWST env action)
 
 instance MonadAWS m => MonadAWS (IdentityT   m) where liftAWS = lift . liftAWS
 instance MonadAWS m => MonadAWS (ListT       m) where liftAWS = lift . liftAWS


### PR DESCRIPTION
The current instance `MonadAWS AWS` is more specific than it needs to be, since `liftAWS :: AWS a -> m a` can be implemented for `AWST m` other than `AWST (ResourceT IO)`, so long as `m` satisfies `(MonadResource m, MonadCatch m)`