### PR TITLE
Add script to audit and generate missing service configurations

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -18,13 +18,8 @@ let
   inherit (pkgs.haskell-nix) haskellLib;
 
   packages = haskellLib.selectProjectPackages pkgs.cabalProject;
-  botocore = "${pkgs.sources.botocore}/botocore/data";
 
 in pkgs.cabalProject // {
-  models = (builtins.attrNames
-    (pkgs.lib.filterAttrs (_path: type: type == "directory")
-      (builtins.readDir botocore)));
-
   ci = {
     libraries = haskellLib.collectComponents' "library" packages;
     checks = builtins.mapAttrs (_: p: p.checks) packages;
@@ -44,17 +39,18 @@ in pkgs.cabalProject // {
     };
 
     buildInputs = [
+      pkgs.coreutils
       pkgs.nixfmt
-      pkgs.shfmt
-      pkgs.shellcheck
       pkgs.ormolu
       pkgs.parallel
+      pkgs.shellcheck
+      pkgs.shfmt
 
       (import pkgs.sources.niv { }).niv
     ];
 
     shellHook = ''
-      export BOTOCORE_PATH='${botocore}'
+      export BOTOCORE_PATH='${pkgs.sources.botocore}/botocore/data';
     '';
   };
 }

--- a/scripts/generate-configs
+++ b/scripts/generate-configs
@@ -1,0 +1,67 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash ../shell.nix
+
+# Usage: generate-configs OUTPUT
+#
+# Generates configuration for all services found in BOTOCORE_PATH that
+# are missing corresponding configurations in ./config/services.
+#
+# The example configurations will be written to individual files under
+# OUTPUT/configs and OUTPUT/annexes.
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+botocore="${BOTOCORE_PATH?}"
+services="config/services"
+output="${1?An OUTPUT argument is required}"
+configs="$output/configs"
+annexes="$output/annexes"
+
+available=()
+configured=()
+unconfigured=0
+
+# Output a message to stderr.
+say() {
+  echo >&2 "$@"
+}
+
+# Write an example configuration and annex to name.json.
+write_config() {
+  local -r name="$1"
+  local -r config="$configs/$name.json"
+  local -r annex="$annexes/$name.json"
+
+  say "Missing $name"
+
+  jq -n --arg name "$name" '{ libraryName: $name }' >"$config"
+  jq -n --arg name "$name" '{}' >"$annex"
+}
+
+for path in "${botocore}"/*/; do
+  model="${path%/}"
+  model="${model##*/}"
+  available+=("$model")
+done
+
+for path in "${services}"/*.json; do
+  model="${path##*/}"
+  model="${model%%.*}"
+  configured+=("$model")
+done
+
+mkdir -p "$configs" "$annexes"
+
+for name in $(comm -13 <(printf "%s\n" "${configured[@]}" | sort) <(printf "%s\n" "${available[@]}" | sort)); do
+  unconfigured=$((unconfigured + 1))
+  write_config "$name"
+done
+
+say "\
+Missing $unconfigured service configurations.
+Wrote examples to $configs and $annexes.
+Found ${#available[@]} models in $botocore.
+Found ${#configured[@]} service configurations in $services.
+Done."


### PR DESCRIPTION
Adds simplistic audit functionality from `generate.nix` that was removed in #639. Additionally, it now writes example skeleton configurations and annexes to the output directory specified by the singular script argument.

Example:

```bash
% generate-configs tmp
...
Missing wafv2
Missing wellarchitected
Missing wisdom
Missing worklink
Missing workmailmessageflow
Missing 141 service configurations.
Wrote examples to tmp/configs and tmp/annexes.
Found 281 models in /nix/store/bvn31qxjpffkaa5misrb8y0kxphhy0gw-source/botocore/data.
Found 140 service configurations in config/services.
Done.
```

The reason for also generating an empty annex file is illustrated by testing with the currently unsupported `textract` service (#509) - it requires `metadata.serviceAbbreviation` to be specified since it's missing from the definition and this is used to infer the root module namespace. At some point in the future I'll get around to merging the configurations to remove the need for annex at all.
