### PR TITLE
cognito-idp: optional UserPoolAddOnsType.AdvancedSecurityMode

### DIFF
--- a/amazonka/CHANGELOG.md
+++ b/amazonka/CHANGELOG.md
@@ -60,6 +60,8 @@ Released: **unreleased**, Compare: 2.0 RC1 (TODO: Linkify)
 [\#649](https://github.com/brendanhay/amazonka/pull/649)
 - amazonka-rds now supports the `DestinationRegion` pseudo-parameter for cross-region requests
 [\#661](https://github.com/brendanhay/amazonka/pull/661)
+- `amazonka-cognito-idp`: `UserPoolAddOnsType.AdvancedSecurityMode` is optional for unparsing's sake
+[\#662](https://github.com/brendanhay/amazonka/pull/662)
 
 ### Other Changes
 

--- a/config/services/cognito-idp.json
+++ b/config/services/cognito-idp.json
@@ -1,3 +1,10 @@
 {
-    "libraryName": "amazonka-cognito-idp"
+    "libraryName": "amazonka-cognito-idp",
+    "typeOverrides": {
+        "UserPoolAddOnsType": {
+            "optionalFields": [
+                "AdvancedSecurityMode"
+            ]
+        }
+    }
 }


### PR DESCRIPTION
If a `CreateUserPool` call is sent to Cognito with no `UserPoolAddOns`
set, Cognito will return `"UserPoolAddOns": {}`, which causes
deserialisation failure.

Closes #473.