### PR TITLE
amazonka-gen: Synthesise NFData and Hashable implementations

### DIFF
--- a/gen/src/Gen/AST/Data/Instance.hs
+++ b/gen/src/Gen/AST/Data/Instance.hs
@@ -18,8 +18,8 @@ data Inst
   | ToQuery [Either (Text, Maybe Text) Field]
   | ToPath [Either Text Field]
   | ToBody Field
-  | IsHashable
-  | IsNFData
+  | IsHashable [Field]
+  | IsNFData [Field]
 
 instance ToJSON Inst where
   toJSON = Aeson.toJSON . instToText
@@ -35,8 +35,8 @@ instToText = \case
   ToQuery {} -> "ToQuery"
   ToPath {} -> "ToPath"
   ToBody {} -> "ToBody"
-  IsHashable -> "Hashable"
-  IsNFData -> "NFData"
+  IsHashable {} -> "Hashable"
+  IsNFData {} -> "NFData"
 
 shapeInsts :: Protocol -> Mode -> [Field] -> [Inst]
 shapeInsts proto mode fields = instances
@@ -72,7 +72,7 @@ shapeInsts proto mode fields = instances
 responseInsts :: [Field] -> [Inst]
 responseInsts fs
   | stream = mempty
-  | otherwise = [IsNFData]
+  | otherwise = [IsNFData fs]
   where
     (not . null -> stream, _) = List.partition fieldStream (notLocated fs)
 

--- a/lib/amazonka-core/src/Amazonka/Data/Time.hs
+++ b/lib/amazonka-core/src/Amazonka/Data/Time.hs
@@ -33,7 +33,6 @@ import qualified Data.Aeson.Types as Aeson
 import qualified Data.Attoparsec.Text as A
 import qualified Data.Attoparsec.Text as AText
 import qualified Data.ByteString.Char8 as BS
-import Data.Hashable (hashWithSalt)
 import qualified Data.Scientific as Scientific
 import qualified Data.Text as Text
 import qualified Data.Time as Time

--- a/lib/amazonka-core/src/Amazonka/Prelude.hs
+++ b/lib/amazonka-core/src/Amazonka/Prelude.hs
@@ -26,7 +26,7 @@ module Amazonka.Prelude
 where
 
 import Control.Applicative as Export (Alternative ((<|>)))
-import Control.DeepSeq as Export (NFData)
+import Control.DeepSeq as Export (NFData (rnf))
 import Control.Exception as Export (Exception, SomeException)
 import Control.Lens as Export
   ( Iso',
@@ -52,7 +52,7 @@ import Data.Functor as Export ((<&>))
 import Data.Functor.Identity as Export (Identity (..))
 import Data.HashMap.Strict as Export (HashMap)
 import Data.HashSet as Export (HashSet)
-import Data.Hashable as Export (Hashable)
+import Data.Hashable as Export (Hashable (hash, hashWithSalt))
 import Data.Int as Export (Int16, Int32, Int64, Int8)
 import Data.Kind as Export (Type)
 import Data.List.NonEmpty as Export (NonEmpty ((:|)))


### PR DESCRIPTION
Rather than relying on the default `Generic` implementation for the `NFData` and `Hashable` classes, generate each respective function implementation to mitigate some compilation overhead.

Example output:

```haskell
instance Prelude.Hashable CreateBucket where
  hash CreateBucket' {..} =
    Prelude.hash grantReadACP
      `Prelude.hashWithSalt` bucket
      `Prelude.hashWithSalt` acl
      `Prelude.hashWithSalt` grantWrite
      `Prelude.hashWithSalt` createBucketConfiguration
      `Prelude.hashWithSalt` grantFullControl
      `Prelude.hashWithSalt` grantRead
      `Prelude.hashWithSalt` grantWriteACP
      `Prelude.hashWithSalt` objectLockEnabledForBucket

instance Prelude.NFData CreateBucket where
  rnf CreateBucket' {..} =
    Prelude.rnf grantReadACP
      `Prelude.seq` Prelude.rnf bucket
      `Prelude.seq` Prelude.rnf acl
      `Prelude.seq` Prelude.rnf grantWrite
      `Prelude.seq` Prelude.rnf createBucketConfiguration
      `Prelude.seq` Prelude.rnf grantFullControl
      `Prelude.seq` Prelude.rnf grantRead
      `Prelude.seq` Prelude.rnf grantWriteACP
      `Prelude.seq` Prelude.rnf objectLockEnabledForBucket
```

And for a datatype with cardinality 1:

```haskell
instance Prelude.Hashable ContinuationEvent where
  hash _ = 0

instance Prelude.NFData ContinuationEvent where
  rnf _ = ()
```

Closes #719