### PR TITLE
Signing improvements

### DIFF
--- a/lib/amazonka-core/amazonka-core.cabal
+++ b/lib/amazonka-core/amazonka-core.cabal
@@ -105,6 +105,7 @@ library
     , case-insensitive      >=1.2
     , conduit               >=1.3
     , conduit-extra         >=1.3
+    , containers            >=0.5     && < 0.7
     , cryptonite            >=0.25
     , deepseq               >=1.4
     , hashable              >=1.2

--- a/lib/amazonka-core/src/Amazonka/Sign/V4/Base.hs
+++ b/lib/amazonka-core/src/Amazonka/Sign/V4/Base.hs
@@ -15,7 +15,9 @@ import Amazonka.Prelude
 import Amazonka.Request
 import Amazonka.Types
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Builder as BSB
 import qualified Data.ByteString.Char8 as BS8
+import qualified Data.ByteString.Lazy as BSL
 import qualified Data.CaseInsensitive as CI
 import qualified Data.Foldable as Foldable
 import qualified Data.Map.Strict as Map
@@ -272,9 +274,9 @@ canonicalQuery = Tag . toBS
 -- all internal whitespace, replacing with a single space char,
 -- unless quoted with \"...\"
 canonicalHeaders :: NormalisedHeaders -> CanonicalHeaders
-canonicalHeaders = Tag . Foldable.foldMap (uncurry f) . untag
+canonicalHeaders = Tag . BSL.toStrict . BSB.toLazyByteString . Foldable.foldMap (uncurry f) . untag
   where
-    f k v = k <> ":" <> stripBS v <> "\n"
+    f k v = BSB.byteString k <> BSB.char7 ':' <> BSB.byteString (stripBS v) <> BSB.char7 '\n'
 
 signedHeaders :: NormalisedHeaders -> SignedHeaders
 signedHeaders = Tag . BS8.intercalate ";" . map fst . untag

--- a/lib/amazonka-core/src/Amazonka/Sign/V4/Base.hs
+++ b/lib/amazonka-core/src/Amazonka/Sign/V4/Base.hs
@@ -18,8 +18,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.CaseInsensitive as CI
 import qualified Data.Foldable as Foldable
-import qualified Data.Function as Function
-import qualified Data.List as List
+import qualified Data.Map.Strict as Map
 import qualified Network.HTTP.Client as Client
 import qualified Network.HTTP.Types as HTTP
 
@@ -36,7 +35,7 @@ data V4 = V4
     metaStringToSign :: StringToSign,
     metaSignature :: Signature,
     metaHeaders :: [Header],
-    metaTimeout :: (Maybe Seconds)
+    metaTimeout :: Maybe Seconds
   }
 
 instance ToLog V4 where
@@ -130,13 +129,15 @@ type Signature = Tag "signature" ByteString
 
 authorisation :: V4 -> ByteString
 authorisation V4 {..} =
-  algorithm
-    <> " Credential="
-    <> toBS metaCredential
-    <> ", SignedHeaders="
-    <> toBS metaSignedHeaders
-    <> ", Signature="
-    <> toBS metaSignature
+  mconcat
+    [ algorithm,
+      " Credential=",
+      toBS metaCredential,
+      ", SignedHeaders=",
+      toBS metaSignedHeaders,
+      ", Signature=",
+      toBS metaSignature
+    ]
 
 signRequest ::
   -- | Pre-signRequestd signing metadata.
@@ -280,10 +281,9 @@ signedHeaders = Tag . BS8.intercalate ";" . map fst . untag
 
 normaliseHeaders :: [Header] -> NormalisedHeaders
 normaliseHeaders =
-  -- FIXME: convert this to an ordered map.
   Tag
     . map (first CI.foldedCase)
-    . List.nubBy ((==) `Function.on` fst)
-    . List.sortBy (compare `Function.on` fst)
-    . filter ((/= "authorization") . fst)
-    . filter ((/= "content-length") . fst)
+    . Map.toList
+    . Map.delete "authorization"
+    . Map.delete "content-length"
+    . Map.fromListWith const

--- a/lib/amazonka-core/src/Amazonka/Sign/V4/Base.hs
+++ b/lib/amazonka-core/src/Amazonka/Sign/V4/Base.hs
@@ -285,7 +285,7 @@ normaliseHeaders :: [Header] -> NormalisedHeaders
 normaliseHeaders =
   Tag
     . map (first CI.foldedCase)
-    . Map.toList
+    . Map.toAscList
     . Map.delete "authorization"
     . Map.delete "content-length"
     . Map.fromListWith const


### PR DESCRIPTION
Based on #742, this might help with the performance of signing requests by avoiding repeated concatenation of bytestrings. It should have the same behaviour as the previous code but I haven't tested that requests work.

@ethercrow can you try out this patch and see if it helps at all? I wouldn't be surprised if it doesn't, but it cleans things up a bit and avoids some obvious less than optimal code.