### PR TITLE
Replace hindent with brittany

### DIFF
--- a/gen/Makefile
+++ b/gen/Makefile
@@ -4,6 +4,7 @@ MODEL_DIR := model
 OUT_DIR   := ..
 BIN_DIR   := ../bin
 GENERATE  := $(BIN_DIR)/amazonka-gen
+BRITTANY  := $(BIN_DIR)/brittany
 STYLISH   := $(BIN_DIR)/stylish-haskell
 
 define version =
@@ -43,10 +44,13 @@ format: $(STYLISH)
 	$(wildcard $(OUT_DIR)/amazonka-*/test/Test/AWS/Gen) \
 	-type f \
 	-name '*.hs' \
-	-exec sh -c "printf ' -> %s\n' $1 {}; $(STYLISH) -i {}" \;
+	-exec sh -c "printf ' -> %s\n' $1 {}; $(BRITTANY) --write-mode=inplace {}; $(STYLISH) -i {}" \;
 
 $(GENERATE): $(BIN_DIR)
 	stack install --nix amazonka-gen
+
+$(BRITTANY): $(BIN_DIR)
+	stack install --nix brittany
 
 $(STYLISH): $(BIN_DIR)
 	stack install --nix stylish-haskell

--- a/gen/amazonka-gen.cabal
+++ b/gen/amazonka-gen.cabal
@@ -69,6 +69,7 @@ executable amazonka-gen
           aeson                >= 1.2
         , attoparsec
         , base                 >= 4.9
+        , brittany
         , bytestring
         , case-insensitive
         , comonad
@@ -82,7 +83,6 @@ executable amazonka-gen
         , free
         , hashable
         , haskell-src-exts     >= 1.19.0 && < 1.24.0
-        , hindent
         , html-conduit
         , lens
         , mtl


### PR DESCRIPTION
hindent is unmaintained and fails to compile on lts-15.12 without some extra effort.

brittany parses in `IO`.  To avoid that ripple, we move the indentation step into the Makefile, next to stylish-haskell.