### PR TITLE
gen: delegate toJSON calls to the payload field if it exists

### DIFF
--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -53,6 +53,9 @@ Released: **?**, Compare: [2.0.0-rc1](https://github.com/brendanhay/amazonka/com
 
 ### Fixed
 
+- Generator: Correctly generate `ToJSON` instances for requests which set a `"payload":` field in `"type": "structure"` definitions.
+[\#790](https://github.com/brendanhay/amazonka/pull/790)
+  - Fixes some API calls in `amazonka-glacier` and `amazonka-pinpoint`
 - Presigning URLs that are not for S3
 [\#767](https://github.com/brendanhay/amazonka/pull/767)
 - `amazonka-s3`/`amazonka-glacier`: treat upload IDs are a mandatory part of the `CreateMultipartUpload`/`InitiateMultipartUpload` responses.


### PR DESCRIPTION
This should fix the ToJSON instances of some types in amazonka-glacier and amazonka-pinpoint.

While the [generated request schema](https://docs.aws.amazon.com/amazonglacier/latest/dev/api-initiate-job-post.html#api-initiate-job-post-requests-syntax) for glacier POSTs suggests that the job parameters are under an explicit key, the [actual examples](https://docs.aws.amazon.com/amazonglacier/latest/dev/api-initiate-job-post.html#api-initiate-job-post-example-retrieve-inventory-request) show them inlined into the body, just like the pinpoint requests described in #765.

This will fix the pinpoint services issue, but I'll close that with a "regenerate-all-services" PR.
