### PR TITLE
SSM: Require more fields

### DIFF
--- a/configs/services/ssm.json
+++ b/configs/services/ssm.json
@@ -1,3 +1,29 @@
 {
-    "libraryName": "amazonka-ssm"
+    "libraryName": "amazonka-ssm",
+    "typeOverrides": {
+        "GetParameterResult": {
+            "requiredFields": [
+                "Parameter"
+            ]
+        },
+        "GetParametersResult": {
+            "requiredFields": [
+                "InvalidParameters",
+                "Parameters"
+            ]
+        },
+        "PutParameterResult": {
+            "requiredFields": [
+                "Version"
+            ]
+        },
+        "Parameter": {
+            "requiredFields": [
+                "Name",
+                "Type",
+                "Value",
+                "Version"
+            ]
+        }
+    }
 }

--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -9,6 +9,8 @@ Released: **?**, Compare: [2.0.0-rc1](https://github.com/brendanhay/amazonka/com
 [\#725](https://github.com/brendanhay/amazonka/pull/725)
 - Hosted Zone IDs for S3 website endpoints are correct for all regions.
 [\#723](https://github.com/brendanhay/amazonka/pull/723)
+- `amazonka-ssm`: Various fields that are always available are no longer Maybe's.
+[\#741](https://github.com/brendanhay/amazonka/pull/741)
 
 ## [2.0.0 RC1](https://github.com/brendanhay/amazonka/tree/2.0.0-rc1)
 Released: **28nd November, 2021**, Compare: [1.6.1](https://github.com/brendanhay/amazonka/compare/1.6.1...2.0.0-rc1)


### PR DESCRIPTION
These were tested by trying the commands put-parameter, get-parameter
and get-parameters with awscli.

```
 % aws ssm put-parameter --name test-dec-20 --value "abc" --type String
{
    "Version": 1
}
 % aws ssm get-parameter --name test-dec-20                            
{
    "Parameter": {
        "Version": 1,
        "Value": "abc",
        "Type": "String",
        "Name": "test-dec-20"
    }
}
 % aws ssm get-parameters --names test-dec-20
{
    "Parameters": [
        {
            "Name": "test-dec-20",
            "Value": "abc",
            "Type": "String",
            "Version": 1
        }
    ],
    "InvalidParameters": []
}
 % aws ssm get-parameters --names test-dec-21
{
    "InvalidParameters": [
        "test-dec-21"
    ],
    "Parameters": []
}
 % aws ssm delete-parameter --name test-dec-20 
 % aws ssm delete-parameter --name test-dec-20

An error occurred (ParameterNotFound) when calling the DeleteParameter operation:
```

Fixes #740.