### PR TITLE
Stop chunked bodies causing empty ContentEncoding metadata in S3

### DIFF
--- a/amazonka/CHANGELOG.md
+++ b/amazonka/CHANGELOG.md
@@ -64,6 +64,8 @@ Released: **unreleased**, Compare: 2.0 RC1 (TODO: Linkify)
 [\#669](https://github.com/brendanhay/amazonka/pull/669)
 - Fixed S3 to use vhost endpoints, parse `LocationConstraint`s properly, and ensure `Content-MD5` header correctly set.
 [\#673](https://github.com/brendanhay/amazonka/pull/673)
+- Fixed S3 to not set empty `Content-Encoding`, and to be able to set `Content-Encoding` without breaking signing
+[\#681](https://github.com/brendanhay/amazonka/pull/681)
 
 
 ### Other Changes


### PR DESCRIPTION
https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html
says that chunked requests should set `Content-Encoding: aws-chunked`.
S3 strips any occurrence of `aws-chunked` from that header, and stores
the remainder as the `ContentEncoding` metadata on the object. It
isn't very smart about this: if `aws-chunked` is the only encoding
listed, S3 will store the empty string as the encoding, which breaks
some HTTP clients and CDNs.

Multiple AWS SDKs appear to have hit this issue, and the developers of
`fog` contacted AWS support. Their suggestion was to omit the
`Content-Encoding:` header entirely because S3 is capable of figuring
it out: https://github.com/fog/fog-aws/pull/147

*****

Fixes #536 - I tested by uploading a file >8192 bytes using 8192-byte chunks and performing `aws s3api head-object` on the result.
Fixes #537 - I tested by uploading a file >8192 bytes using 8192-byte chunks with `field @"contentEncoding" ?~ "identity"` and opening the file in the browser (using the "Open" link in the S3 console). I also gzipped my test file into `test_file.txt.gz` (it was still >8192b after compression), uploaded it to `test_file.txt` with `field @"contentEncoding" ?~ "gzip"` and checked the headers using `curl` - it sent it back to me in compressed form, with `Content-Encoding: gzip` in the response headers.