### PR TITLE
gen: Correct generator invocation example

### DIFF
--- a/gen/README.md
+++ b/gen/README.md
@@ -10,4 +10,4 @@ actual generator code/logic changes.
 
 Generate all models:
 
-    $ nix-build generate.nix
+    $ ./scripts/generate


### PR DESCRIPTION
I know `generate.nix` went away, but is this the correct invocation?