### PR TITLE
Add Amazon SES V2 support, fixes #632

### DIFF
--- a/config/annexes/sesv2.json
+++ b/config/annexes/sesv2.json
@@ -1,0 +1,5 @@
+{
+    "metadata": {
+        "serviceAbbreviation": "SESv2"
+    }
+}

--- a/config/services/sesv2.json
+++ b/config/services/sesv2.json
@@ -1,0 +1,3 @@
+{
+    "libraryName": "amazonka-sesv2"
+}


### PR DESCRIPTION
This adds the config for Amazon SES v2, which already exists in the botocore lib and seems to work out of the box (I've not tested all methods, but it compiles and the api calls I tried succeed).

This fixes #632