### PR TITLE
Fix presign urls that are not for S3

### DIFF
--- a/lib/amazonka-core/src/Amazonka/Data/Body.hs
+++ b/lib/amazonka-core/src/Amazonka/Data/Body.hs
@@ -312,7 +312,8 @@ hashedBody = HashedStream
 -- | Invariant: only services that support _both_ standard and
 -- chunked signing expose 'RequestBody' as a parameter.
 data RequestBody
-  = Chunked ChunkedBody
+  = -- | Currently S3 only, see 'ChunkedBody' for details.
+    Chunked ChunkedBody
   | Hashed HashedBody
   deriving stock (Show)
 

--- a/lib/amazonka-core/src/Amazonka/Sign/V4.hs
+++ b/lib/amazonka-core/src/Amazonka/Sign/V4.hs
@@ -11,6 +11,7 @@ module Amazonka.Sign.V4
   )
 where
 
+import Amazonka.Bytes
 import Amazonka.Data.Body
 import Amazonka.Data.ByteString
 import Amazonka.Data.Headers
@@ -22,11 +23,18 @@ import Amazonka.Request
 import qualified Amazonka.Sign.V4.Base as Base
 import qualified Amazonka.Sign.V4.Chunked as Chunked
 import Amazonka.Types
+import qualified Data.ByteString as BS
 import qualified Data.CaseInsensitive as CI
 
 v4 :: Signer
 v4 = Signer sign presign
 
+-- |
+-- Presigns a URL according to the AWS Request Signature V4 spec <https://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html>.
+-- In the case that the URL contains a payload that is not signed when sending requests to Amazon S3, a literal `UNSIGNED-PAYLOAD`
+-- must be included when constructing the cannonical request. See <https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html>
+-- In the edge case that the request body is a @Amazonka.Data.Body.ChunkedBody@ we will also use the `UNSIGNED-PAYLOAD` literal as we won't consume the stream
+-- to hash it.
 presign :: Seconds -> Algorithm a
 presign ex rq a r ts = Base.signRequest meta mempty auth
   where
@@ -42,7 +50,15 @@ presign ex rq a r ts = Base.signRequest meta mempty auth
         . pair (CI.original hAMZSignedHeaders) (toBS shs)
         . pair (CI.original hAMZToken) (toBS <$> _authSessionToken a)
 
-    digest = Base.Tag "UNSIGNED-PAYLOAD"
+    digest =
+      case _requestBody rq of
+        Chunked _ -> unsignedPayload
+        Hashed (HashedStream h _ _) -> Base.Tag $ encodeBase16 h
+        Hashed (HashedBytes h b)
+          | BS.null b && _serviceSigningName (_requestService rq) == "s3" -> unsignedPayload
+          | otherwise -> Base.Tag $ encodeBase16 h
+
+    unsignedPayload = Base.Tag "UNSIGNED-PAYLOAD"
 
     prepare = requestHeaders %~ (hdr hHost host)
 

--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -45,6 +45,8 @@ Released: **?**, Compare: [2.0.0-rc1](https://github.com/brendanhay/amazonka/com
 
 ### Fixed
 
+- Presigning URLs that are not for S3
+[\#767](https://github.com/brendanhay/amazonka/pull/767)
 - Lenses for the `Env'` data type have been manually provided, as `generic-lens` cannot always derive them when required.
 [\#727](https://github.com/brendanhay/amazonka/pull/727)
 - `amazonka-s3`/`amazonka-glacier`: treat upload IDs are a mandatory part of the `CreateMultipartUpload`/`InitiateMultipartUpload` responses.


### PR DESCRIPTION
Fixes #766 
- If the body is HashedBody and == "", and the service is s3: hash "UNSIGNED-PAYLOAD"
- If the body is HashedBody but either of the above conditions fail: hash the body as provided to presign.
- If the body is ChunkedBody, hash "UNSIGNED-PAYLOAD". This is an edge-case I'd hardly expect to see: we don't want to consume the stream to hash it, and I can't imagine a sensible architecture that wants to presign requests (implying that the presigned request is handed off to something else) but has the stream on hand (what "somewhere else" is going to have the same stream we do?).