### PR TITLE
Separate product and sum into own modules

### DIFF
--- a/gen/src/Gen/Import.hs
+++ b/gen/src/Gen/Import.hs
@@ -22,6 +22,8 @@ import Data.Monoid
 
 import Gen.Types
 
+import qualified Data.Set as Set
+
 operationImports :: Library -> Operation Identity SData a -> [NS]
 operationImports l o = sort $
       "Network.AWS.Request"
@@ -29,7 +31,6 @@ operationImports l o = sort $
     : "Network.AWS.Lens"
     : "Network.AWS.Prelude"
     : l ^. typesNS
-    : l ^. productNS
     : l ^. operationModules
    ++ maybeToList (const "Network.AWS.Pager" <$> o ^. opPager)
 
@@ -38,8 +39,6 @@ typeImports l = sort $
       "Network.AWS.Lens"
     : "Network.AWS.Prelude"
     : signatureImport (l ^. signatureVersion)
-    : l ^. sumNS
-    : l ^. productNS
     : l ^. typeModules
 
 sumImports :: Library -> [NS]
@@ -47,12 +46,16 @@ sumImports l = sort $
       "Network.AWS.Prelude"
     : l ^. typeModules
 
-productImports :: Library -> [NS]
-productImports l = sort $
+productImports :: Library -> Prod -> [NS]
+productImports l p = sort $
       "Network.AWS.Lens"
     : "Network.AWS.Prelude"
-    : l ^. sumNS
     : l ^. typeModules
+   ++ (Set.toList $ Set.map (l ^. typesNS <>) moduleDependencies)
+  where
+    moduleDependencies = Set.intersection dependencies moduleShapes
+    dependencies = Set.map mkNS $ _prodDeps p
+    moduleShapes = Set.fromList (mkNS . typeId . identifier <$> l ^.. shapes . each)
 
 waiterImports :: Library -> [NS]
 waiterImports l = sort $

--- a/gen/src/Gen/Tree.hs
+++ b/gen/src/Gen/Tree.hs
@@ -31,7 +31,8 @@ import Control.Monad.Except
 import Data.Aeson            hiding (json)
 import Data.Bifunctor
 import Data.Functor.Identity
-import Data.Monoid
+import Data.Maybe            (mapMaybe)
+import Data.Monoid           hiding (Sum)
 import Data.Text             (Text)
 
 import Filesystem.Path.CurrentOS hiding (FilePath, root)
@@ -86,10 +87,8 @@ populate d Templates{..} l = (encodeString d :/) . dir lib <$> layout
             [ dir "Network"
                 [ dir "AWS"
                     [ dir svc $
-                        [ dir "Types"
-                            [ mod (l ^. sumNS) (sumImports l) sumTemplate
-                            , mod (l ^. productNS) (productImports l) productTemplate
-                            ]
+                        [ dir "Types" $
+                            mapMaybe shape (l ^.. shapes . each)
                         , mod (l ^. typesNS) (typeImports l) typesTemplate
                         , mod (l ^. waitersNS) (waiterImports l) waitersTemplate
                         ] ++ map op (l ^.. operations . each)
@@ -137,6 +136,13 @@ populate d Templates{..} l = (encodeString d :/) . dir lib <$> layout
     op :: Operation Identity SData a -> DirTree (Either Error Touch)
     op = write . operation' l operationTemplate
 
+    shape :: SData -> Maybe (DirTree (Either Error Touch))
+    shape s = (\t -> (write . shape' l t) s) <$> template s
+      where
+        template (Prod _ _ _) = Just productTemplate
+        template (Sum  _ _ _) = Just sumTemplate
+        template (Fun  _)     = Nothing
+
     fixture :: Operation Identity SData a -> [DirTree (Either Error Touch)]
     fixture o =
         [ touch (n <> "Response.proto") blankTemplate mempty
@@ -171,6 +177,21 @@ operation' l t o = module' n is t $ do
     m  = l ^. metadata
 
     is = operationImports l o
+
+
+shape' :: Library
+       -> Template
+       -> SData
+       -> DirTree (Either Error Rendered)
+shape' l t s = module' n (is s) t $ pure env
+  where
+    n = (l ^. typesNS) <> ((mkNS . typeId) $ identifier s)
+
+    is (Prod _ prod _) = productImports l prod
+    is (Sum  _ _    _) = sumImports l
+    is _               = []
+
+    env = object ["shape" .= s]
 
 module' :: ToJSON a
         => NS

--- a/gen/src/Gen/Types/Data.hs
+++ b/gen/src/Gen/Types/Data.hs
@@ -29,6 +29,7 @@ import Gen.Types.Id
 import Gen.Types.Map
 import Gen.Types.TypeOf
 
+import qualified Data.Set       as Set
 import qualified Data.Text      as Text
 import qualified Data.Text.Lazy as LText
 
@@ -56,6 +57,7 @@ data Prod = Prod'
     , _prodDecl   :: Rendered
     , _prodCtor   :: Fun
     , _prodLenses :: [Fun]
+    , _prodDeps   :: Set.Set Text
     } deriving (Eq, Show)
 
 prodToJSON :: ToJSON a => Solved -> Prod -> Map Text a -> [Pair]

--- a/gen/template/types.ede
+++ b/gen/template/types.ede
@@ -46,6 +46,14 @@ module {{ moduleName }}
 {% for import in moduleImports %}
 import {{ import.value }}
 {% endfor %}
+{% for shape in shapes %}
+{% case shape.value.type %}
+{% when "product" %}
+import {{moduleName}}.{{ shape.value.name }}
+{% when "sum" %}
+import {{moduleName}}.{{ shape.value.name }}
+{% endcase %}  
+{% endfor %}
 
 {% include "_include/function.ede" with function = serviceInstance %}
 {% for shape in shapes %}

--- a/gen/template/types/product.ede
+++ b/gen/template/types/product.ede
@@ -14,10 +14,5 @@ module {{ moduleName }} where
 {% for import in moduleImports %}
 import {{ import.value }}
 {% endfor %}
-{% for shape in shapes %}
-  {% case shape.value.type %}
-  {% when "product" %}
 
-{% include "_include/product.ede" with shape = shape.value %}
-  {% endcase %}
-{% endfor %}
+{% include "_include/product.ede" %}

--- a/gen/template/types/sum.ede
+++ b/gen/template/types/sum.ede
@@ -14,10 +14,5 @@ module {{ moduleName }} where
 {% for import in moduleImports %}
 import {{ import.value }}
 {% endfor %}
-{% for shape in shapes %}
-  {% case shape.value.type %}
-  {% when "sum" %}
-
-{% include "_include/sum.ede" with shape = shape.value %}
-  {% endcase %}
-{% endfor %}
+  
+{% include "_include/sum.ede" with shape = shape %}


### PR DESCRIPTION
Large modules, such as `Network.AWS.ECS.Types`, take too long to compile.  This generates each generated sum and product into their own module, which are then re-exported in `Types`.  There are two advantages:

1. Smaller modules promote parallel compilation, so wall time drops.
2. Compilation of large modules is superlinear, so total CPU time drops. 

This change should be compatible.