### PR TITLE
Fixes to compile on ghc-8.10.1

### DIFF
--- a/amazonka/src/Control/Monad/Trans/AWS.hs
+++ b/amazonka/src/Control/Monad/Trans/AWS.hs
@@ -249,8 +249,12 @@ instance MonadBaseControl b m => MonadBaseControl b (AWST' r m) where
     restoreM     = defaultRestoreM
 
 instance MonadUnliftIO m => MonadUnliftIO (AWST' r m) where
+#if MIN_VERSION_unliftio_core(0,2,0)
+    withRunInIO inner = (AWST' $ (\(UnliftIO f) -> UnliftIO $ f . unAWST) <$> askUnliftIO) >>= \u -> liftIO (inner (unliftIO u))
+#else
     askUnliftIO = AWST' $ (\(UnliftIO f) -> UnliftIO $ f . unAWST)
         <$> askUnliftIO
+#endif
 
 instance MonadResource m => MonadResource (AWST' r m) where
     liftResourceT = lift . liftResourceT

--- a/gen/amazonka-gen.cabal
+++ b/gen/amazonka-gen.cabal
@@ -81,7 +81,7 @@ executable amazonka-gen
         , formatting
         , free
         , hashable
-        , haskell-src-exts     >= 1.19.0 && < 1.21.0
+        , haskell-src-exts     >= 1.19.0 && < 1.24.0
         , hindent
         , html-conduit
         , lens


### PR DESCRIPTION
* Bump upper bound of `haskell-src-exts`.
* Fix MonadUnlifIO compiler errors on ghc-8.10.1