### PR TITLE
amazonka-core: 304 is the only successful redirect response

### DIFF
--- a/lib/amazonka-core/src/Amazonka/Error.hs
+++ b/lib/amazonka-core/src/Amazonka/Error.hs
@@ -46,7 +46,7 @@ _MatchServiceError ::
 _MatchServiceError s c = _ServiceError . hasService s . hasCode c
 
 statusSuccess :: Status -> Bool
-statusSuccess (statusCode -> n) = n >= 200 && n < 400
+statusSuccess (statusCode -> n) = n >= 200 && n < 300 || n == 304
 
 _HttpStatus :: AsError a => Getting (First Status) a Status
 _HttpStatus = _Error . f

--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -105,6 +105,8 @@ Released: **?**, Compare: [2.0.0-rc1](https://github.com/brendanhay/amazonka/com
 
 ### Fixed
 
+- `amazonka-core`: Only consider 2xx and 304 responses as successful
+[\#835](https://github.com/brendanhay/amazonka/pull/835)
 - `amazonka-core`: Allow customisation of S3 addressing styles like Boto 3 can (thanks @basvandijk, @ivb-supercede)
 [\#832](https://github.com/brendanhay/amazonka/pull/832)
 - `amazonka-core`: Correctly split error-codes-in-headers at the first colon


### PR DESCRIPTION
From https://github.com/brendanhay/amazonka/issues/755:

> If you use the wrong region and do a simple S3 `GetObject`, then the
> response is a 301 redirect. The problem is that this library treats
> this as a successful response, and returns the AWS XML redirect page
> as the response body!

However, S3 returns 304 if a request matches the given ETag. Therefore, consider only 2xx and 304 responses as successful.

Closes #755