### PR TITLE
Include non-standard port in signed host header

### DIFF
--- a/core/src/Network/AWS/Sign/V4.hs
+++ b/core/src/Network/AWS/Sign/V4.hs
@@ -57,7 +57,13 @@ presign ex rq a r ts = signRequest meta mempty auth
 
     digest = Tag "UNSIGNED-PAYLOAD"
 
-    prepare = rqHeaders %~ ( hdr hHost (_endpointHost end) )
+    prepare = rqHeaders %~ ( hdr hHost host )
+
+    host = case (_endpointSecure end, _endpointPort end) of
+        (False, 80) -> _endpointHost end
+        (True, 443) -> _endpointHost end
+        (_, port) -> _endpointHost end <> ":" <> toBS port
+
     end     = _svcEndpoint (_rqService rq) r
 
 sign :: Algorithm a

--- a/core/src/Network/AWS/Sign/V4/Base.hs
+++ b/core/src/Network/AWS/Sign/V4/Base.hs
@@ -95,11 +95,16 @@ base h rq a r ts = (meta, auth)
     presigner _ _ = id
 
     prepare = rqHeaders %~
-        ( hdr hHost             (_endpointHost end)
+        ( hdr hHost             host
         . hdr hAMZDate          (toBS (Time ts :: AWSTime))
         . hdr hAMZContentSHA256 (toBS h)
         . maybe id (hdr hAMZToken . toBS) (_authToken a)
         )
+
+    host = case (_endpointSecure end, _endpointPort end) of
+        (False, 80) -> _endpointHost end
+        (True, 443) -> _endpointHost end
+        (_, port) -> _endpointHost end <> ":" <> toBS port
 
     end = _svcEndpoint (_rqService rq) r
 


### PR DESCRIPTION
We ran into a V4 signature issue with presigned URLs against a local Minio installation on a non-default port. This change fixed it.
I also applied the same change to the normal request signing logic, although interestingly, it worked both with and without it.

This is also [how they do it in botocore](https://github.com/boto/botocore/blob/30206ab9e9081c80fa68e8b2cb56296b09be6337/botocore/auth.py#L190).

Also, we are using this branch in production already.