### PR TITLE
Document Service Description API Version

### DIFF
--- a/config/templates/cabal.ede
+++ b/config/templates/cabal.ede
@@ -13,9 +13,10 @@ build-type:            Simple
 cabal-version:         >= 1.10
 extra-source-files:    README.md fixture/*.yaml fixture/*.proto src/.gitkeep
 description:
+    Derived from API version @{{ apiVersion }}@ of the AWS service descriptions, licensed under Apache 2.0.
+    .
     The types from this library are intended to be used with <http://hackage.haskell.org/package/amazonka amazonka>,
-    which provides mechanisms for specifying AuthN/AuthZ information, sending requests,
-    and receiving responses.
+    which provides mechanisms for specifying AuthN/AuthZ information, sending requests, and receiving responses.
     .
     It is recommended to use generic lenses or optics from packages such as <https://hackage.haskell.org/package/generic-lens generic-lens> or <https://hackage.haskell.org/package/optics optics> to modify optional fields and deconstruct responses.
     .

--- a/config/templates/readme.ede
+++ b/config/templates/readme.ede
@@ -7,9 +7,8 @@
 
 
 ## Version
-
-`{{ libraryVersion }}`
-
+ 
+`{{ libraryVersion }}` - Derived from API version @{{ apiVersion }}@ of the AWS service descriptions, licensed under Apache 2.0.
 
 ## Description
 

--- a/config/templates/toc.ede
+++ b/config/templates/toc.ede
@@ -1,9 +1,9 @@
 {-# OPTIONS_GHC -fno-warn-unused-imports    #-}
 {-# OPTIONS_GHC -fno-warn-duplicate-exports #-}
 
--- Derived from AWS service descriptions, licensed under Apache 2.0.
-
 {% include "_include/license.ede" %}
+--
+-- Derived from API version @{{ apiVersion }}@ of the AWS service descriptions, licensed under Apache 2.0.
 --
 -- {{ documentation }}
 module {{ moduleName }}


### PR DESCRIPTION
Adds a note about the service description's api version used for generation to the README and cabal files, example:

Derived from API version `2019-07-12` of the AWS service descriptions, licensed under Apache 2.0.