### PR TITLE
mtl-2.3 compatibility

### DIFF
--- a/lib/amazonka-core/amazonka-core.cabal
+++ b/lib/amazonka-core/amazonka-core.cabal
@@ -114,6 +114,7 @@ library
     , http-types            >=0.12
     , lens                  >=4.14
     , memory                >=0.6
+    , mtl                   >=2.2     && <2.4
     , regex-posix           >=0.96
     , resourcet             >=1.1
     , scientific            >=0.3

--- a/lib/amazonka-core/src/Amazonka/Error.hs
+++ b/lib/amazonka-core/src/Amazonka/Error.hs
@@ -14,6 +14,7 @@ import Amazonka.Types
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Types as Aeson.Types
 import qualified Data.ByteString.Lazy as LBS
+import Data.Either (fromRight)
 import qualified Network.HTTP.Client as Client
 import Network.HTTP.Types.Status (Status (..))
 

--- a/lib/amazonka-core/src/Amazonka/Prelude.hs
+++ b/lib/amazonka-core/src/Amazonka/Prelude.hs
@@ -47,7 +47,6 @@ import qualified Data.ByteString.Builder as ByteString.Builder
 import qualified Data.ByteString.Lazy as ByteString.Lazy
 import Data.CaseInsensitive as Export (CI)
 import Data.Coerce as Export (Coercible, coerce)
-import Data.Either as Export (fromRight)
 import Data.Function as Export ((&))
 import Data.Functor as Export ((<&>))
 import Data.Functor.Identity as Export (Identity (..))

--- a/lib/amazonka-core/src/Amazonka/Prelude.hs
+++ b/lib/amazonka-core/src/Amazonka/Prelude.hs
@@ -47,6 +47,7 @@ import qualified Data.ByteString.Builder as ByteString.Builder
 import qualified Data.ByteString.Lazy as ByteString.Lazy
 import Data.CaseInsensitive as Export (CI)
 import Data.Coerce as Export (Coercible, coerce)
+import Data.Either as Export (fromRight)
 import Data.Function as Export ((&))
 import Data.Functor as Export ((<&>))
 import Data.Functor.Identity as Export (Identity (..))

--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -59,6 +59,8 @@ Released: **?**, Compare: [2.0.0-rc1](https://github.com/brendanhay/amazonka/com
 [\#723](https://github.com/brendanhay/amazonka/pull/723)
 - `amazonka-ssm`: Various fields that are always available are no longer Maybe's.
 [\#741](https://github.com/brendanhay/amazonka/pull/741)
+- `amazonka-core`: to be compatible with mtl-2.3, avoid `Alternative (Either String)`
+[\#779](https://github.com/brendanhay/amazonka/pull/779)
 
 ## [2.0.0 RC1](https://github.com/brendanhay/amazonka/tree/2.0.0-rc1)
 Released: **28nd November, 2021**, Compare: [1.6.1](https://github.com/brendanhay/amazonka/compare/1.6.1...2.0.0-rc1)


### PR DESCRIPTION
Before this PR, compilation on mtl-2.3 fails with

```
src/Amazonka/Error.hs:98:51: error:
    • No instance for (Alternative (Either String))
        arising from a use of ‘<|>’
    • In the third argument of ‘either’, namely
        ‘(h .# hAMZRequestId <|> h .# hAMZNRequestId)’
      In the expression:
        either
          (const Nothing) Just (h .# hAMZRequestId <|> h .# hAMZNRequestId)
      In an equation for ‘getRequestId’:
          getRequestId h
            = either
                (const Nothing) Just (h .# hAMZRequestId <|> h .# hAMZNRequestId)
   |
98 |   either (const Nothing) Just (h .# hAMZRequestId <|> h .# hAMZNRequestId)
```

The instance `Alternative (Either String)` makes little sense to me since I don't know how the instance can manufacture an `empty` value for the Alternative instance.

So in this PR, I try to avoid this instance.

This is untested, I'd appreciate advice on how best to test this.