### PR TITLE
Use `coerced` from lens instead of making our own

### DIFF
--- a/gen/src/Gen/AST/Data/Syntax.hs
+++ b/gen/src/Gen/AST/Data/Syntax.hs
@@ -934,9 +934,9 @@ iso :: TType -> Maybe Exp
 iso = \case
   TLit Time -> Just (var "Core._Time")
   TLit Base64 -> Just (var "Core._Base64")
-  TMap {} -> Just (var "Lens._Coerce")
-  TList1 {} -> Just (var "Lens._Coerce")
-  TList {} -> Just (var "Lens._Coerce")
+  TMap {} -> Just (var "Lens.coerced")
+  TList1 {} -> Just (var "Lens.coerced")
+  TList {} -> Just (var "Lens.coerced")
   TSensitive x -> Just (infixE (var "Core._Sensitive") "Prelude.." (maybeToList (iso x)))
   _ -> Nothing
 

--- a/lib/amazonka/src/Network/AWS/Lens.hs
+++ b/lib/amazonka/src/Network/AWS/Lens.hs
@@ -5,11 +5,7 @@
 -- Maintainer  : Brendan Hay <brendan.g.hay+amazonka@gmail.com>
 -- Stability   : provisional
 -- Portability : non-portable (GHC extensions)
-module Network.AWS.Lens
-  ( module Export,
-    _Coerce,
-  )
-where
+module Network.AWS.Lens (module Export) where
 
 import Control.Exception.Lens as Export
   ( catching,
@@ -34,6 +30,7 @@ import Control.Lens as Export
     Traversal',
     allOf,
     anyOf,
+    coerced,
     concatOf,
     filtered,
     folding,
@@ -62,7 +59,3 @@ import Control.Lens as Export
     _Just,
     _last,
   )
-import Data.Coerce (Coercible, coerce)
-
-_Coerce :: (Coercible a b, Coercible b a) => Iso' a b
-_Coerce = iso coerce coerce


### PR DESCRIPTION
Lens has provided a `coerced` `Iso` since 4.13, so we probably don't need to use our own.

I kept the `Network.AWS.Lens` module to avoid adding `lens` into the template of every service, and to only bring in the set of identifiers that we care about when using lens stuff in generated code. Happy to remove the module entirely if you think that's better.

I did a generate-and-test locally; it seems to work.