### PR TITLE
examples: Make them compile again

### DIFF
--- a/examples/amazonka-examples.cabal
+++ b/examples/amazonka-examples.cabal
@@ -34,7 +34,6 @@ library
   build-depends:
     , amazonka              >=1.6.1 && <1.6.2
     , amazonka-apigateway
-    , amazonka-core
     , amazonka-dynamodb
     , amazonka-ec2
     , amazonka-s3
@@ -44,6 +43,7 @@ library
     , conduit
     , conduit-extra
     , exceptions
+    , generic-lens
     , lens
     , semigroups
     , text

--- a/examples/src/Example/ExceptionSemantics.hs
+++ b/examples/src/Example/ExceptionSemantics.hs
@@ -1,4 +1,7 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Module      : Example.ExceptionSemantics
@@ -13,15 +16,13 @@ import Control.Exception.Lens
 import Control.Lens
 import Control.Monad.Catch
 import Control.Monad.IO.Class
-import Control.Monad.Trans.AWS
 import Data.Conduit
 import qualified Data.Conduit.List as CL
+import Data.Generics.Product
 import Data.List.NonEmpty (NonEmpty (..))
-import Data.Monoid
-import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
-import Network.AWS.Data
+import Network.AWS
 import Network.AWS.DynamoDB
 import System.IO
 
@@ -33,38 +34,36 @@ exceptions ::
   IO ()
 exceptions r n = do
   lgr <- newLogger Info stdout
-  env <- newEnv Discover <&> set envLogger lgr
+  env <- newEnv Discover <&> set (field @"envLogger") lgr . within r
 
-  let scan' = scan n & sAttributesToGet ?~ "foo" :| []
+  let scan = newScan n & field @"attributesToGet" ?~ "foo" :| []
 
   runResourceT $ do
-    runAWST env . within r $ do
-      sayLn $ "Listing all tables in region " <> toText r
-      paginate listTables
-        =$= CL.concatMap (view ltrsTableNames)
-          $$ CL.mapM_ (sayLn . mappend "Table: ")
+    sayLn $ "Listing all tables in region " <> toText r
+    runConduit $ paginate env newListTables
+      .| CL.concatMap (view (field @"tableNames" . _Just))
+      .| CL.mapM_ (sayLn . mappend "Table: ")
 
-      say "Throwing deliberate IOError ... "
-      Left _ <-
-        trying _IOException $
-          throwM (userError "deliberate!")
-      sayLn "OK!"
+    say "Throwing deliberate IOError ... "
+    Left _ <-
+      trying _IOException $
+        throwM (userError "deliberate!")
+    sayLn "OK!"
 
-      say $ "Performing table scan of " <> n <> " using 'send' ... "
-      s <- try $ send scan'
-      sayLn "OK!"
+    say $ "Performing table scan of " <> n <> " using 'send' ... "
+    s <- try $ send env scan
+    sayLn "OK!"
 
-      say "Displaying error while scanning using 'paginate': "
-      display s
+    say "Displaying error while scanning using 'paginate': "
+    display s
 
-      say $ "Performing table scan of " <> n <> " using 'paginate': "
-      p <- try $ paginate scan' $$ CL.consume
-      sayLn "OK!"
+    say $ "Performing table scan of " <> n <> " using 'paginate': "
+    p <- try . runConduit $ paginate env scan .| CL.consume
+    sayLn "OK!"
 
-      say "Displaying error while scanning using 'paginate': "
-      display p
+    say "Displaying error while scanning using 'paginate': "
+    display p
 
-    sayLn "Exited AWST scope."
   sayLn "Exited ResourceT scope."
 
 display :: (MonadIO m, Show a) => Either SomeException a -> m ()


### PR DESCRIPTION
We'll need to do this at some point, and it'll help the fellow in #664.

I haven't actually _run_ any of them, just chased type errors until `ghicd` said `All good`.

Summary of changes:

* Anything that creates a request (like `putItem`) is now `newPutItem`.
* Lenses into a structure are replaced with `generic-lens`' `field`: `piFooBar` -> `field @"fooBar"`
* `env` is passed into `send`/`paginate`/etc directly; I suspect downstream projects will want to bake it into their environment directly instead of using the (departed, clunky) `MonadAWS` stuff (which has deservedly been removed). Then they'll need to wrap `amazonka`'s `send` with their own version which pulls from their monad stack.
* `within` is now applied directly to the `env` - projects storing an `Env` in their monad stack may want to use `local`.
* More fields contain `Maybe`, so apply some `_Just`ice.

Ping @cmdv - relevant to your migration ; @ketzacoatl - you were thinking about writing migration docs.

Closes #642.