### PR TITLE
removes core reexports from main Amazonka module

### DIFF
--- a/lib/amazonka/src/Amazonka.hs
+++ b/lib/amazonka/src/Amazonka.hs
@@ -132,9 +132,6 @@ module Amazonka
 
     -- ** Constructing a Logger
     newLogger,
-
-    -- * Re-exported Types
-    module Amazonka.Core,
   )
 where
 


### PR DESCRIPTION
This MR is (initially) a coarse way to address #728. It simply removes the reexports of `Amazonka.Core` from the main `Amazonka` module.

This may remove too much, in that users expect to have certain types and function reexported from core, but I don't have enough context to know.