### PR TITLE
amazonka-core: no readme

### DIFF
--- a/lib/amazonka-core/amazonka-core.cabal
+++ b/lib/amazonka-core/amazonka-core.cabal
@@ -11,7 +11,6 @@ maintainer:         Brendan Hay <brendan.g.hay+amazonka@gmail.com>
 copyright:          Copyright (c) 2013-2021 Brendan Hay
 category:           AWS
 build-type:         Simple
-extra-source-files: README.md
 description:
   Core data types and serialisation primitives for Amazonka related Amazon Web Service SDKs.
   .


### PR DESCRIPTION
I also ran `cabal check` and `cabal sdist` on every package, and found nothing else alarming. This seems uncontroversial, so it's going straight in.