### PR TITLE
ci: Add -build-flags "-L --keep-going" to nix-build-uncached

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,6 @@ jobs:
       - if: ${{ matrix.os != 'macos-latest' }}
         run: sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt &
 
-      - run: |2
-          nix-shell -p nix-build-uncached --run \
-            'nix-build-uncached -A ci --argstr ghcVersion ${{ matrix.ghc }}'
+      - run: "nix-env -f '<nixpkgs>' -iA nix-build-uncached"
+
+      - run: "nix-build-uncached -build-flags '-L --keep-going' -A ci --argstr ghcVersion ${{ matrix.ghc }}"


### PR DESCRIPTION
This causes `nix-build-uncached` to emit logs, and to build (and therefore cache) as much as possible on each CI run.

The theory is that on a hot cache, it should be easier to find out what went wrong because you should only see build logs of broken things.