### PR TITLE
amazonka-route53: correct S3 Website Hosted Zone IDs

### DIFF
--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [2.0.0](https://github.com/brendanhay/amazonka/tree/2.0.0)
+Released: **?**, Compare: [2.0.0-rc1](https://github.com/brendanhay/amazonka/compare/2.0.0-rc1...2.0.0)
+
+### Fixed
+
+- Hosted Zone IDs for S3 website endpoints are correct for all regions.
+[\#723](https://github.com/brendanhay/amazonka/pull/723)
+
 ## [2.0.0 RC1](https://github.com/brendanhay/amazonka/tree/2.0.0-rc1)
 Released: **28nd November, 2021**, Compare: [1.6.1](https://github.com/brendanhay/amazonka/compare/1.6.1...2.0.0-rc1)
 

--- a/lib/services/amazonka-route53/src/Amazonka/Route53/Internal.hs
+++ b/lib/services/amazonka-route53/src/Amazonka/Route53/Internal.hs
@@ -64,8 +64,8 @@ instance FromXML ResourceId where
 getHostedZoneId :: Region -> Maybe ResourceId
 getHostedZoneId = \case
     Ohio            -> Just "Z2O1EMRO9K5GLX"
-    NorthVirginia   -> Just "Z3AQBSTGFYJSTF "
-    NorthCalifornia -> Just "Z2F56UZL2M1ACD "
+    NorthVirginia   -> Just "Z3AQBSTGFYJSTF"
+    NorthCalifornia -> Just "Z2F56UZL2M1ACD"
     Oregon          -> Just "Z3BJ6K6RIION7M"
     CapeTown        -> Just "Z11KHD8FBVPUYU"
     HongKong        -> Just "ZNB98KWMFR0R6"
@@ -76,14 +76,14 @@ getHostedZoneId = \case
     Sydney          -> Just "Z1WCIGYICN2BYD"
     Tokyo           -> Just "Z2M4EHUR26P7ZW"
     Montreal        -> Just "Z1QDHH18159H29"
-    Ningxia         -> Nothing
+    Ningxia         -> Just "Z282HJ1KT0DH03"
     Frankfurt       -> Just "Z21DNDUVLTQW6Q"
     Ireland         -> Just "Z1BKCTXD74EZPE"
     London          -> Just "Z3GKZC51ZF0DB4"
-    Milan           -> Nothing
+    Milan           -> Just "Z30OZKI7KPW7MI"
     Paris           -> Just "Z3R1K369G5AVDG"
     Stockholm       -> Just "Z3BAZG2TWCNX0D"
-    Bahrain         -> Nothing
+    Bahrain         -> Just "Z1MPMWCPA7YB62"
     SaoPaulo        -> Just "Z7KQH4QJS55SO"
     GovCloudEast    -> Just "Z2NIFVYYW2VKV1"
     GovCloudWest    -> Just "Z31GFT0UA1I2HV"


### PR DESCRIPTION
I noticed in my travels that we didn't have all the zone IDs. Perhaps AWS added them after this function was written?