### PR TITLE
Implement Seconds with DiffTime

### DIFF
--- a/lib/amazonka-core/src/Amazonka/Types.hs
+++ b/lib/amazonka-core/src/Amazonka/Types.hs
@@ -819,13 +819,10 @@ pattern Mumbai = Region' "ap-south-1"
 -- | A numeric value representing seconds.
 newtype Seconds = Seconds DiffTime
   deriving stock (Eq, Ord, Read, Show, Generic)
-  deriving newtype
-    ( Enum,
-      Num,
-      Real,
-      Hashable,
-      NFData
-    )
+  deriving newtype (Enum, Num, Real, NFData)
+
+instance Hashable Seconds where
+  hashWithSalt salt = hashWithSalt salt . toRational . toSeconds
 
 instance FromText Seconds where
   fromText t = maybe (Left err) (Right . Seconds)


### PR DESCRIPTION
There are known use cases for more precision than whole seconds.

Some choices were made:

1. In conversion to/from text values, we format and parse as `%Es`,
   which is whole seconds and up to 12 decimal points, if necessary

   This may be a compatibility concern, if clients are trying to use a
   _formatted_ `Seconds` and don't expect the decimal point.

   I can't see this being an issue for parsing AWS responses. This
   represents a relaxing of the parser (we now accept decimals), so
   nothing that worked before should fail now.

2. In conversion to (whole) microseconds, we `round`.

   We could do that differently (e.g. `floor`, or `ceil`), or we could
   retain as much precision as we can by not returning `Int` from this
   function either.

   I don't feel that precision beyond microseconds is useful. Evidence
   for this would be the Haskell `threadDelay` and `timeout` functions,
   and our current (only) use-case, which is setting retries in the
   `HTTP` module. None would gain any value, and in fact would only be
   made more complex, if we returned more precision.

Closes https://github.com/brendanhay/amazonka/issues/638.