### PR TITLE
sso/sts fixups

### DIFF
--- a/configs/services/sso.json
+++ b/configs/services/sso.json
@@ -1,6 +1,12 @@
 {
     "libraryName": "amazonka-sso",
     "typeOverrides": {
+        "AccessKeyType": {
+            "replacedBy": {
+                "name": "Core.AccessKey",
+                "underive": []
+            }
+        },
         "GetRoleCredentialsResponse": {
             "requiredFields": [
                 "roleCredentials"
@@ -11,6 +17,15 @@
                 "accessKeyId",
                 "secretAccessKey"
             ]
+        },
+        "SecretAccessKeyType": {
+            "replacedBy": {
+                "name": "Core.SecretKey",
+                "underive": [
+                    "read",
+                    "show"
+                ]
+            }
         }
     }
 }

--- a/configs/services/sts.json
+++ b/configs/services/sts.json
@@ -25,6 +25,21 @@
                 ]
             }
         },
+        "AssumeRoleResponse": {
+            "requiredFields": [
+                "Credentials"
+            ]
+        },
+        "AssumeRoleWithWebIdentityResponse": {
+            "requiredFields": [
+                "Credentials"
+            ]
+        },
+        "AssumeRoleWithWebSAMLResponse": {
+            "requiredFields": [
+                "Credentials"
+            ]
+        },
         "Credentials": {
             "replacedBy": {
                 "name": "Core.AuthEnv",

--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -34,6 +34,11 @@ Released: **?**, Compare: [2.0.0-rc1](https://github.com/brendanhay/amazonka/com
 
 ### Changed
 
+
+- `amazonka-sso`: Use `amazonka-core` types in `GetRoleCredentials` response
+[\#791](https://github.com/brendanhay/amazonka/pull/791)
+- `amazonka-sts`: Mark `Credentials` as required in `AssumeRole*` responses
+[\#791](https://github.com/brendanhay/amazonka/pull/791)
 - `amazonka-sso`: Mark `RoleCredentials_{accessKeyId,secretAccessKey}` as required
 [\#789](https://github.com/brendanhay/amazonka/pull/789)
 - `amazonka-core`: urldecode query string parts when parsing to `QueryString`


### PR DESCRIPTION
STS: require `Credentials` in all `AssumeRole*` responses
SSO: Use `amazonka-core` types in `GetRoleCredentials` responses

Closes #768