### PR TITLE
[#651] Allow 'profile ' in `~/.aws/config` file sections

### DIFF
--- a/amazonka/CHANGELOG.md
+++ b/amazonka/CHANGELOG.md
@@ -58,6 +58,8 @@ Released: **unreleased**, Compare: 2.0 RC1 (TODO: Linkify)
 [\#648](https://github.com/brendanhay/amazonka/pull/648)
 - S3 object sizes are now `Integer` instead of `Int`
 [\#649](https://github.com/brendanhay/amazonka/pull/649)
+- Fix getting regions from named profiles
+[\#654](https://github.com/brendanhay/amazonka/pull/654)
 
 ### Other Changes
 

--- a/amazonka/src/Network/AWS/Auth.hs
+++ b/amazonka/src/Network/AWS/Auth.hs
@@ -514,11 +514,12 @@ fromFilePath profile cred conf =
         else do
           ini <- INI.readIniFile path >>= either (throwInvalid path Nothing) pure
 
-          let regionValueE =
-                INI.lookupValue profile confRegion ini
-                <> INI.lookupValue ("profile " <> profile) confRegion ini
+          let configProfile =
+                if profile == "default"
+                then profile
+                else "profile " <> profile
 
-          case regionValueE of
+          case INI.lookupValue configProfile confRegion ini of
             Left _ -> pure Nothing
             Right regionValue ->
               case fromText regionValue of

--- a/amazonka/src/Network/AWS/Auth.hs
+++ b/amazonka/src/Network/AWS/Auth.hs
@@ -514,10 +514,14 @@ fromFilePath profile cred conf =
         else do
           ini <- INI.readIniFile path >>= either (throwInvalid path Nothing) pure
 
-          case INI.lookupValue profile confRegion ini of
-            Left _ -> empty
-            Right value ->
-              case fromText value of
+          let regionValueE =
+                INI.lookupValue profile confRegion ini
+                <> INI.lookupValue ("profile " <> profile) confRegion ini
+
+          case regionValueE of
+            Left _ -> pure Nothing
+            Right regionValue ->
+              case fromText regionValue of
                 Left err -> liftIO (throwInvalid path (Just confRegion) err)
                 Right ok -> pure (Just ok)
 


### PR DESCRIPTION
closes #651 