### PR TITLE
Fix haddock escaping for `fromFileEnv` function

### DIFF
--- a/lib/amazonka/src/Amazonka/Auth/ConfigFile.hs
+++ b/lib/amazonka/src/Amazonka/Auth/ConfigFile.hs
@@ -255,9 +255,9 @@ data CredentialSource = Environment | Ec2InstanceMetadata | EcsContainer
 -- This looks in in the @HOME@ directory as determined by the
 -- <http://hackage.haskell.org/package/directory directory> library.
 --
--- * Not Windows: @$HOME/.aws/credentials@
+-- * Not Windows: @$HOME\/.aws\/credentials@
 --
--- * Windows: @%USERPROFILE%\.aws\credentials@
+-- * Windows: @%USERPROFILE%\\.aws\\credentials@
 fromFileEnv ::
   (MonadIO m, Foldable withAuth) => Env' withAuth -> m Env
 fromFileEnv env = liftIO $ do


### PR DESCRIPTION
This PR adds some necessary escaping in the haddocks of the `fromFileEnv` function.

Without this PR, the haddocks look like:

![image](https://user-images.githubusercontent.com/64804/191580537-8d1f0096-8ba1-4cc7-a936-8757c5f513a0.png)

With the proper escaping from this PR, the haddocks now look like:

![image](https://user-images.githubusercontent.com/64804/191580644-81145fb0-1e17-4903-960b-ad9f55008b0f.png)

It is a little confusing that things in `@...@` in haddocks still require escaping.
