### PR TITLE
Update versions of things

### DIFF
--- a/gen/amazonka-gen.cabal
+++ b/gen/amazonka-gen.cabal
@@ -125,11 +125,11 @@ executable amazonka-gen
     , formatting
     , free
     , hashable
-    , haskell-src-exts      >=1.19.0 && <1.22
+    , haskell-src-exts      ^>=1.23
     , lens
     , mtl
     , optparse-applicative
-    , pandoc                ^>=2.13
+    , pandoc                >=2.13 && < 2.15
     , scientific
     , system-fileio
     , system-filepath

--- a/gen/src/Gen/AST/Data/Syntax.hs
+++ b/gen/src/Gen/AST/Data/Syntax.hs
@@ -161,7 +161,7 @@ lensD type' f = Exts.sfun (ident l) [] (unguarded rhs) Exts.noBinds
 
 errorS :: Text -> Decl
 errorS n =
-  let cxt = Exts.CxSingle () (Exts.ClassA () (unqual "Core.AsError") [tyvar "a"])
+  let cxt = Exts.CxSingle () (Exts.TypeA () $ tycon "Core.AsError" `tyapp` tyvar "a")
       forall = Exts.TyForall () Nothing (Just cxt)
    in Exts.TypeSig () [ident n] . forall $
         tycon "Lens.Getting"

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "boto",
         "repo": "botocore",
-        "rev": "f1d41183e0fad31301ad7331a8962e3af6359a22",
-        "sha256": "1xz6bysc70642bnw59bfh5cgdywa6hj147ra1n9lrl2vkvpf4fwj",
+        "rev": "6de7bb75238743217f009fbcdd54ee75a48b1e8b",
+        "sha256": "1cn5jjvniilldx0sradc3y190x7n74ngqlvgmd6vn49g2vrskjyy",
         "type": "tarball",
-        "url": "https://github.com/boto/botocore/archive/f1d41183e0fad31301ad7331a8962e3af6359a22.tar.gz",
+        "url": "https://github.com/boto/botocore/archive/6de7bb75238743217f009fbcdd54ee75a48b1e8b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "hackage.nix": {
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "aa77b359c6b0c9ba1433aefde5d2233b40497ddc",
-        "sha256": "1pal7kgnmlwqsysl6887x887lqmjawa9k1nkci8w639xh82vps8b",
+        "rev": "3cb86e863a5403b12572a7d48b87a4b921946c1b",
+        "sha256": "1x0vpdp14n8y2hwvzg4hnc1zyzw1wyi2s1rcy8v26aqblmbzh30z",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/hackage.nix/archive/aa77b359c6b0c9ba1433aefde5d2233b40497ddc.tar.gz",
+        "url": "https://github.com/input-output-hk/hackage.nix/archive/3cb86e863a5403b12572a7d48b87a4b921946c1b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell.nix": {
@@ -29,10 +29,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "87a4143ea9b78a7f9bbb765fee648e3be3813b20",
-        "sha256": "0v42vrb7j8vw086pyim897g2bp10lpkwk8ha225rfdzmwm51bq58",
+        "rev": "f8d4795cfea54312728ec018aa95b255b811de90",
+        "sha256": "0s6qmdm948b9hmb6ssb5y0qxi4idw4fxy4pill1wl1z4brbx30ia",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/87a4143ea9b78a7f9bbb765fee648e3be3813b20.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/f8d4795cfea54312728ec018aa95b255b811de90.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {
@@ -41,10 +41,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "af958e8057f345ee1aca714c1247ef3ba1c15f5e",
-        "sha256": "1qjavxabbrsh73yck5dcq8jggvh3r2jkbr6b5nlz5d9yrqm9255n",
+        "rev": "65a61b147f307d24bfd0a5cd56ce7d7b7cc61d2e",
+        "sha256": "17mirpsx5wyw262fpsd6n6m47jcgw8k2bwcp1iwdnrlzy4dhcgqh",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/af958e8057f345ee1aca714c1247ef3ba1c15f5e.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/65a61b147f307d24bfd0a5cd56ce7d7b7cc61d2e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
Ran `cabal outdated` on `amazonka/`, `examples/`, `gen/`, and `test/`. `haskell-src-exts` broke compatibility, so fix it. `pandoc` worked without changes, so raise bounds.

Pull in new versions of all the nix dependencies so we get latest botocore and hackage..

Fixes #676 
Fixes #660 