### PR TITLE
Adds paginators to AWS Secrets Manager API

### DIFF
--- a/gen/annex/secretsmanager.json
+++ b/gen/annex/secretsmanager.json
@@ -1,5 +1,19 @@
 {
     "metadata": {
         "serviceAbbreviation": "SecretsManager"
+    },
+    "pagination": {
+        "ListSecrets": {
+            "input_token": "NextToken",
+            "output_token": "NextToken",
+            "limit_key": "MaxResults",
+            "result_key": "SecretList"
+        },
+        "ListSecretVersionIds": {
+            "input_token": "NextToken",
+            "output_token": "NextToken",
+            "limit_key": "MaxResults",
+            "result_key": "Versions"
+        }
     }
 }


### PR DESCRIPTION
Replaces #505 by moving the config to the annex.