### PR TITLE
ci: Only build derivations not present in the cachix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
 
       - uses: cachix/install-nix-action@v12
         with:
+          nix_path: nixpkgs=channel:nixos-20.09
           extra_nix_config: |
             trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
             substituters = https://hydra.iohk.io https://cache.nixos.org/
@@ -35,4 +36,6 @@ jobs:
       - if: ${{ matrix.os != 'macos-latest' }}
         run: sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt &
 
-      - run: nix-build -A ci --argstr ghcVersion ${{ matrix.ghc }}
+      - run: |2
+          nix-shell -p nix-build-uncached --run \
+            'nix-build-uncached -A ci --argstr ghcVersion ${{ matrix.ghc }}'


### PR DESCRIPTION
`nix-build-uncached` morally does a `nix-build --dry-run`, parses out the list of derivations nix wants to build, and then does a real `nix build` of those derviations. We use it at work to prevent a cache-priming CI from downloading a bunch of stuff that it doesn't need to refetch.