### PR TITLE
Extend operationPlugins to Support Wildcards

### DIFF
--- a/config/services/glacier.json
+++ b/config/services/glacier.json
@@ -1,3 +1,6 @@
 {
-    "libraryName": "amazonka-glacier"
+    "libraryName": "amazonka-glacier",
+    "operationPlugins": {
+        "*": ["Request.glacierVersionHeader (Prelude._svcVersion defaultService)"]
+    }
 }

--- a/gen/src/Gen/Types/Config.hs
+++ b/gen/src/Gen/Types/Config.hs
@@ -120,6 +120,12 @@ makeClassy ''Versions
 data Config = Config
   { _libraryName :: Text,
     _operationModules :: [NS],
+    -- | Custom plugin functions to be applied to the generated 'AWSRequest.request'
+    -- instance body. Each function is of the form @Request a -> Request a@.
+    --
+    -- Using a wildcard key of @*@ in the configuration results in the plugins
+    -- being applied to _all_ operations. The wildcard is only applied if no
+    -- matching operation name is found in the map.
     _operationPlugins :: Map Id [Text],
     _typeModules :: [NS],
     _typeOverrides :: Map Id Override,


### PR DESCRIPTION
This is specifically to allow setting the `x-amz-glacier-version` header to Glacier's API version for every operation.

Closes #468