### PR TITLE
bazel: Add GHC9 toolchains

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -234,6 +234,26 @@ rules_haskell_dependencies()
 register_toolchains("//tools/ghc:toolchain")
 
 haskell_register_ghc_nixpkgs(
+    name = "ghc921",
+    attribute_path = "haskell.compiler.ghc921",
+    haddock_flags = [
+        "--no-warnings",
+    ],
+    repository = "@nixpkgs",
+    version = "9.2.1",
+)
+
+haskell_register_ghc_nixpkgs(
+    name = "ghc901",
+    attribute_path = "haskell.compiler.ghc901",
+    haddock_flags = [
+        "--no-warnings",
+    ],
+    repository = "@nixpkgs",
+    version = "9.0.1",
+)
+
+haskell_register_ghc_nixpkgs(
     name = "ghc8107",
     attribute_path = "haskell.compiler.ghc8107",
     haddock_flags = [

--- a/tools/ghc/BUILD.bazel
+++ b/tools/ghc/BUILD.bazel
@@ -6,6 +6,8 @@ string_flag(
     values = [
         "884",
         "8107",
+        "901",
+        "921"
     ],
 )
 
@@ -23,11 +25,27 @@ config_setting(
     },
 )
 
+config_setting(
+    name = "901",
+    flag_values = {
+        ":version": "901",
+    },
+)
+
+config_setting(
+    name = "921",
+    flag_values = {
+        ":version": "921",
+    },
+)
+
 toolchain(
     name = "toolchain",
     toolchain = select({
         "//tools/ghc:884": "@ghc884_ghc_nixpkgs_haskell_toolchain//:toolchain-impl",
         "//tools/ghc:8107": "@ghc8107_ghc_nixpkgs_haskell_toolchain//:toolchain-impl",
+        "//tools/ghc:901": "@ghc901_ghc_nixpkgs_haskell_toolchain//:toolchain-impl",
+        "//tools/ghc:921": "@ghc921_ghc_nixpkgs_haskell_toolchain//:toolchain-impl",
     }),
     toolchain_type = "@rules_haskell//haskell:toolchain",
 )


### PR DESCRIPTION
Cargo-culting, but I think I got this right.

We'll need this eventually, but the stackage snapshot doesn't support the base-4.15 versions of some libraries - not sure what @brendanhay wants to do about that. (Merge this later? Re-pin stackage?)

I did a full build of the repo using GHC 9.0.1 and all the tests passed. There is currently no build plan for GHC 9.2.1; at least one of our transitive dependencies ([memory](https://github.com/vincenthz/hs-memory/pull/87)) needs updating for GHC 9.2.1 and a new Hackage release.