### PR TITLE
amazonka-dynamodb: Use a sum type for AttributeValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This repository is organised into the following directory structure:
 
 * [`lib/amazonka`](lib/amazonka): The main library containing setup, authentication, and send logic. This will be your primary dependency.
 * `lib/service/amazonka-*`: A library per supported Amazon Web Service, you'll need to add a dependency on each selected service library.
+* [`lib/amazonka-core`](lib/amazonka-core): The `amazonka-core` library upon which each of the services depends.
 * [`lib/amazonka-test`](lib/amazonka-test): Common test functionality.
 * [`examples`](examples): Basic examples for using the service libraries.
 * [`configs`](configs): Service configuration, templates, and assets used by the code generator.

--- a/configs/services/dynamodb.json
+++ b/configs/services/dynamodb.json
@@ -23,6 +23,11 @@
                 "Responses",
                 "UnprocessedKeys"
             ]
+        },
+        "BatchWriteItemOutput": {
+            "requiredFields": [
+                "UnprocessedItems"
+            ]
         }
     }
 }

--- a/configs/services/dynamodb.json
+++ b/configs/services/dynamodb.json
@@ -4,7 +4,6 @@
         "aeson",
         "containers",
         "hashable >=1.3.4.0 && <1.5",
-        "lens",
         "unordered-containers",
         "vector"
     ],

--- a/configs/services/dynamodb.json
+++ b/configs/services/dynamodb.json
@@ -1,3 +1,22 @@
 {
-    "libraryName": "amazonka-dynamodb"
+    "libraryName": "amazonka-dynamodb",
+    "extraDependencies": [
+        "aeson",
+        "containers",
+        "hashable >=1.3.4.0 && <1.5",
+        "lens",
+        "unordered-containers",
+        "vector"
+    ],
+    "typeModules": [
+        "Amazonka.DynamoDB.Internal"
+    ],
+    "typeOverrides": {
+        "AttributeValue": {
+            "replacedBy": {
+                "name": "AttributeValue",
+                "underive": []
+            }
+        }
+    }
 }

--- a/configs/services/dynamodb.json
+++ b/configs/services/dynamodb.json
@@ -28,6 +28,11 @@
             "requiredFields": [
                 "UnprocessedItems"
             ]
+        },
+        "GetItemOutput": {
+            "requiredFields": [
+                "Item"
+            ]
         }
     }
 }

--- a/configs/services/dynamodb.json
+++ b/configs/services/dynamodb.json
@@ -17,6 +17,12 @@
                 "name": "AttributeValue",
                 "underive": []
             }
+        },
+        "BatchGetItemOutput": {
+            "requiredFields": [
+                "Responses",
+                "UnprocessedKeys"
+            ]
         }
     }
 }

--- a/configs/services/dynamodb.json
+++ b/configs/services/dynamodb.json
@@ -33,6 +33,11 @@
             "requiredFields": [
                 "Item"
             ]
+        },
+        "QueryOutput": {
+            "requiredFields": [
+                "Items"
+            ]
         }
     }
 }

--- a/configs/services/dynamodbstreams.json
+++ b/configs/services/dynamodbstreams.json
@@ -4,7 +4,6 @@
         "aeson",
         "containers",
         "hashable >=1.3.4.0 && <1.5",
-        "lens",
         "unordered-containers",
         "vector"
     ],

--- a/configs/services/dynamodbstreams.json
+++ b/configs/services/dynamodbstreams.json
@@ -1,3 +1,22 @@
 {
-    "libraryName": "amazonka-dynamodb-streams"
+    "libraryName": "amazonka-dynamodb-streams",
+    "extraDependencies": [
+        "aeson",
+        "containers",
+        "hashable >=1.3.4.0 && <1.5",
+        "lens",
+        "unordered-containers",
+        "vector"
+    ],
+    "typeModules": [
+        "Amazonka.DynamoDBStreams.Internal"
+    ],
+    "typeOverrides": {
+        "AttributeValue": {
+            "replacedBy": {
+                "name": "AttributeValue",
+                "underive": []
+            }
+        }
+    }
 }

--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -5,7 +5,10 @@ Released: **?**, Compare: [2.0.0-rc1](https://github.com/brendanhay/amazonka/com
 
 ### Changed
 
+- `amazonka-dynamodb`: Mark various fields as required
+[\#724](https://github.com/brendanhay/amazonka/pull/724)
 - `amazonka-dynamodb`: Provide a sum type for `AttributeValue`
+[\#724](https://github.com/brendanhay/amazonka/pull/724)
 - `amazonka-dynamodb-streams`: Provide a sum type for `AttributeValue`
 [\#724](https://github.com/brendanhay/amazonka/pull/724)
 

--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -6,6 +6,7 @@ Released: **?**, Compare: [2.0.0-rc1](https://github.com/brendanhay/amazonka/com
 ### Changed
 
 - `amazonka-dynamodb`: Provide a sum type for `AttributeValue`
+- `amazonka-dynamodb-streams`: Provide a sum type for `AttributeValue`
 [\#724](https://github.com/brendanhay/amazonka/pull/724)
 
 ### Fixed

--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [2.0.0](https://github.com/brendanhay/amazonka/tree/2.0.0)
 Released: **?**, Compare: [2.0.0-rc1](https://github.com/brendanhay/amazonka/compare/2.0.0-rc1...2.0.0)
 
+### Changed
+
+- `amazonka-dynamodb`: Provide a sum type for `AttributeValue`
+[\#724](https://github.com/brendanhay/amazonka/pull/724)
+
 ### Fixed
 
 - `amazonka-s3`/`amazonka-glacier`: treat upload IDs are a mandatory part of the `CreateMultipartUpload`/`InitiateMultipartUpload` responses.

--- a/lib/services/amazonka-dynamodb-streams/src/Amazonka/DynamoDBStreams/Internal.hs
+++ b/lib/services/amazonka-dynamodb-streams/src/Amazonka/DynamoDBStreams/Internal.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StrictData #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wall -Werror #-}
 
 -- |
@@ -15,27 +14,10 @@
 -- Maintainer  : Brendan Hay <brendan.g.hay@gmail.com>
 -- Stability   : experimental
 -- Portability : non-portable (GHC extensions)
-module Amazonka.DynamoDBStreams.Internal
-  ( -- * Attribute Values
-    AttributeValue (..),
-
-    -- ** Attribute Value Prisms
-    _L,
-    _NS,
-    _M,
-    _NULL,
-    _N,
-    _BS,
-    _B,
-    _SS,
-    _S,
-    _BOOL,
-  )
-where
+module Amazonka.DynamoDBStreams.Internal where
 
 import Amazonka.Core
 import Amazonka.Prelude
-import Control.Lens.TH (makePrisms)
 import Data.Aeson (pairs)
 import Data.Hashable
 import Data.Map (Map)
@@ -107,8 +89,6 @@ data AttributeValue
     BOOL Bool
   deriving stock (Eq, Read, Show, Generic)
   deriving anyclass (NFData)
-
-$(makePrisms ''AttributeValue)
 
 instance Hashable AttributeValue where
   hashWithSalt salt = \case

--- a/lib/services/amazonka-dynamodb-streams/src/Amazonka/DynamoDBStreams/Internal.hs
+++ b/lib/services/amazonka-dynamodb-streams/src/Amazonka/DynamoDBStreams/Internal.hs
@@ -1,0 +1,169 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StrictData #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+-- |
+-- Module      : Amazonka.DynamoDBStreams.Internal
+-- Copyright   : (c) 2013-2021 Brendan Hay
+-- License     : Mozilla Public License, v. 2.0.
+-- Maintainer  : Brendan Hay <brendan.g.hay@gmail.com>
+-- Stability   : experimental
+-- Portability : non-portable (GHC extensions)
+module Amazonka.DynamoDBStreams.Internal
+  ( -- * Attribute Values
+    AttributeValue (..),
+
+    -- ** Attribute Value Prisms
+    _L,
+    _NS,
+    _M,
+    _NULL,
+    _N,
+    _BS,
+    _B,
+    _SS,
+    _S,
+    _BOOL,
+  )
+where
+
+import Amazonka.Core
+import Amazonka.Prelude
+import Control.Lens.TH (makePrisms)
+import Data.Aeson (pairs)
+import Data.Hashable
+import Data.Map (Map)
+import Data.Vector (Vector)
+
+#if MIN_VERSION_aeson(2,0,0)
+import qualified  Data.Aeson.KeyMap as KeyMap
+#else
+import qualified  Data.HashMap.Strict as KeyMap
+#endif
+
+-- | Represents the data for an attribute.
+--
+-- DynamoDB sends and receives JSON objects which contain a single
+-- item whose key is a data type and the value is the data itself. We
+-- provide an actual sum type to interact with these.
+--
+-- For more information, see
+-- <https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes Data Types>
+-- in the /Amazon DynamoDB Developer Guide/.
+data AttributeValue
+  = -- | An attribute of type List. For example:
+    --
+    -- @\"L\": [ {\"S\": \"Cookies\"} , {\"S\": \"Coffee\"}, {\"N\", \"3.14159\"}]@
+    L (Vector AttributeValue)
+  | -- | An attribute of type Number Set. For example:
+    --
+    -- @\"NS\": [\"42.2\", \"-19\", \"7.5\", \"3.14\"]@
+    --
+    -- Numbers are sent across the network to DynamoDB as strings, to maximize
+    -- compatibility across languages and libraries. However, DynamoDB treats
+    -- them as number type attributes for mathematical operations.
+    NS (Vector Text)
+  | -- | An attribute of type Map. For example:
+    --
+    -- @\"M\": {\"Name\": {\"S\": \"Joe\"}, \"Age\": {\"N\": \"35\"}}@
+    M (Map Text AttributeValue)
+  | -- | An attribute of type Null. For example:
+    --
+    -- @\"NULL\": true@
+    NULL
+  | -- | An attribute of type Number. For example:
+    --
+    -- @\"N\": \"123.45\"@
+    --
+    -- Numbers are sent across the network to DynamoDB as strings, to maximize
+    -- compatibility across languages and libraries. However, DynamoDB treats
+    -- them as number type attributes for mathematical operations.
+    N Text
+  | -- | An attribute of type Binary Set. For example:
+    --
+    -- @\"BS\": [\"U3Vubnk=\", \"UmFpbnk=\", \"U25vd3k=\"]@
+    BS (Vector Base64)
+  | -- | An attribute of type Binary. For example:
+    --
+    -- @\"B\": \"dGhpcyB0ZXh0IGlzIGJhc2U2NC1lbmNvZGVk\"@
+    B Base64
+  | -- | An attribute of type String Set. For example:
+    --
+    -- @\"SS\": [\"Giraffe\", \"Hippo\" ,\"Zebra\"]@
+    SS (Vector Text)
+  | -- | An attribute of type String. For example:
+    --
+    -- @\"S\": \"Hello\"@
+    S Text
+  | -- | An attribute of type Boolean. For example:
+    --
+    -- @\"BOOL\": true@
+    BOOL Bool
+  deriving stock (Eq, Read, Show, Generic)
+  deriving anyclass (NFData)
+
+$(makePrisms ''AttributeValue)
+
+instance Hashable AttributeValue where
+  hashWithSalt salt = \case
+    L avs -> salt `hashWithSalt` (0 :: Int) `hashVector` avs
+    NS ns -> salt `hashWithSalt` (1 :: Int) `hashVector` ns
+    M m -> salt `hashWithSalt` (2 :: Int) `hashWithSalt` m
+    NULL -> salt `hashWithSalt` (3 :: Int) `hashWithSalt` ()
+    N n -> salt `hashWithSalt` (4 :: Int) `hashWithSalt` n
+    BS bs -> salt `hashWithSalt` (5 :: Int) `hashVector` bs
+    B b -> salt `hashWithSalt` (6 :: Int) `hashWithSalt` b
+    SS ss -> salt `hashWithSalt` (7 :: Int) `hashVector` ss
+    S s -> salt `hashWithSalt` (8 :: Int) `hashWithSalt` s
+    BOOL b -> salt `hashWithSalt` (9 :: Int) `hashWithSalt` b
+    where
+      hashVector :: Hashable a => Int -> Vector a -> Int
+      hashVector = hashUsing toList
+
+instance FromJSON AttributeValue where
+  parseJSON = withObject "AttributeValue" $ \o ->
+    case KeyMap.toList o of
+      [("L", v)] -> L <$> parseJSON v
+      [("NS", v)] -> NS <$> parseJSON v
+      [("M", v)] -> M <$> parseJSON v
+      [("NULL", _)] -> pure NULL
+      [("N", v)] -> N <$> parseJSON v
+      [("BS", v)] -> BS <$> parseJSON v
+      [("B", v)] -> B <$> parseJSON v
+      [("SS", v)] -> SS <$> parseJSON v
+      [("S", v)] -> S <$> parseJSON v
+      [("BOOL", v)] -> B <$> parseJSON v
+      [] -> fail "No keys"
+      _ -> fail $ "Multiple or unrecognized keys: " ++ show (KeyMap.keys o)
+
+instance ToJSON AttributeValue where
+  toJSON =
+    object . pure . \case
+      L avs -> "L" .= avs
+      NS ns -> "NS" .= ns
+      M m -> "M" .= m
+      NULL -> "NULL" .= True
+      N n -> "N" .= n
+      BS bs -> "BS" .= bs
+      B b -> "B" .= b
+      SS ss -> "SS" .= ss
+      S s -> "S" .= s
+      BOOL b -> "BOOL" .= b
+  toEncoding =
+    pairs . \case
+      L avs -> "L" .= avs
+      NS ns -> "NS" .= ns
+      M m -> "M" .= m
+      NULL -> "NULL" .= True
+      N n -> "N" .= n
+      BS bs -> "BS" .= bs
+      B b -> "B" .= b
+      SS ss -> "SS" .= ss
+      S s -> "S" .= s
+      BOOL b -> "BOOL" .= b

--- a/lib/services/amazonka-dynamodb/src/Amazonka/DynamoDB/Internal.hs
+++ b/lib/services/amazonka-dynamodb/src/Amazonka/DynamoDB/Internal.hs
@@ -1,0 +1,169 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StrictData #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+-- |
+-- Module      : Amazonka.DynamoDB.Internal
+-- Copyright   : (c) 2013-2021 Brendan Hay
+-- License     : Mozilla Public License, v. 2.0.
+-- Maintainer  : Brendan Hay <brendan.g.hay@gmail.com>
+-- Stability   : experimental
+-- Portability : non-portable (GHC extensions)
+module Amazonka.DynamoDB.Internal
+  ( -- * Attribute Values
+    AttributeValue (..),
+
+    -- ** Attribute Value Prisms
+    _L,
+    _NS,
+    _M,
+    _NULL,
+    _N,
+    _BS,
+    _B,
+    _SS,
+    _S,
+    _BOOL,
+  )
+where
+
+import Amazonka.Core
+import Amazonka.Prelude
+import Control.Lens.TH (makePrisms)
+import Data.Aeson (pairs)
+import Data.Hashable
+import Data.Map (Map)
+import Data.Vector (Vector)
+
+#if MIN_VERSION_aeson(2,0,0)
+import qualified  Data.Aeson.KeyMap as KeyMap
+#else
+import qualified  Data.HashMap.Strict as KeyMap
+#endif
+
+-- | Represents the data for an attribute.
+--
+-- DynamoDB sends and receives JSON objects which contain a single
+-- item whose key is a data type and the value is the data itself. We
+-- provide an actual sum type to interact with these.
+--
+-- For more information, see
+-- <https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes Data Types>
+-- in the /Amazon DynamoDB Developer Guide/.
+data AttributeValue
+  = -- | An attribute of type List. For example:
+    --
+    -- @\"L\": [ {\"S\": \"Cookies\"} , {\"S\": \"Coffee\"}, {\"N\", \"3.14159\"}]@
+    L (Vector AttributeValue)
+  | -- | An attribute of type Number Set. For example:
+    --
+    -- @\"NS\": [\"42.2\", \"-19\", \"7.5\", \"3.14\"]@
+    --
+    -- Numbers are sent across the network to DynamoDB as strings, to maximize
+    -- compatibility across languages and libraries. However, DynamoDB treats
+    -- them as number type attributes for mathematical operations.
+    NS (Vector Text)
+  | -- | An attribute of type Map. For example:
+    --
+    -- @\"M\": {\"Name\": {\"S\": \"Joe\"}, \"Age\": {\"N\": \"35\"}}@
+    M (Map Text AttributeValue)
+  | -- | An attribute of type Null. For example:
+    --
+    -- @\"NULL\": true@
+    NULL
+  | -- | An attribute of type Number. For example:
+    --
+    -- @\"N\": \"123.45\"@
+    --
+    -- Numbers are sent across the network to DynamoDB as strings, to maximize
+    -- compatibility across languages and libraries. However, DynamoDB treats
+    -- them as number type attributes for mathematical operations.
+    N Text
+  | -- | An attribute of type Binary Set. For example:
+    --
+    -- @\"BS\": [\"U3Vubnk=\", \"UmFpbnk=\", \"U25vd3k=\"]@
+    BS (Vector Base64)
+  | -- | An attribute of type Binary. For example:
+    --
+    -- @\"B\": \"dGhpcyB0ZXh0IGlzIGJhc2U2NC1lbmNvZGVk\"@
+    B Base64
+  | -- | An attribute of type String Set. For example:
+    --
+    -- @\"SS\": [\"Giraffe\", \"Hippo\" ,\"Zebra\"]@
+    SS (Vector Text)
+  | -- | An attribute of type String. For example:
+    --
+    -- @\"S\": \"Hello\"@
+    S Text
+  | -- | An attribute of type Boolean. For example:
+    --
+    -- @\"BOOL\": true@
+    BOOL Bool
+  deriving stock (Eq, Read, Show, Generic)
+  deriving anyclass (NFData)
+
+$(makePrisms ''AttributeValue)
+
+instance Hashable AttributeValue where
+  hashWithSalt salt = \case
+    L avs -> salt `hashWithSalt` (0 :: Int) `hashVector` avs
+    NS ns -> salt `hashWithSalt` (1 :: Int) `hashVector` ns
+    M m -> salt `hashWithSalt` (2 :: Int) `hashWithSalt` m
+    NULL -> salt `hashWithSalt` (3 :: Int) `hashWithSalt` ()
+    N n -> salt `hashWithSalt` (4 :: Int) `hashWithSalt` n
+    BS bs -> salt `hashWithSalt` (5 :: Int) `hashVector` bs
+    B b -> salt `hashWithSalt` (6 :: Int) `hashWithSalt` b
+    SS ss -> salt `hashWithSalt` (7 :: Int) `hashVector` ss
+    S s -> salt `hashWithSalt` (8 :: Int) `hashWithSalt` s
+    BOOL b -> salt `hashWithSalt` (9 :: Int) `hashWithSalt` b
+    where
+      hashVector :: Hashable a => Int -> Vector a -> Int
+      hashVector = hashUsing toList
+
+instance FromJSON AttributeValue where
+  parseJSON = withObject "AttributeValue" $ \o ->
+    case KeyMap.toList o of
+      [("L", v)] -> L <$> parseJSON v
+      [("NS", v)] -> NS <$> parseJSON v
+      [("M", v)] -> M <$> parseJSON v
+      [("NULL", _)] -> pure NULL
+      [("N", v)] -> N <$> parseJSON v
+      [("BS", v)] -> BS <$> parseJSON v
+      [("B", v)] -> B <$> parseJSON v
+      [("SS", v)] -> SS <$> parseJSON v
+      [("S", v)] -> S <$> parseJSON v
+      [("BOOL", v)] -> B <$> parseJSON v
+      [] -> fail "No keys"
+      _ -> fail $ "Multiple or unrecognized keys: " ++ show (KeyMap.keys o)
+
+instance ToJSON AttributeValue where
+  toJSON =
+    object . pure . \case
+      L avs -> "L" .= avs
+      NS ns -> "NS" .= ns
+      M m -> "M" .= m
+      NULL -> "NULL" .= True
+      N n -> "N" .= n
+      BS bs -> "BS" .= bs
+      B b -> "B" .= b
+      SS ss -> "SS" .= ss
+      S s -> "S" .= s
+      BOOL b -> "BOOL" .= b
+  toEncoding =
+    pairs . \case
+      L avs -> "L" .= avs
+      NS ns -> "NS" .= ns
+      M m -> "M" .= m
+      NULL -> "NULL" .= True
+      N n -> "N" .= n
+      BS bs -> "BS" .= bs
+      B b -> "B" .= b
+      SS ss -> "SS" .= ss
+      S s -> "S" .= s
+      BOOL b -> "BOOL" .= b

--- a/lib/services/amazonka-dynamodb/src/Amazonka/DynamoDB/Internal.hs
+++ b/lib/services/amazonka-dynamodb/src/Amazonka/DynamoDB/Internal.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StrictData #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wall -Werror #-}
 
 -- |
@@ -15,27 +14,10 @@
 -- Maintainer  : Brendan Hay <brendan.g.hay@gmail.com>
 -- Stability   : experimental
 -- Portability : non-portable (GHC extensions)
-module Amazonka.DynamoDB.Internal
-  ( -- * Attribute Values
-    AttributeValue (..),
-
-    -- ** Attribute Value Prisms
-    _L,
-    _NS,
-    _M,
-    _NULL,
-    _N,
-    _BS,
-    _B,
-    _SS,
-    _S,
-    _BOOL,
-  )
-where
+module Amazonka.DynamoDB.Internal where
 
 import Amazonka.Core
 import Amazonka.Prelude
-import Control.Lens.TH (makePrisms)
 import Data.Aeson (pairs)
 import Data.Hashable
 import Data.Map (Map)
@@ -107,8 +89,6 @@ data AttributeValue
     BOOL Bool
   deriving stock (Eq, Read, Show, Generic)
   deriving anyclass (NFData)
-
-$(makePrisms ''AttributeValue)
 
 instance Hashable AttributeValue where
   hashWithSalt salt = \case


### PR DESCRIPTION
Note:

* I haven't actually used this in anger yet. Putting it up now for discussion and possibly to test work code against once we get across to `amazonka-2.0` RC1 (next week, most likely).
* Branch is currently based off #723 so I can write a decent changelog entry. Merge that first and then this will look sensible.
* I had to temporarily revert #721 while developing this because the generated instances failed to compile with "Ambiguous Type" errors.
* I have tested building using `--constraints 'aeson < 2.0'` as well as `--constraints 'aeson >= 2.0'`.
* Need to `scripts/generate dynamodb` before testing, obviously.

Open questions:

* Do we actually want this? I feel that it's OK for amazonka to do this because it hews closely to the data formats, but a more advanced/opinionated mapping library would be out of scope for this project.
* Should we use the pattern synonym/`newtype` trick here in case AWS add more data types to dynamo? Feels a bit unlikely.
* I believe @brendanhay has a long-term plan to remove the direct `lens` dependency - I'm prepared to write the prisms manually if necessary.