### PR TITLE
Unsigned requests

### DIFF
--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -22,7 +22,6 @@ Released: **22nd October, 2021**, Compare: [1.6.1](https://github.com/brendanhay
 
 - CI
   - Nix, Bazel, and GitHub Actions are used for CI
-  - `nix-build-uncached` is used to prevent spurious rebuilds in CI [#627](https://github.com/brendanhay/amazonka/pull/627)
   - CPP supporting GHC < 8.8 has been removed.
   - While GHC 8.6 is not in the CI matrix, it currently builds, so packages depend on `base >= 4.12`.
 

--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -28,6 +28,8 @@ Released: **22nd October, 2021**, Compare: [1.6.1](https://github.com/brendanhay
 
 ### Fixed
 
+- It is now possible to make unsigned requests. Useful for [`sts:AssumeRoleWithWebIdentity`](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html)
+[\#707](https://github.com/brendanhay/amazonka/pull/707)
 - Fix trailing slash bug in gen model
 [\#528](https://github.com/brendanhay/amazonka/pull/528)
 - Close connections immediately (when we know that we can)

--- a/lib/amazonka/src/Amazonka.hs
+++ b/lib/amazonka/src/Amazonka.hs
@@ -528,7 +528,7 @@ presign ::
 presign env time expires rq =
   Presign.presignWith
     (appEndo (getDual (Env.envOverride env)))
-    (Env.envAuth env)
+    (fromMaybe (error "Amazonka.presign: Env with no Auth") $ Env.envAuth env)
     (Env.envRegion env)
     time
     expires

--- a/lib/amazonka/src/Amazonka/Env.hs
+++ b/lib/amazonka/src/Amazonka/Env.hs
@@ -45,7 +45,7 @@ data Env = Env
     envRetryCheck :: Int -> Client.HttpException -> Bool,
     envOverride :: Dual (Endo Service),
     envManager :: Client.Manager,
-    envAuth :: Auth
+    envAuth :: Maybe Auth
   }
   deriving stock (Generic)
 

--- a/lib/amazonka/src/Amazonka/Types.hs
+++ b/lib/amazonka/src/Amazonka/Types.hs
@@ -52,6 +52,7 @@ module Amazonka.Types
     requestBody,
     requestSign,
     requestPresign,
+    requestUnsigned,
 
     -- * Retries
     Retry (..),
@@ -426,7 +427,7 @@ instance ToLog Meta where
 
 -- | A signed 'ClientRequest' and associated metadata specific
 -- to the signing algorithm, tagged with the initial request type
--- to be able to obtain the associated response, 'Rs a'.
+-- to be able to obtain the associated response, @'AWSResponse' a@.
 data Signed a = Signed
   { signedMeta :: Meta,
     signedRequest :: ClientRequest
@@ -503,6 +504,20 @@ requestSign x = signerSign (_serviceSigner (_requestService x)) x
 
 requestPresign :: Seconds -> Algorithm a
 requestPresign ex x = signerPresign (_serviceSigner (_requestService x)) ex x
+
+-- | Create an unsigned 'ClientRequest'. You will almost never need to do this.
+requestUnsigned :: Request a -> Region -> ClientRequest
+requestUnsigned Request {..} r =
+  (newClientRequest end _serviceTimeout)
+    { Client.method = toBS _requestMethod,
+      Client.path = toBS (escapePath _requestPath),
+      Client.queryString = toBS _requestQuery,
+      Client.requestHeaders = _requestHeaders,
+      Client.requestBody = toRequestBody _requestBody
+    }
+  where
+    end = _serviceEndpoint r
+    Service {..} = _requestService
 
 -- | Specify how a request can be de/serialised.
 class AWSRequest a where


### PR DESCRIPTION
Add the ability to make unsigned requests. Tested by performing `s3:GetObject` against a bucket whose policy allowed access from `"Principal": "*"`.

Ping @K0Te , since this may be a better way to handle the `sts:AssumeRoleWithWebIdentity` stuff. It also lets us work towards an `amazonka`/`amazonka-auth` split down the line.