### PR TITLE
Make AsError Typeable

### DIFF
--- a/core/src/Network/AWS/Types.hs
+++ b/core/src/Network/AWS/Types.hs
@@ -298,7 +298,7 @@ serviceMessage = lens _serviceMessage (\s a -> s { _serviceMessage = a })
 serviceRequestId :: Lens' ServiceError (Maybe RequestId)
 serviceRequestId = lens _serviceRequestId (\s a -> s { _serviceRequestId = a })
 
-class AsError a where
+class Typeable a => AsError a where
     -- | A general Amazonka error.
     _Error          :: Prism' a Error
     {-# MINIMAL _Error #-}


### PR DESCRIPTION
In order to be able to use [`catches`](https://hackage.haskell.org/package/exceptions-0.10.4/docs/Control-Monad-Catch.html#v:catches) and [`handler`](https://hackage.haskell.org/package/lens-4.19.2/docs/Control-Exception-Lens.html#v:handler), errors' lenses should be `Typeable`.

I have chosen to directly change `AsError` instead of each `Lens`es because all instances are already `Typeable` making the change less impacting.