### PR TITLE
Revert "cognito-idp: optional UserPoolAddOnsType.AdvancedSecurityMode"

### DIFF
--- a/amazonka/CHANGELOG.md
+++ b/amazonka/CHANGELOG.md
@@ -62,8 +62,6 @@ Released: **unreleased**, Compare: 2.0 RC1 (TODO: Linkify)
 [\#654](https://github.com/brendanhay/amazonka/pull/654)
 - amazonka-rds now supports the `DestinationRegion` pseudo-parameter for cross-region requests
 [\#661](https://github.com/brendanhay/amazonka/pull/661)
-- `amazonka-cognito-idp`: `UserPoolAddOnsType.AdvancedSecurityMode` is optional for unparsing's sake
-[\#662](https://github.com/brendanhay/amazonka/pull/662)
 
 ### Other Changes
 

--- a/config/services/cognito-idp.json
+++ b/config/services/cognito-idp.json
@@ -1,10 +1,3 @@
 {
-    "libraryName": "amazonka-cognito-idp",
-    "typeOverrides": {
-        "UserPoolAddOnsType": {
-            "optionalFields": [
-                "AdvancedSecurityMode"
-            ]
-        }
-    }
+    "libraryName": "amazonka-cognito-idp"
 }


### PR DESCRIPTION
Reverts brendanhay/amazonka#662

In https://github.com/boto/botocore/issues/2514 , @stobrien89 asked me to double-check that AWS was generating bogus `UserPoolAddOns` in the `CreateUserResponse`. It is not, so this "fix" shouldn't exist.