### PR TITLE
amazonka-rds: Support DestinationRegion pseudo-parameter

### DIFF
--- a/amazonka/CHANGELOG.md
+++ b/amazonka/CHANGELOG.md
@@ -58,6 +58,8 @@ Released: **unreleased**, Compare: 2.0 RC1 (TODO: Linkify)
 [\#648](https://github.com/brendanhay/amazonka/pull/648)
 - S3 object sizes are now `Integer` instead of `Int`
 [\#649](https://github.com/brendanhay/amazonka/pull/649)
+- amazonka-rds now supports the `DestinationRegion` pseudo-parameter for cross-region requests
+[\#661](https://github.com/brendanhay/amazonka/pull/661)
 
 ### Other Changes
 

--- a/config/annexes/rds.json
+++ b/config/annexes/rds.json
@@ -1,5 +1,47 @@
 {
     "metadata": {
         "serviceAbbreviation": "RDS"
+    },
+    "shapes": {
+        "CopyDBClusterSnapshotMessage": {
+            "members": {
+                "DestinationRegion": {
+                    "shape": "String",
+                    "documentation": "Pseudo-parameter used when populating the <code>PreSignedUrl</code> of a cross-region <code>CopyDBClusterSnapshot</code> request. To replicate from region <code>SRC</code> to region <code>DST</code>, send a request to region <code>DST</code>. In that request, pass a <code>PreSignedUrl</code> for region <code>SRC</code> with <code>DestinationRegion</code> set to region <code>DST</code>."
+                }
+            }
+        },
+        "CreateDBClusterMessage": {
+            "members": {
+                "DestinationRegion": {
+                    "shape": "String",
+                    "documentation": "Pseudo-parameter used when populating the <code>PreSignedUrl</code> of a cross-region <code>CreateDBCluster</code> request. To replicate from region <code>SRC</code> to region <code>DST</code>, send a request to region <code>DST</code>. In that request, pass a <code>PreSignedUrl</code> for region <code>SRC</code> with <code>DestinationRegion</code> set to region <code>DST</code>."
+                }
+            }
+        },
+        "CopyDBSnapshotMessage": {
+            "members": {
+                "DestinationRegion": {
+                    "shape": "String",
+                    "documentation": "Pseudo-parameter used when populating the <code>PreSignedUrl</code> of a cross-region <code>CopyDBSnapshot</code> request. To replicate from region <code>SRC</code> to region <code>DST</code>, send a request to region <code>DST</code>. In that request, pass a <code>PreSignedUrl</code> for region <code>SRC</code> with <code>DestinationRegion</code> set to region <code>DST</code>."
+                }
+            }
+        },
+        "CreateDBInstanceReadReplicaMessage": {
+            "members": {
+                "DestinationRegion": {
+                    "shape": "String",
+                    "documentation": "Pseudo-parameter used when populating the <code>PreSignedUrl</code> of a cross-region <code>CreateDBInstanceReadReplica</code> request. To replicate from region <code>SRC</code> to region <code>DST</code>, send a request to region <code>DST</code>. In that request, pass a <code>PreSignedUrl</code> for region <code>SRC</code> with <code>DestinationRegion</code> set to region <code>DST</code>."
+                }
+            }
+        },
+        "StartDBInstanceAutomatedBackupsReplicationMessage": {
+            "members": {
+                "DestinationRegion": {
+                    "shape": "String",
+                    "documentation": "Pseudo-parameter used when populating the <code>PreSignedUrl</code> of a cross-region <code>StartDBInstanceAutomatedBackupsReplication</code> request. To replicate from region <code>SRC</code> to region <code>DST</code>, send a request to region <code>DST</code>. In that request, pass a <code>PreSignedUrl</code> for region <code>SRC</code> with <code>DestinationRegion</code> set to region <code>DST</code>."
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Cross-region replication on RDS is performed by making a request
against the _destination_ region. In that request, you need to pass a
`PreSignedUrl` for the _source_ region, with the `DestionationRegion`
parameter set to the _destination_ region.

There are five such requests at the moment, specified by

https://github.com/boto/botocore/blob/77359646878e261eaa9debad888fc8f3b20832ef/botocore/data/rds/2014-10-31/service-2.sdk-extras.json

These specify a `SourceRegion` parameter because botocore rearranges
the rds requests internally, stripping `SourceRegion` from the request
itself and injecting a `DestinationRegion` parameter into the
`PreSignedUrl` field:

https://github.com/boto/botocore/blob/ec0eb680d6e6e753c7d7ddf0242b8ae1c3b38db5/botocore/handlers.py#L1080-L1089

Fixes #378