### PR TITLE
gen: handle suffixes with numbers in them again

### DIFF
--- a/gen/src/Gen/Text.hs
+++ b/gen/src/Gen/Text.hs
@@ -49,7 +49,11 @@ stripSuffix :: Text -> Text -> Text
 stripSuffix s t = Text.strip . fromMaybe t $ s `Text.stripSuffix` t
 
 renameOperation :: Text -> Text
-renameOperation = Text.dropWhileEnd (not . Char.isAlpha)
+renameOperation t
+  | "S3" `Text.isSuffixOf` t = t
+  | "EC2" `Text.isSuffixOf` t = t
+  | "V2" `Text.isSuffixOf` t = t -- e.g. "ListObjectsV2"
+  | otherwise = Text.dropWhileEnd (not . Char.isAlpha) t
 
 renameServiceFunction :: Text -> Text
 renameServiceFunction _n = "defaultService"


### PR DESCRIPTION
This is probably the best compromise - we can't `takeWhile isAlphaNum`
because that captures many operations that have datestamps in them.

Fixes #698 - Once ListObjectsV2 gets the correct name again, it gets its `AWSPager` instance back.