### PR TITLE
Fix compilation with Cabal

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,6 @@
 packages: */
+
+source-repository-package
+  type: git
+  location: https://github.com/brendanhay/ede.git
+  tag: 5a8756c1b3105af55b055f78ea273d00620a6731

--- a/gen/amazonka-gen.cabal
+++ b/gen/amazonka-gen.cabal
@@ -82,7 +82,7 @@ executable amazonka-gen
         , formatting
         , free
         , hashable
-        , haskell-src-exts     >= 1.19.0 && < 1.24.0
+        , haskell-src-exts     >= 1.19.0 && < 1.22.0
         , html-conduit
         , lens
         , mtl


### PR DESCRIPTION
I believe this PR fixes two Cabal compilation errors.

Updating the `ede` dependency appears to fix this build error: https://travis-ci.org/github/brendanhay/amazonka/jobs/716818638#L4516-L4541  Is it acceptable to point to an untagged commit for the `ede` dependency?

The second error was caused by the absence of `ClassA` https://github.com/peterbecich/haskell-src-exts/blob/d24b20323a4fe20ce476c4914e19c6ebb2c46cb3/src/Language/Haskell/Exts/ExactPrint.hs#L1174 in `haskell-src-exts` >= 1.22

Tested with GHC 8.6.5

https://github.com/brendanhay/amazonka/issues/604 may be necessary