### PR TITLE
Minimum GHC version supported is 8.6

### DIFF
--- a/amazonka-s3-encryption/amazonka-s3-encryption.cabal
+++ b/amazonka-s3-encryption/amazonka-s3-encryption.cabal
@@ -74,7 +74,7 @@ common base
     TypeFamilies
     ViewPatterns
 
-  build-depends:      base >=4.13 && <5
+  build-depends:      base >=4.12 && <5
 
 library
   import:          base

--- a/amazonka/amazonka.cabal
+++ b/amazonka/amazonka.cabal
@@ -69,7 +69,7 @@ common base
     TypeFamilies
     ViewPatterns
 
-  build-depends:      base >=4.13 && <5
+  build-depends:      base >=4.12 && <5
 
 library
   import:          base

--- a/config/templates/cabal.ede
+++ b/config/templates/cabal.ede
@@ -58,7 +58,7 @@ library
 
     build-depends:
           amazonka == {{ clientVersion }}.*
-        , base     >= 4.13 && < 5
+        , base     >= 4.12 && < 5
       {% for dep in extraDependencies %}
         , {{ dep.value }}
       {% endfor %}


### PR DESCRIPTION
This allows GHC 8.6 which is still widely supported in the ecosystem and there seems no reason to not allow it, since it builds and passes the test suite. My employer is currently using GHC 8.6 and it would be nice if we could upgrade amazonka before we switch compilers.

Tested by doing `cabal run -w ghc-8.6.5` in the `amazonka/amazonka` directory which ran the test suite, which passed.

Note that this is not only changing base versions but also adjusting [the note](https://github.com/brendanhay/amazonka/compare/develop...ysangkok:allow-ghc-8.6?expand=1#diff-8065007e4fa64061c955805c98352c64e5cb8544cf78ea45b241785ef17ce6eaL27) that specifies the minimum supported GHC version.