### PR TITLE
Gen hackery

### DIFF
--- a/gen/src/Gen/AST.hs
+++ b/gen/src/Gen/AST.hs
@@ -49,10 +49,10 @@ rewriteService cfg s = do
   elaborate (s ^. shapes)
     -- Annotate the comonadic tree with the associated
     -- bi/unidirectional (input/output/both) relation for shapes.
-    >>= traverse (pure . attach Related rs)
+    <&> fmap (attach Related rs)
     -- Apply the override configuration to the service, and default any
     -- optional fields from the JSON where needed.
-    >>= pure . (\ss -> override (cfg ^. typeOverrides) (s {_shapes = ss}))
+    <&> (\ss -> override (cfg ^. typeOverrides) (s {_shapes = ss}))
     -- Ensure no empty operation references exist, and that operation shapes
     -- are considered 'unique', so they can be lifted into the operation's
     -- module, separately from .Types.
@@ -69,7 +69,7 @@ renderShapes cfg svc = do
     prefixes (svc ^. shapes)
       -- Determine the appropriate Haskell AST type, auto deriveable instances,
       -- and fully rendered instances.
-      >>= pure . solve cfg
+      <&> solve cfg
       -- Separate the operation input/output shapes from the .Types shapes.
       >>= separate (svc ^. operations)
 

--- a/gen/src/Gen/AST/Cofree.hs
+++ b/gen/src/Gen/AST/Cofree.hs
@@ -22,7 +22,7 @@ attach ::
   HashMap Id b ->
   Cofree t a ->
   Cofree t c
-attach ctor m = Comonad.extend (go . Comonad.extract)
+attach ctor m = fmap go
   where
     go x = ctor x . fromMaybe mempty $ HashMap.lookup (identifier x) m
 

--- a/gen/src/Gen/Types/Ann.hs
+++ b/gen/src/Gen/Types/Ann.hs
@@ -51,7 +51,6 @@ instance Semigroup Relation where
 
 instance Monoid Relation where
   mempty = Relation 0 mempty
-  mappend = (<>)
 
 instance (Functor f, HasRelation a) => HasRelation (Cofree f a) where
   relation = Lens.lens Comonad.extract (flip (:<) . Cofree.unwrap) . relation

--- a/gen/src/Gen/Types/Ann.hs
+++ b/gen/src/Gen/Types/Ann.hs
@@ -96,6 +96,9 @@ derivingName = \case
   DNFData -> Nothing
   other -> Just (drop 1 (show other))
 
+-- | Primitive types in AWS service definition files.
+--
+-- /See:/ 'Gen.Types.Service.ShapeF' for lists/maps/structs.
 data Lit
   = Int
   | Long

--- a/gen/src/Gen/Types/Config.hs
+++ b/gen/src/Gen/Types/Config.hs
@@ -6,7 +6,7 @@ import qualified Control.Lens as Lens
 import Data.Aeson ((.!=), (.:), (.:?), (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.List as List
-import Data.Ord (Down (..), comparing)
+import Data.Ord (Down (..))
 import qualified Data.Text as Text
 import qualified Data.Time as Time
 import Gen.Prelude
@@ -166,7 +166,7 @@ instance ToJSON Library where
             "otherModules" .= List.sort (l ^. otherModules),
             "extraDependencies" .= List.sort (l ^. extraDependencies),
             "operations"
-              .= List.sortBy (comparing _opName) (l ^.. operations . Lens.each),
+              .= List.sortOn _opName (l ^.. operations . Lens.each),
             "shapes" .= List.sort (l ^.. shapes . Lens.each),
             "waiters" .= (l ^.. waiters . Lens.each)
           ]

--- a/gen/src/Gen/Types/Config.hs
+++ b/gen/src/Gen/Types/Config.hs
@@ -6,7 +6,7 @@ import qualified Control.Lens as Lens
 import Data.Aeson ((.!=), (.:), (.:?), (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.List as List
-import Data.Ord (Down (..))
+import Data.Ord (Down (..), comparing)
 import qualified Data.Text as Text
 import qualified Data.Time as Time
 import Gen.Prelude
@@ -165,7 +165,8 @@ instance ToJSON Library where
             "exposedModules" .= List.sort (l ^. exposedModules),
             "otherModules" .= List.sort (l ^. otherModules),
             "extraDependencies" .= List.sort (l ^. extraDependencies),
-            "operations" .= (l ^.. operations . Lens.each),
+            "operations"
+              .= List.sortBy (comparing _opName) (l ^.. operations . Lens.each),
             "shapes" .= List.sort (l ^.. shapes . Lens.each),
             "waiters" .= (l ^.. waiters . Lens.each)
           ]

--- a/gen/src/Gen/Types/Id.hs
+++ b/gen/src/Gen/Types/Id.hs
@@ -52,6 +52,9 @@ data Id = Id Text Text
 instance Eq Id where
   Id x _ == Id y _ = x == y
 
+instance Ord Id where
+  compare (Id x _) (Id y _) = compare x y
+
 instance Hashable Id where
   hashWithSalt n (Id x _) = hashWithSalt n x
 

--- a/gen/src/Gen/Types/Service.hs
+++ b/gen/src/Gen/Types/Service.hs
@@ -31,6 +31,7 @@ data Signature
   | V3HTTPS
   | V4
   | S3
+  | S3V4
   deriving (Eq, Show, Generic)
 
 sigToText :: Signature -> Text


### PR DESCRIPTION
~~I had hoped to teach `gen` how to handle recursive shape definitions in general, but ran out of time and mainline project work re-starts from next week. This at least lets us regenerate everything, as previously `rds-data` failed to generate due to a three-deep recursive cycle.~~

This PR teaches `gen` to handle recursive shape definitions.