### PR TITLE
`amazonka-core`: urldecode parts when parsing to `QueryString`

### DIFF
--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -34,6 +34,8 @@ Released: **?**, Compare: [2.0.0-rc1](https://github.com/brendanhay/amazonka/com
 
 ### Changed
 
+- `amazonka-core`: urldecode query string parts when parsing to `QueryString`
+[\#780](https://github.com/brendanhay/amazonka/pull/769)
 - `amazonka-dynamodb`, `amazonka-dynamodb-streams`: Fix deserialisation of booleans
 [\#775](https://github.com/brendanhay/amazonka/pull/775)
 - `amazonka`: Add a public interface to send unsigned requests. Sending functions are now defined in `Amazonka.Send`, but are re-exported from `Amazonka`.


### PR DESCRIPTION
The query string parser did not handle %-encoding:

Before:
```
> parseQueryString "PostedBefore=2022-05-31T23%3A16%3A43Z&MaxResultsPerPage=100&PostedAfter=2022-05-31T22%3A16%3A43Z"
QList [QPair "PostedBefore" (QValue (Just "2022-05-31T23%3A16%3A43Z")),QPair "MaxResultsPerPage" (QValue (Just "100")),QPair "PostedAfter" (QValue (Just "2022-05-31T22%3A16%3A43Z"))]
```
After:
```
> parseQueryString "PostedBefore=2022-05-31T23%3A16%3A43Z&MaxResultsPerPage=100&PostedAfter=2022-05-31T22%3A16%3A43Z"
QList [QPair "PostedBefore" (QValue (Just "2022-05-31T23:16:43Z")),QPair "MaxResultsPerPage" (QValue (Just "100")),QPair "PostedAfter" (QValue (Just "2022-05-31T22:16:43Z"))]
```