### PR TITLE
Allow aeson-2.1

### DIFF
--- a/lib/amazonka-core/amazonka-core.cabal
+++ b/lib/amazonka-core/amazonka-core.cabal
@@ -99,7 +99,7 @@ library
     Amazonka.Waiter
 
   build-depends:
-    , aeson                 ^>=1.5.0.0 || ^>= 2.0.0.0
+    , aeson                 ^>=1.5.0.0 || >=2.0 && <2.2
     , attoparsec            >=0.11.3
     , bytestring            >=0.10.8
     , case-insensitive      >=1.2

--- a/lib/amazonka-s3-encryption/amazonka-s3-encryption.cabal
+++ b/lib/amazonka-s3-encryption/amazonka-s3-encryption.cabal
@@ -91,7 +91,7 @@ library
     Amazonka.S3.Encryption.Types
 
   build-depends:
-    , aeson                 ^>=1.5.0.0 || ^>= 2.0.0.0
+    , aeson                 ^>=1.5.0.0 || >=2.0 && <2.2
     , amazonka              ^>=2.0
     , amazonka-core         ^>=2.0
     , amazonka-kms          ^>=2.0

--- a/lib/amazonka/amazonka.cabal
+++ b/lib/amazonka/amazonka.cabal
@@ -97,7 +97,7 @@ library
     Amazonka.Data, Amazonka.Types, Amazonka.Bytes, Amazonka.Endpoint, Amazonka.Crypto
 
   build-depends:
-    , aeson                 ^>=1.5.0.0 || ^>=2.0.0.0
+    , aeson                 ^>=1.5.0.0 || >=2.0 && <2.2
     , amazonka-core         ^>=2.0
     , amazonka-sso          ^>=2.0
     , amazonka-sts          ^>=2.0


### PR DESCRIPTION
Tested using

    cabal test --constraint='aeson^>=2.1' -w ghc-9.2.4
