### PR TITLE
sso(RoleCredentials): require accessKeyId and secretAccessKey

### DIFF
--- a/configs/services/sso.json
+++ b/configs/services/sso.json
@@ -5,6 +5,12 @@
             "requiredFields": [
                 "roleCredentials"
             ]
+        },
+        "RoleCredentials": {
+            "requiredFields": [
+                "accessKeyId",
+                "secretAccessKey"
+            ]
         }
     }
 }

--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -34,6 +34,8 @@ Released: **?**, Compare: [2.0.0-rc1](https://github.com/brendanhay/amazonka/com
 
 ### Changed
 
+- `amazonka-sso`: Mark `RoleCredentials_{accessKeyId,secretAccessKey}` as required
+[\#789](https://github.com/brendanhay/amazonka/pull/789)
 - `amazonka-core`: urldecode query string parts when parsing to `QueryString`
 [\#780](https://github.com/brendanhay/amazonka/pull/769)
 - `amazonka-dynamodb`, `amazonka-dynamodb-streams`: Fix deserialisation of booleans


### PR DESCRIPTION
Everywhere else I've seen AWS credentials, you always get an access key ID and a secret access key, and you may get a session token and an expiry time.