### PR TITLE
sso: GetRoleCredentialsResponse_roleCredentials is required

### DIFF
--- a/configs/services/sso.json
+++ b/configs/services/sso.json
@@ -1,3 +1,10 @@
 {
-    "libraryName": "amazonka-sso"
+    "libraryName": "amazonka-sso",
+    "typeOverrides": {
+        "GetRoleCredentialsResponse": {
+            "requiredFields": [
+                "roleCredentials"
+            ]
+        }
+    }
 }

--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -40,6 +40,8 @@ Released: **?**, Compare: [2.0.0-rc1](https://github.com/brendanhay/amazonka/com
 [\#775](https://github.com/brendanhay/amazonka/pull/775)
 - `amazonka`: Add a public interface to send unsigned requests. Sending functions are now defined in `Amazonka.Send`, but are re-exported from `Amazonka`.
 [\#769](https://github.com/brendanhay/amazonka/pull/769)
+- `amazonka-sso`: Mark `GetRoleCredentialsResponse_roleCredentials` as required
+[\#759](https://github.com/brendanhay/amazonka/pull/759)
 - `amazonka-dynamodb`: Mark various fields as required
 [\#724](https://github.com/brendanhay/amazonka/pull/724)
 - `amazonka-dynamodb`: Provide a sum type for `AttributeValue`


### PR DESCRIPTION
It's the only field in the response, and @pbrisbin 's work makes me think this is always present in a successful response.

See also: botocore:

https://github.com/boto/botocore/blob/cecca8c0e916297baeb06d236b2b23060170d8bb/botocore/data/sso/2019-06-10/service-2.json#L151-L154

#739 