### PR TITLE
Generate sum types as pattern synonyms

### DIFF
--- a/gen/src/Gen/AST/Data.hs
+++ b/gen/src/Gen/AST/Data.hs
@@ -147,11 +147,15 @@ sumData p s i vs = Sum s <$> mk <*> (Map.keys <$> insts)
   where
     mk = Sum' (typeId n) (i ^. infoDocumentation)
         <$> pp Print decl
+        <*> pure ctor
         <*> pure bs
 
-    decl = dataD n (map f . sort $ Map.keys bs) (derivingOf s)
+    decl = dataD n [newt] (derivingOf s)
       where
-        f x = conD (Exts.ConDecl () (ident x) [])
+        newt = conD (Exts.ConDecl () (ident ctor) [tyapp (tycon "CI") (tycon "Text")])
+
+    -- Sometimes the values share a name with a type, so we prime the data constructor to avoid clashes.
+    ctor = ((<> "'") . typeId) n
 
     insts = renderInsts p n $ shapeInsts p (s ^. relMode) []
 

--- a/gen/src/Gen/Import.hs
+++ b/gen/src/Gen/Import.hs
@@ -42,7 +42,8 @@ typeImports l = sort $
 
 sumImports :: Library -> [NS]
 sumImports l = sort $
-      "Network.AWS.Prelude"
+      "Data.CaseInsensitive"
+    : "Network.AWS.Prelude"
     : l ^. typeModules
 
 productImports :: Library -> Prod -> [NS]

--- a/gen/src/Gen/Tree.hs
+++ b/gen/src/Gen/Tree.hs
@@ -178,7 +178,6 @@ operation' l t o = module' n is t $ do
 
     is = operationImports l o
 
-
 shape' :: Library
        -> Template
        -> SData
@@ -205,7 +204,9 @@ module' ns is tmpl f =
         return $! x <> fromPairs
             [ "moduleName"    .= ns
             , "moduleImports" .= is
+            , "templateName"  .= (templateName ns)
             ]
+      where templateName (NS xs) = last xs
 
 file' :: ToJSON a
       => Path

--- a/gen/src/Gen/Types/Data.hs
+++ b/gen/src/Gen/Types/Data.hs
@@ -81,6 +81,7 @@ data Sum = Sum'
     { _sumName  :: Text
     , _sumDoc   :: Maybe Help
     , _sumDecl  :: Rendered
+    , _sumCtor  :: Text
     , _sumCtors :: Map Text Text
     } deriving (Eq, Show)
 
@@ -88,6 +89,7 @@ sumToJSON :: Solved -> Sum -> [Text] -> [Pair]
 sumToJSON s Sum'{..} is =
     [ "type"          .= Text.pack "sum"
     , "name"          .= _sumName
+    , "constructor"   .= _sumCtor
     , "constructors"  .= _sumCtors
     , "documentation" .= _sumDoc
     , "declaration"   .= _sumDecl

--- a/gen/src/Gen/Types/TypeOf.hs
+++ b/gen/src/Gen/Types/TypeOf.hs
@@ -53,7 +53,7 @@ instance HasId a => TypeOf (Shape a) where
         shape = \case
             Ptr _ t              -> t
             Struct st            -> TType  (typeId n) (struct st)
-            Enum   {}            -> TType  (typeId n) (enum <> derivingBase)
+            Enum   {}            -> TType  (typeId n) (ord <> derivingBase)
             List (ListF i e)
                 | nonEmpty i     -> TList1 (typeOf e)
                 | otherwise      -> TList  (typeOf e)
@@ -120,13 +120,14 @@ derivingOf = uniq . typ . typeOf
         Bool   -> derivingBase <> enum
         Json   -> [DEq, DShow, DData, DTypeable, DGeneric, DHashable, DNFData]
 
-stream, string, num, frac, monoid, enum :: [Derive]
+stream, string, num, frac, monoid, enum, ord :: [Derive]
 stream = [DShow, DGeneric]
 string = [DOrd, DIsString]
 num    = DNum : DIntegral : DReal : enum
 frac   = [DOrd, DRealFrac, DRealFloat]
 monoid = [DMonoid, DSemigroup]
 enum   = [DOrd, DEnum, DBounded]
+ord    = [DOrd]
 
 derivingBase :: [Derive]
 derivingBase = [DEq, DRead, DShow, DData, DTypeable, DGeneric, DHashable, DNFData]

--- a/gen/template/_include/sum.ede
+++ b/gen/template/_include/sum.ede
@@ -3,19 +3,51 @@
 {% endif %}
 {{ shape.declaration }}
 
+{% for ctor in shape.constructors %}
+pattern {{ ctor.key }} :: {{ shape.name }}
+pattern {{ ctor.key }} = {{ shape.constructor }} "{{ ctor.value }}"
+
+{% endfor %}
+{-# COMPLETE
+{% for ctor in shape.constructors %}
+  {{ ctor.key }},
+{% endfor %}
+  {{ shape.constructor }} #-}
+
 instance FromText {{ shape.name }} where
-    parser = takeLowerText >>= \case
-      {% for ctor in shape.constructors %}
-        "{{ ctor.value | toLower }}" -> pure {{ ctor.key }}
-      {% endfor %}
-        e -> fromTextError $ "Failure parsing {{ shape.name }} from value: '" <> e
-           <> "'. Accepted values: {% for c in shape.constructors %}{{ c.value | toLower }}{% if !c.last %}, {% endif %}{%endfor %}"
+    parser = ({{ shape.constructor}} . mk) <$> takeText
 
 instance ToText {{ shape.name }} where
-    toText = \case
-      {% for ctor in shape.constructors %}
-        {{ ctor.key }} -> "{{ ctor.value }}"
-      {% endfor %}
+    toText ({{ shape.constructor }} ci) = original ci
+
+-- | Represents an enum of /known/ ${{shape.name}}.
+--   AWS may have added more since the source was generated.
+--   This instance exists only for backward compatibility.
+--   fromEnum is a partial function, and will error on values unknown at generation time.
+instance Enum {{ shape.name }} where
+    toEnum i = case i of
+        {% for ctor in shape.constructors %}
+        {{ ctor.index0 }} -> {{ ctor.key }}
+        {% endfor %}
+        _ -> (error . showText) $ "Unknown index for {{ shape.name }}: " <> toText i
+    fromEnum x = case x of
+        {% for ctor in shape.constructors %}
+        {{ ctor.key }} -> {{ ctor.index0 }}
+        {% endfor %}    
+        {{ shape.constructor }} name -> (error . showText) $ "Unknown {{ shape.name }}: " <> original name
+
+-- | Represents the bounds of /known/ ${{shape.name}}.
+--   AWS may have added more since the source was generated.
+--   This instance exists only for backward compatibility.
+instance Bounded {{ shape.name }} where
+    {% for ctor in shape.constructors %}
+    {% if ctor.first %}
+    minBound = {{ ctor.key }}
+    {% endif %}
+    {% if ctor.last %}
+    maxBound = {{ ctor.key }}
+    {% endif %}
+    {% endfor %}
 
 instance Hashable     {{ shape.name }}
 instance NFData       {{ shape.name }}

--- a/gen/template/_include/sum.ede
+++ b/gen/template/_include/sum.ede
@@ -20,35 +20,6 @@ instance FromText {{ shape.name }} where
 instance ToText {{ shape.name }} where
     toText ({{ shape.constructor }} ci) = original ci
 
--- | Represents an enum of /known/ ${{shape.name}}.
---   AWS may have added more since the source was generated.
---   This instance exists only for backward compatibility.
---   fromEnum is a partial function, and will error on values unknown at generation time.
-instance Enum {{ shape.name }} where
-    toEnum i = case i of
-        {% for ctor in shape.constructors %}
-        {{ ctor.index0 }} -> {{ ctor.key }}
-        {% endfor %}
-        _ -> (error . showText) $ "Unknown index for {{ shape.name }}: " <> toText i
-    fromEnum x = case x of
-        {% for ctor in shape.constructors %}
-        {{ ctor.key }} -> {{ ctor.index0 }}
-        {% endfor %}    
-        {{ shape.constructor }} name -> (error . showText) $ "Unknown {{ shape.name }}: " <> original name
-
--- | Represents the bounds of /known/ ${{shape.name}}.
---   AWS may have added more since the source was generated.
---   This instance exists only for backward compatibility.
-instance Bounded {{ shape.name }} where
-    {% for ctor in shape.constructors %}
-    {% if ctor.first %}
-    minBound = {{ ctor.key }}
-    {% endif %}
-    {% if ctor.last %}
-    maxBound = {{ ctor.key }}
-    {% endif %}
-    {% endfor %}
-
 instance Hashable     {{ shape.name }}
 instance NFData       {{ shape.name }}
 instance ToByteString {{ shape.name }}

--- a/gen/template/cabal.ede
+++ b/gen/template/cabal.ede
@@ -57,6 +57,7 @@ library
     build-depends:
           amazonka-core == {{ coreVersion }}.*
         , base          >= 4.7     && < 5
+        , case-insensitive
       {% for dep in extraDependencies %}
         , {{ dep.value }}
       {% endfor %}
@@ -83,6 +84,7 @@ test-suite {{ libraryName }}-test
         , {{ libraryName }}
         , base
         , bytestring
+        , case-insensitive
         , tasty
         , tasty-hunit
         , text

--- a/gen/template/types/sum.ede
+++ b/gen/template/types/sum.ede
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE LambdaCase         #-}
 {-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE PatternSynonyms    #-}
 
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
 
@@ -9,10 +10,17 @@
 
 {% include "_include/license.ede" %}
 --
-module {{ moduleName }} where
+module {{ moduleName }} (
+  {{ shape.name }} (
+    ..
+    {% for ctor in shape.constructors %}
+    , {{ ctor.key }}
+    {% endfor %}
+    )
+  ) where
 
 {% for import in moduleImports %}
 import {{ import.value }}
 {% endfor %}
-  
-{% include "_include/sum.ede" with shape = shape %}
+
+{% include "_include/sum.ede" %}


### PR DESCRIPTION
Sometimes, AWS introduces new values to its enums, which causes crashes when the Amazonka-generated sum types haven't caught up.  The encoding in this PR instead uses pattern synonyms over `CI String` for the known values, while permitting an unknown value.  For example:

```haskell
data PutMode = PutMode' (CI Text)
                 deriving (Eq, Ord, Read, Show, Data, Typeable,
                           Generic)

pattern Merge :: PutMode
pattern Merge = PutMode' "merge"

pattern Overwrite :: PutMode
pattern Overwrite = PutMode' "overwrite"

{-# COMPLETE
  Merge,
  Overwrite,
  PutMode' #-}
```

This should be source compatible.  We match values as before, but now get warnings if we don't handle unknown cases:

```haskell
pm :: PutMode -> Either Text Text
pm Merge = Right "M"
pm Overwrite = Right "O"
```

```
warning: [-Wincomplete-patterns]
    Pattern match(es) are non-exhaustive
    In an equation for ‘pm’: Patterns not matched: (PutMode' _)
   |
83 | pm Merge = "M"
   | ^^^^^^^^^^^^^^...
```

To make the code robust to new values, simply add the missing case:

```haskell
pm :: PutMode -> Either Text Text
pm Merge = Right "M"
pm Overwrite = Right "O"
pm (PutMode' m) = Left $ "Uh-oh, AWS added one: " <> (original m)
```

All instances are preserved for compatibility, though two of them become morally dubious in the presence of unknown values:

1. `fromEnum` becomes partial:

```haskell
instance Enum PutMode where
    toEnum i = case i of
        0 -> Merge
        1 -> Overwrite
        _ -> (error . showText) $ "Unknown index for PutMode: " <> toText i
    fromEnum x = case x of
        Merge -> 0
        Overwrite -> 1
        PutMode' name -> (error . showText) $ "Unknown PutMode: " <> original name
```

2. Our `Bounded` instance becomes a lie in the presence of unknown values:

```haskell
instance Bounded PutMode where
    minBound = Merge
    maxBound = Overwrite
```

```
> PutMode' (CI.mk "Aardvark") < minBound             
True
```

We've been running happily on this encoding for a couple months now.  I wanted to present it for consideration for 1.7, or maybe 2.0 if we want to think about pruning the problematic instances.
