### PR TITLE
Revert "amazonka-autoscaling: AutoScalingGroupName should be optional"

### DIFF
--- a/amazonka/CHANGELOG.md
+++ b/amazonka/CHANGELOG.md
@@ -54,8 +54,6 @@ Released: **unreleased**, Compare: 2.0 RC1 (TODO: Linkify)
 [\#625](https://github.com/brendanhay/amazonka/pull/625)
 - Duplicate files that differ only in case have been removed
 [\#637](https://github.com/brendanhay/amazonka/pull/637)
-- `amazonka-autoscaling`: `AutoScalingGroupName` is optional in `Activity` structures
-[\#648](https://github.com/brendanhay/amazonka/pull/648)
 - S3 object sizes are now `Integer` instead of `Int`
 [\#649](https://github.com/brendanhay/amazonka/pull/649)
 - Fix getting regions from named profiles

--- a/config/services/autoscaling.json
+++ b/config/services/autoscaling.json
@@ -1,11 +1,6 @@
 {
     "libraryName": "amazonka-autoscaling",
     "typeOverrides": {
-        "Activity": {
-            "optionalFields": [
-                "AutoScalingGroupName"
-            ]
-        },
         "AutoScalingGroup": {
             "optionalFields": [
                 "LaunchConfigurationName"


### PR DESCRIPTION
Reverts brendanhay/amazonka#648

When I sent this request:

```
Action=TerminateInstanceInAutoScalingGroup&InstanceId=i-07a5806dcc427bd75&ShouldDecrementDesiredCapacity=false&Version=2011-01-01
```

AWS responded with:

```
<TerminateInstanceInAutoScalingGroupResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
  <TerminateInstanceInAutoScalingGroupResult>
    <Activity>
      <Description>Terminating EC2 instance: i-07a5806dcc427bd75</Description>
      <Cause>At 2021-10-06T20:22:57Z instance i-07a5806dcc427bd75 was taken out of service in response to a user request.</Cause>
      <ActivityId>2c35f15d-17fc-02d7-8d5c-3238170a50e5</ActivityId>
      <AutoScalingGroupName>test-asg</AutoScalingGroupName>
      <Progress>0</Progress>
      <StartTime>2021-10-06T20:22:57.536Z</StartTime>
      <Details>{&quot;Subnet ID&quot;:&quot;subnet-7c77841a&quot;,&quot;Availability Zone&quot;:&quot;ap-southeast-2b&quot;}</Details>
      <StatusCode>InProgress</StatusCode>
    </Activity>
  </TerminateInstanceInAutoScalingGroupResult>
  <ResponseMetadata>
    <RequestId>355914bb-5d46-4b49-87cc-d2b1522881f4</RequestId>
  </ResponseMetadata>
</TerminateInstanceInAutoScalingGroupResponse>
```

Note that AWS is now responding with an `<AutoScalingGroupName>` element.