### PR TITLE
Import stuff from base instead of mtl

### DIFF
--- a/amazonka/src/Control/Monad/Trans/AWS.hs
+++ b/amazonka/src/Control/Monad/Trans/AWS.hs
@@ -159,6 +159,7 @@ module Control.Monad.Trans.AWS
     ) where
 
 import Control.Applicative
+import Control.Monad
 import Control.Monad.Base
 import Control.Monad.Catch
 import Control.Monad.Error.Class    (MonadError (..))

--- a/amazonka/src/Network/AWS/Internal/HTTP.hs
+++ b/amazonka/src/Network/AWS/Internal/HTTP.hs
@@ -24,6 +24,7 @@ module Network.AWS.Internal.HTTP
 import Control.Arrow                (first)
 import Control.Monad
 import Control.Monad.Catch (MonadThrow, MonadCatch, Handler(Handler), catches)
+import Control.Monad.IO.Class
 import Control.Monad.Reader
 import Control.Monad.Trans.Resource
 import Control.Retry


### PR DESCRIPTION
There is an intention to stop re-exporting functions from `base` in future versions of `mtl`: https://github.com/haskell/mtl/pull/74
This PR brings `amazonka` in line with the proposed change, because at the moment `Control.Monad.Trans.AWS` imports `MonadPlus` and `Network.AWS.Internal.HTTP` imports `join` (both originally from `Control.Monad`) from `Control.Monad.Reader`.