### PR TITLE
Use two-step token request for Instance MetaData

### DIFF
--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -102,6 +102,8 @@ Released: **?**, Compare: [2.0.0-rc1](https://github.com/brendanhay/amazonka/com
 [\#724](https://github.com/brendanhay/amazonka/pull/724)
 - `amazonka`: SSO authentication support (thanks @pbrisbin)
 [\#757](https://github.com/brendanhay/amazonka/pull/757)
+- `amazonka`: Use IMDSv2 for metadata requests on EC2 (thanks @pbrisbin)
+[\#831](https://github.com/brendanhay/amazonka/pull/831)
 
 ### Fixed
 

--- a/lib/amazonka/src/Amazonka/EC2/Metadata.hs
+++ b/lib/amazonka/src/Amazonka/EC2/Metadata.hs
@@ -296,7 +296,7 @@ isEC2 :: MonadIO m => Client.Manager -> m Bool
 isEC2 m = liftIO (Exception.catch req err)
   where
     req = do
-      !_ <- request m "http://instance-data/latest"
+      !_ <- get m "http://instance-data/latest"
 
       return True
 
@@ -462,9 +462,6 @@ get m url = liftIO $ do
     strip bs
       | BS8.isSuffixOf "\n" bs = BS8.init bs
       | otherwise = bs
-
-request :: Client.Manager -> Text -> IO ByteString
-request = requestWith id
 
 requestWith ::
   (Client.Request -> Client.Request) ->

--- a/lib/amazonka/src/Amazonka/EC2/Metadata.hs
+++ b/lib/amazonka/src/Amazonka/EC2/Metadata.hs
@@ -452,14 +452,12 @@ get m url = liftIO $ do
     requestToken =
       requestWith
         ( setRequestMethod "PUT"
-            . setRequestHeader (headerPrefix <> "token-ttl-seconds") ["21600"]
+            . setRequestHeader "X-aws-ec2-metadata-token-ttl-seconds" ["21600"]
         )
         m
         (latest <> "/api/token")
 
-    addToken token = setRequestHeader (headerPrefix <> "token") [token]
-
-    headerPrefix = "X-aws-ec2-metadata-"
+    addToken token = setRequestHeader "X-aws-ec2-metadata-token" [token]
 
     strip bs
       | BS8.isSuffixOf "\n" bs = BS8.init bs

--- a/lib/amazonka/src/Amazonka/EC2/Metadata.hs
+++ b/lib/amazonka/src/Amazonka/EC2/Metadata.hs
@@ -452,7 +452,7 @@ get m url = liftIO $ do
     requestToken =
       requestWith
         ( setRequestMethod "PUT"
-            . setRequestHeader "X-aws-ec2-metadata-token-ttl-seconds" ["21600"]
+            . setRequestHeader "X-aws-ec2-metadata-token-ttl-seconds" ["60"]
         )
         m
         (latest <> "api/token")

--- a/lib/amazonka/src/Amazonka/EC2/Metadata.hs
+++ b/lib/amazonka/src/Amazonka/EC2/Metadata.hs
@@ -455,7 +455,7 @@ get m url = liftIO $ do
             . setRequestHeader "X-aws-ec2-metadata-token-ttl-seconds" ["21600"]
         )
         m
-        (latest <> "/api/token")
+        (latest <> "api/token")
 
     addToken token = setRequestHeader "X-aws-ec2-metadata-token" [token]
 

--- a/lib/amazonka/src/Amazonka/EC2/Metadata.hs
+++ b/lib/amazonka/src/Amazonka/EC2/Metadata.hs
@@ -325,7 +325,7 @@ userdata m =
     Exception.try (get m (latest <> "user-data")) >>= \case
       Left (Client.HttpExceptionRequest _ (Client.StatusCodeException rs _))
         | fromEnum (Client.responseStatus rs) == 404 ->
-            return Nothing
+          return Nothing
       --
       Left e -> Exception.throwIO e
       --


### PR DESCRIPTION
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html

A few caveats:

- This requests a new token on every separate use a `get`. It would be
  better to support requesting a token first and re-using it across many
  calls, but the current interface doesn't support that and would have
  to be re-designed. I'm happy to do that, if given guidance on
  preferred ergonomics (`ReaderT`? Explicit argument passing? Set up the
  `Manager` with a `modifyRequest`?)

- The timeout of 21600 comes from the docs. We could probably go
  shorter given point one.

- I don't have any easy way to verify that this works. Does there happen
  to be integration test coverage?

Closes #745.
