### PR TITLE
amazonka-autoscaling: AutoScalingGroupName should be optional

### DIFF
--- a/amazonka/CHANGELOG.md
+++ b/amazonka/CHANGELOG.md
@@ -54,6 +54,8 @@ Released: **unreleased**, Compare: 2.0 RC1 (TODO: Linkify)
 [\#625](https://github.com/brendanhay/amazonka/pull/625)
 - Duplicate files that differ only in case have been removed
 [\#637](https://github.com/brendanhay/amazonka/pull/637)
+- `amazonka-autoscaling`: `AutoScalingGroupName` is optional in `Activity` structures
+[\#648](https://github.com/brendanhay/amazonka/pull/648)
 - S3 object sizes are now `Integer` instead of `Int`
 [\#649](https://github.com/brendanhay/amazonka/pull/649)
 

--- a/config/services/autoscaling.json
+++ b/config/services/autoscaling.json
@@ -1,6 +1,11 @@
 {
     "libraryName": "amazonka-autoscaling",
     "typeOverrides": {
+        "Activity": {
+            "optionalFields": [
+                "AutoScalingGroupName"
+            ]
+        },
         "AutoScalingGroup": {
             "optionalFields": [
                 "LaunchConfigurationName"


### PR DESCRIPTION
Boto is lying, and the sample response does not include this field.
http://docs.aws.amazon.com/AutoScaling/latest/APIReference/API_TerminateInstanceInAutoScalingGroup.html#API_TerminateInstanceInAutoScalingGroup_Examples

Closes #342 