### PR TITLE
Finer data exports

### DIFF
--- a/configs/services/kinesis.json
+++ b/configs/services/kinesis.json
@@ -3,7 +3,7 @@
     "typeOverrides": {
         "SubscribeToShardEventStream": {
             "replacedBy": {
-                "name": "Core.Value",
+                "name": "Data.Value",
                 "underive": [
                     "show",
                     "read",

--- a/configs/templates/sum.ede
+++ b/configs/templates/sum.ede
@@ -40,18 +40,18 @@ import {{ import.value }}
   deriving newtype
       ( Prelude.Hashable
       , Prelude.NFData
-      , Core.FromText
-      , Core.ToText
-      , Core.ToByteString
-      , Core.ToLog
-      , Core.ToHeader
-      , Core.ToQuery
-      , Core.FromJSON
-      , Core.FromJSONKey
-      , Core.ToJSON 
-      , Core.ToJSONKey
-      , Core.FromXML
-      , Core.ToXML
+      , Data.FromText
+      , Data.ToText
+      , Data.ToByteString
+      , Data.ToLog
+      , Data.ToHeader
+      , Data.ToQuery
+      , Data.FromJSON
+      , Data.FromJSONKey
+      , Data.ToJSON
+      , Data.ToJSONKey
+      , Data.FromXML
+      , Data.ToXML
     )
 
 {% for ctor in shape.constructors %}

--- a/examples/src/DynamoDB.hs
+++ b/examples/src/DynamoDB.hs
@@ -13,11 +13,13 @@ import Amazonka
 import Amazonka.DynamoDB as DynamoDB
 import Control.Lens
 import Control.Monad.IO.Class
+import Data.ByteString (ByteString)
 import Data.Conduit
 import qualified Data.Conduit.List as CL
 import Data.Generics.Product
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as Map
+import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import System.IO
@@ -44,7 +46,7 @@ printTables reg sec hst prt = do
         . configureService dynamo
 
   runResourceT $ do
-    say $ "Listing all tables in region " <> toText reg
+    say $ "Listing all tables in region " <> fromRegion reg
     runConduit $
       paginate env newListTables
         .| CL.concatMap (view (field @"tableNames" . _Just))

--- a/examples/src/EC2.hs
+++ b/examples/src/EC2.hs
@@ -26,7 +26,7 @@ instanceOverview reg = do
           [ "[instance:" <> build (x ^. #instanceId) <> "] {",
             "\n  public-dns = " <> build (x ^. #publicDnsName),
             "\n  tags       = " <> build (x ^. #tags . to show),
-            "\n  state      = " <> build (x ^. #state . #name . to toBS),
+            "\n  state      = " <> build (x ^. #state . #name . to fromInstanceStateName),
             "\n}\n"
           ]
 

--- a/examples/src/ExceptionSemantics.hs
+++ b/examples/src/ExceptionSemantics.hs
@@ -15,6 +15,7 @@ import Data.Conduit
 import qualified Data.Conduit.List as CL
 import Data.Generics.Product
 import Data.List.NonEmpty (NonEmpty (..))
+import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import System.IO
@@ -33,7 +34,7 @@ exceptions reg n = do
   let scan = newScan n & field @"attributesToGet" ?~ "foo" :| []
 
   runResourceT $ do
-    sayLn $ "Listing all tables in region " <> toText reg
+    sayLn $ "Listing all tables in region " <> fromRegion reg
     runConduit $
       paginate env newListTables
         .| CL.concatMap (view (field @"tableNames" . _Just))

--- a/examples/src/SQS.hs
+++ b/examples/src/SQS.hs
@@ -13,6 +13,7 @@ import Control.Monad
 import Control.Monad.IO.Class
 import Data.Foldable (for_)
 import Data.Generics.Labels ()
+import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import System.IO

--- a/gen/src/Gen/AST/Data.hs
+++ b/gen/src/Gen/AST/Data.hs
@@ -149,7 +149,7 @@ sumData p s i vs = Sum s <$> mk <*> fmap HashMap.keys insts
       Exts.RecDecl
         ()
         (ident ctor)
-        [ Exts.FieldDecl () [ident ("from" <> typeId n)] (tycon "Core.Text")
+        [ Exts.FieldDecl () [ident ("from" <> typeId n)] (tycon "Data.Text")
         ]
 
     -- Sometimes the values share a name with a type, so we prime the

--- a/gen/src/Gen/AST/Data/Instance.hs
+++ b/gen/src/Gen/AST/Data/Instance.hs
@@ -40,15 +40,15 @@ instToText = \case
 
 instToQualifiedText :: Inst -> Text
 instToQualifiedText = \case
-  FromJSON {} -> "Core.FromJSON"
-  FromXML {} -> "Core.FromXML"
-  ToJSON {} -> "Core.ToJSON"
-  ToXML {} -> "Core.ToXML"
-  ToElement {} -> "Core.ToElement"
-  ToHeaders {} -> "Core.ToHeaders"
-  ToQuery {} -> "Core.ToQuery"
-  ToPath {} -> "Core.ToPath"
-  ToBody {} -> "Core.ToBody"
+  FromJSON {} -> "Data.FromJSON"
+  FromXML {} -> "Data.FromXML"
+  ToJSON {} -> "Data.ToJSON"
+  ToXML {} -> "Data.ToXML"
+  ToElement {} -> "Data.ToElement"
+  ToHeaders {} -> "Data.ToHeaders"
+  ToQuery {} -> "Data.ToQuery"
+  ToPath {} -> "Data.ToPath"
+  ToBody {} -> "Data.ToBody"
   IsHashable {} -> "Prelude.Hashable"
   IsNFData {} -> "Prelude.NFData"
 

--- a/gen/src/Gen/Import.hs
+++ b/gen/src/Gen/Import.hs
@@ -15,6 +15,7 @@ operationImports l _o =
     "qualified Amazonka.Response as Response" :
     "qualified Amazonka.Core as Core" :
     "qualified Amazonka.Core.Lens.Internal as Lens" :
+    "qualified Amazonka.Data as Data" :
     "qualified Amazonka.Prelude as Prelude" :
     l ^. typesNS :
     l ^. operationModules
@@ -36,6 +37,7 @@ sumImports :: Library -> [NS]
 sumImports l =
   List.sort $
     "qualified Amazonka.Core as Core" :
+    "qualified Amazonka.Data as Data" :
     "qualified Amazonka.Prelude as Prelude" :
     l ^. typeModules
 
@@ -44,6 +46,7 @@ productImports l p =
   List.sort $
     "qualified Amazonka.Core as Core" :
     "qualified Amazonka.Core.Lens.Internal as Lens" :
+    "qualified Amazonka.Data as Data" :
     "qualified Amazonka.Prelude as Prelude" :
     l ^. typeModules ++ productDependencies l p
 
@@ -72,6 +75,7 @@ waiterImports l =
   List.sort $
     "qualified Amazonka.Core as Core" :
     "qualified Amazonka.Core.Lens.Internal as Lens" :
+    "qualified Amazonka.Data as Data" :
     "qualified Amazonka.Prelude as Prelude" :
     l ^. typesNS :
     l ^. lensNS :

--- a/gen/src/Gen/Tree.hs
+++ b/gen/src/Gen/Tree.hs
@@ -194,7 +194,7 @@ bootShape' l template s =
     Module
       { name = (l ^. typesNS) <> ((mkNS . typeId) $ identifier s),
         imports =
-          [ "qualified Amazonka.Core as Core",
+          [ "qualified Amazonka.Data as Data",
             "qualified Amazonka.Prelude as Prelude"
           ],
         template,

--- a/lib/amazonka-core/src/Amazonka/Core.hs
+++ b/lib/amazonka-core/src/Amazonka/Core.hs
@@ -19,7 +19,13 @@ module Amazonka.Core
   )
 where
 
-import Amazonka.Data
+-- Export Amazonka.Data submodules piecemeal and avoid exporting AWS
+-- encoding/decoding modules, so we don't leak too much to library
+-- clients. Service bindings import Amazonka.Data directly.
+import Amazonka.Data.Base64 as Amazonka.Data
+import Amazonka.Data.Body as Amazonka.Data
+import Amazonka.Data.Log as Amazonka.Data
+import Amazonka.Data.Sensitive as Amazonka.Data
 import Amazonka.Endpoint
 import Amazonka.Error
 import Amazonka.Pager

--- a/lib/amazonka-core/src/Amazonka/Request.hs
+++ b/lib/amazonka-core/src/Amazonka/Request.hs
@@ -42,6 +42,7 @@ module Amazonka.Request
 where
 
 import Amazonka.Core
+import Amazonka.Data
 import Amazonka.Prelude
 import qualified Data.ByteString.Char8 as B8
 import qualified Network.HTTP.Client as Client

--- a/lib/amazonka-core/test/Test/Amazonka/Arbitrary.hs
+++ b/lib/amazonka-core/test/Test/Amazonka/Arbitrary.hs
@@ -10,6 +10,7 @@
 module Test.Amazonka.Arbitrary where
 
 import Amazonka.Core
+import Amazonka.Data
 import Amazonka.Prelude
 import Amazonka.Sign.V4
 import qualified Data.ByteString.Char8 as BS8

--- a/lib/amazonka-core/test/Test/Amazonka/Data/List.hs
+++ b/lib/amazonka-core/test/Test/Amazonka/Data/List.hs
@@ -8,9 +8,8 @@
 module Test.Amazonka.Data.List (tests) where
 
 import Amazonka.Core
-import Amazonka.Prelude hiding
-  ( Item,
-  )
+import Amazonka.Data
+import Amazonka.Prelude hiding (Item)
 import Test.Amazonka.Util
 import Test.Tasty
 

--- a/lib/amazonka-core/test/Test/Amazonka/Data/Maybe.hs
+++ b/lib/amazonka-core/test/Test/Amazonka/Data/Maybe.hs
@@ -7,10 +7,8 @@
 -- Portability : non-portable (GHC extensions)
 module Test.Amazonka.Data.Maybe (tests) where
 
-import Amazonka.Core
-import Amazonka.Prelude hiding
-  ( Item,
-  )
+import Amazonka.Data
+import Amazonka.Prelude hiding (Item)
 import Test.Amazonka.Util
 import Test.Tasty
 import Test.Tasty.HUnit

--- a/lib/amazonka-core/test/Test/Amazonka/Data/Numeric.hs
+++ b/lib/amazonka-core/test/Test/Amazonka/Data/Numeric.hs
@@ -7,7 +7,6 @@
 -- Portability : non-portable (GHC extensions)
 module Test.Amazonka.Data.Numeric (tests) where
 
-import Amazonka.Core
 import Amazonka.Prelude
 import Test.Amazonka.Util
 import Test.Tasty

--- a/lib/amazonka-core/test/Test/Amazonka/Data/Path.hs
+++ b/lib/amazonka-core/test/Test/Amazonka/Data/Path.hs
@@ -7,7 +7,7 @@
 -- Portability : non-portable (GHC extensions)
 module Test.Amazonka.Data.Path (tests) where
 
-import Amazonka.Core
+import Amazonka.Data
 import Amazonka.Prelude
 import Test.Tasty
 import Test.Tasty.HUnit

--- a/lib/amazonka-core/test/Test/Amazonka/Data/Query.hs
+++ b/lib/amazonka-core/test/Test/Amazonka/Data/Query.hs
@@ -7,7 +7,7 @@
 -- Portability : non-portable (GHC extensions)
 module Test.Amazonka.Data.Query (tests) where
 
-import Amazonka.Core
+import Amazonka.Data
 import Amazonka.Prelude
 import Test.Tasty
 import Test.Tasty.HUnit (testCase, (@?=))

--- a/lib/amazonka-core/test/Test/Amazonka/Data/Time.hs
+++ b/lib/amazonka-core/test/Test/Amazonka/Data/Time.hs
@@ -7,7 +7,7 @@
 -- Portability : non-portable (GHC extensions)
 module Test.Amazonka.Data.Time (tests) where
 
-import Amazonka.Core hiding (error)
+import Amazonka.Data
 import Amazonka.Prelude
 import qualified Data.Time as Time
 import Test.Amazonka.Util

--- a/lib/amazonka-core/test/Test/Amazonka/Error.hs
+++ b/lib/amazonka-core/test/Test/Amazonka/Error.hs
@@ -8,6 +8,7 @@
 module Test.Amazonka.Error (tests) where
 
 import Amazonka.Core
+import Amazonka.Data
 import Amazonka.Prelude
 import Network.HTTP.Types.Status (status400, status404)
 import Test.Amazonka.Arbitrary ()

--- a/lib/amazonka-core/test/Test/Amazonka/Sign/V2Header.hs
+++ b/lib/amazonka-core/test/Test/Amazonka/Sign/V2Header.hs
@@ -4,7 +4,7 @@
 -- Portability : non-portable (GHC extensions)
 module Test.Amazonka.Sign.V2Header (tests) where
 
-import Amazonka.Core hiding (length, nonEmptyText)
+import Amazonka.Data hiding (length)
 import Amazonka.Prelude
 import Amazonka.Sign.V2Header
 import qualified Data.ByteString.Char8 as BS8
@@ -270,7 +270,7 @@ allIncreasing xs =
 
 testHeaders :: [HTTP.Header] -> Bool
 testHeaders headers =
-  length sortedHeaders == length sortedHeaders && allIncreasing sortedHeaders
+  length headers == length sortedHeaders && allIncreasing sortedHeaders
   where
     sortedHeaders = List.sort headers
 

--- a/lib/amazonka-core/test/Test/Amazonka/Sign/V4/Base.hs
+++ b/lib/amazonka-core/test/Test/Amazonka/Sign/V4/Base.hs
@@ -8,6 +8,7 @@
 module Test.Amazonka.Sign.V4.Base where
 
 import Amazonka.Core
+import Amazonka.Data
 import Amazonka.Prelude
 import Amazonka.Sign.V4
 import Amazonka.Sign.V4.Base as Base

--- a/lib/amazonka-core/test/Test/Amazonka/Util.hs
+++ b/lib/amazonka-core/test/Test/Amazonka/Util.hs
@@ -7,7 +7,7 @@
 -- Portability : non-portable (GHC extensions)
 module Test.Amazonka.Util where
 
-import Amazonka.Core hiding (error)
+import Amazonka.Data
 import Amazonka.Prelude
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS

--- a/lib/amazonka-s3-encryption/src/Amazonka/S3/Encryption/Encrypt.hs
+++ b/lib/amazonka-s3-encryption/src/Amazonka/S3/Encryption/Encrypt.hs
@@ -11,6 +11,7 @@ module Amazonka.S3.Encryption.Encrypt where
 
 import qualified Amazonka as AWS
 import Amazonka.Core
+import Amazonka.Data
 import Amazonka.Prelude
 import qualified Amazonka.S3 as S3
 import Amazonka.S3.Encryption.Envelope

--- a/lib/amazonka-s3-encryption/src/Amazonka/S3/Encryption/Envelope.hs
+++ b/lib/amazonka-s3-encryption/src/Amazonka/S3/Encryption/Envelope.hs
@@ -10,7 +10,7 @@
 module Amazonka.S3.Encryption.Envelope where
 
 import qualified Amazonka as AWS
-import Amazonka.Core
+import Amazonka.Data
 import qualified Amazonka.KMS as KMS
 import qualified Amazonka.KMS.Lens as KMS
 import Amazonka.Prelude hiding (length)

--- a/lib/amazonka-s3-encryption/src/Amazonka/S3/Encryption/Types.hs
+++ b/lib/amazonka-s3-encryption/src/Amazonka/S3/Encryption/Types.hs
@@ -9,7 +9,7 @@
 -- Portability : non-portable (GHC extensions)
 module Amazonka.S3.Encryption.Types where
 
-import Amazonka.Core
+import Amazonka.Data
 import Amazonka.Prelude
 import qualified Amazonka.S3 as S3
 import qualified Control.Exception.Lens as Exception.Lens

--- a/lib/amazonka-s3-encryption/test/Test/Amazonka/S3/Encryption/Envelope.hs
+++ b/lib/amazonka-s3-encryption/test/Test/Amazonka/S3/Encryption/Envelope.hs
@@ -15,6 +15,7 @@ import Control.Monad.Trans.Resource
 import Crypto.Cipher.AES
 import Crypto.Cipher.Types
 import Crypto.Error
+import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.Conduit
 import qualified Data.Conduit.List as CL

--- a/lib/amazonka-test/src/Test/Amazonka/Fixture.hs
+++ b/lib/amazonka-test/src/Test/Amazonka/Fixture.hs
@@ -19,6 +19,7 @@
 module Test.Amazonka.Fixture where
 
 import Amazonka.Core
+import Amazonka.Data
 import Amazonka.Prelude
 import Control.Monad.Trans.Resource
 import qualified Data.ByteString.Lazy as LBS

--- a/lib/amazonka-test/src/Test/Amazonka/Orphans.hs
+++ b/lib/amazonka-test/src/Test/Amazonka/Orphans.hs
@@ -12,7 +12,7 @@
 -- Portability : non-portable (GHC extensions)
 module Test.Amazonka.Orphans where
 
-import Amazonka.Core
+import Amazonka.Data
 import Data.Aeson
 
 instance FromJSON ByteString where

--- a/lib/amazonka-test/src/Test/Amazonka/TH.hs
+++ b/lib/amazonka-test/src/Test/Amazonka/TH.hs
@@ -13,8 +13,8 @@
 -- Portability : non-portable (GHC extensions)
 module Test.Amazonka.TH where
 
-import Amazonka.Core hiding (error)
 import Amazonka.Core.Lens.Internal (view)
+import Amazonka.Data
 import Data.Time (Day (..), DiffTime, UTCTime (..))
 import Language.Haskell.TH
 import Language.Haskell.TH.Syntax

--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -32,6 +32,11 @@ Released: **?**, Compare: [2.0.0-rc1](https://github.com/brendanhay/amazonka/com
 
   - The `Amazonka.Auth.runCredentialChain` function allows you to build your own custom credential chains.
 
+- Select parts of `amazonka-core:Amazonka.Data` are now re-exported from `amazonka-core:Amazonka.Core` (and by extension, `amazonka:Amazonka`), instead of the entire module. [\#851](https://github.com/brendanhay/amazonka/pull/851).
+
+  - In particular, serialisation classes and helpers are no longer exported, and service bindings import `Amazonka.Data` directly.
+  - Most library users should see little difference, but the `ToText` and `ToByteString` classes are no longer exported by default.
+
 - Records within the `amazonka-core` and `amazonka` libraries no longer have (inconsistent) leading underscores or prefixes [\#844](https://github.com/brendanhay/amazonka/pull/844). A few other functions were renamed/removed for consistency or to avoid name clashes:
 
   - `Amazonka.Env.envAuthMaybe` -> `Amazonka.authMaybe` (and its re-export from `Amazonka`)

--- a/lib/services/amazonka-dynamodb-streams/src/Amazonka/DynamoDBStreams/Internal.hs
+++ b/lib/services/amazonka-dynamodb-streams/src/Amazonka/DynamoDBStreams/Internal.hs
@@ -16,7 +16,7 @@
 -- Portability : non-portable (GHC extensions)
 module Amazonka.DynamoDBStreams.Internal where
 
-import Amazonka.Core
+import Amazonka.Data
 import Amazonka.Prelude
 import Data.Aeson (pairs)
 import Data.Hashable

--- a/lib/services/amazonka-dynamodb/src/Amazonka/DynamoDB/Types/AttributeValue.hs
+++ b/lib/services/amazonka-dynamodb/src/Amazonka/DynamoDB/Types/AttributeValue.hs
@@ -16,7 +16,7 @@
 -- Portability : non-portable (GHC extensions)
 module Amazonka.DynamoDB.Types.AttributeValue where
 
-import Amazonka.Core
+import Amazonka.Data
 import Amazonka.Prelude
 import Data.Aeson (pairs)
 import Data.Hashable

--- a/lib/services/amazonka-dynamodb/src/Amazonka/DynamoDB/Types/WriteRequest.hs
+++ b/lib/services/amazonka-dynamodb/src/Amazonka/DynamoDB/Types/WriteRequest.hs
@@ -16,10 +16,17 @@
 -- Portability : non-portable (GHC extensions)
 module Amazonka.DynamoDB.Types.WriteRequest where
 
-import Amazonka.Core
 import Amazonka.DynamoDB.Types.AttributeValue (AttributeValue)
 import Amazonka.Prelude
-import Data.Aeson (pairs)
+import Data.Aeson
+  ( FromJSON (..),
+    ToJSON (..),
+    object,
+    pairs,
+    withObject,
+    (.:),
+    (.=),
+  )
 import Data.Map (Map)
 
 #if MIN_VERSION_aeson(2,0,0)

--- a/lib/services/amazonka-ec2/src/Amazonka/EC2/Internal.hs
+++ b/lib/services/amazonka-ec2/src/Amazonka/EC2/Internal.hs
@@ -11,45 +11,45 @@
 -- Portability : non-portable (GHC extensions)
 module Amazonka.EC2.Internal where
 
-import Amazonka.Core
 import Amazonka.Core.Lens.Internal
+import Amazonka.Data
 import Amazonka.Prelude
 
 -- | Custom 'Tag' type which has an optional value component.
 --
 -- /See:/ 'tag' smart constructor.
-data DeleteTag = DeleteTag
-  { _deleteTagKey :: !Text,
-    _deleteTagValue :: !(Maybe Text)
+data DeleteTag = DeleteTag'
+  { key :: !Text,
+    value :: !(Maybe Text)
   }
   deriving (Eq, Read, Show, Generic)
 
-deleteTag ::
-  -- | 'deleteTagKey'
+newDeleteTag ::
+  -- | 'key'
   Text ->
   DeleteTag
-deleteTag k = DeleteTag k Nothing
+newDeleteTag k = DeleteTag' k Nothing
 
 -- | The key of the tag to delete.
 --
 -- Constraints: Tag keys are case-sensitive and accept a maximum of 127
 -- Unicode characters. May not begin with 'aws:'
-deleteTagKey :: Lens' DeleteTag Text
-deleteTagKey = lens _deleteTagKey (\s a -> s {_deleteTagKey = a})
+deleteTag_key :: Lens' DeleteTag Text
+deleteTag_key = lens key (\s a -> s {key = a})
 
 -- | The optional value of the tag to delete.
 --
 -- Constraints: Tag values are case-sensitive and accept a maximum of 255
 -- Unicode characters.
-deleteTagValue :: Lens' DeleteTag (Maybe Text)
-deleteTagValue = lens _deleteTagValue (\s a -> s {_deleteTagValue = a})
+deleteTag_value :: Lens' DeleteTag (Maybe Text)
+deleteTag_value = lens value (\s a -> s {value = a})
 
 instance FromXML DeleteTag where
-  parseXML x = DeleteTag <$> (x .@ "key") <*> (x .@? "value")
+  parseXML x = DeleteTag' <$> (x .@ "key") <*> (x .@? "value")
 
 instance ToQuery DeleteTag where
-  toQuery DeleteTag {..} =
+  toQuery DeleteTag' {..} =
     mconcat
-      [ "Key" =: _deleteTagKey,
-        "Value" =: _deleteTagValue
+      [ "Key" =: key,
+        "Value" =: value
       ]

--- a/lib/services/amazonka-elb/src/Amazonka/ELB/Internal.hs
+++ b/lib/services/amazonka-elb/src/Amazonka/ELB/Internal.hs
@@ -16,6 +16,7 @@ module Amazonka.ELB.Internal
     ) where
 
 import Amazonka.Core
+import Amazonka.Data
 
 -- | This account identifier is used when attaching a policy to your S3 bucket
 -- allowing ELB to upload and write access logs.

--- a/lib/services/amazonka-redshift/src/Amazonka/Redshift/Internal.hs
+++ b/lib/services/amazonka-redshift/src/Amazonka/Redshift/Internal.hs
@@ -1,6 +1,5 @@
-{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-
 {-# OPTIONS_GHC -Wall -Werror #-}
 
 -- |
@@ -10,12 +9,13 @@
 -- Maintainer  : Brendan Hay <brendan.g.hay@gmail.com>
 -- Stability   : experimental
 -- Portability : non-portable (GHC extensions)
---
 module Amazonka.Redshift.Internal
-    ( getAccountId
-    ) where
+  ( getAccountId,
+  )
+where
 
 import Amazonka.Core
+import Amazonka.Data
 
 -- | This account identifier is used when attaching a policy to your S3 bucket
 -- allowing Redshift to upload and write database audit logs.
@@ -23,25 +23,25 @@ import Amazonka.Core
 -- /See:/ <http://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html#db-auditing-enable-logging Enabling Database Audit Logging>.
 getAccountId :: Region -> Maybe Text
 getAccountId = \case
-    NorthVirginia   -> Just "193672423079"
-    Ohio            -> Just "391106570357"
-    NorthCalifornia -> Just "262260360010"
-    Oregon          -> Just "902366379725"
-    CapeTown        -> Just "365689465814"
-    HongKong        -> Just "313564881002"
-    Mumbai          -> Just "865932855811"
-    Osaka           -> Just "090321488786"
-    Seoul           -> Just "760740231472"
-    Singapore       -> Just "361669875840"
-    Sydney          -> Just "762762565011"
-    Tokyo           -> Just "404641285394"
-    Montreal        -> Just "907379612154"
-    Frankfurt       -> Just "053454850223"
-    Ireland         -> Just "210876761215"
-    London          -> Just "307160386991"
-    Milan           -> Just "945612479654"
-    Paris           -> Just "915173422425"
-    Stockholm       -> Just "729911121831"
-    Bahrain         -> Just "013126148197"
-    SaoPaulo        -> Just "075028567923"
-    _other          -> Nothing
+  NorthVirginia -> Just "193672423079"
+  Ohio -> Just "391106570357"
+  NorthCalifornia -> Just "262260360010"
+  Oregon -> Just "902366379725"
+  CapeTown -> Just "365689465814"
+  HongKong -> Just "313564881002"
+  Mumbai -> Just "865932855811"
+  Osaka -> Just "090321488786"
+  Seoul -> Just "760740231472"
+  Singapore -> Just "361669875840"
+  Sydney -> Just "762762565011"
+  Tokyo -> Just "404641285394"
+  Montreal -> Just "907379612154"
+  Frankfurt -> Just "053454850223"
+  Ireland -> Just "210876761215"
+  London -> Just "307160386991"
+  Milan -> Just "945612479654"
+  Paris -> Just "915173422425"
+  Stockholm -> Just "729911121831"
+  Bahrain -> Just "013126148197"
+  SaoPaulo -> Just "075028567923"
+  _other -> Nothing

--- a/lib/services/amazonka-route53/src/Amazonka/Route53/Internal.hs
+++ b/lib/services/amazonka-route53/src/Amazonka/Route53/Internal.hs
@@ -22,6 +22,7 @@ module Amazonka.Route53.Internal
     ) where
 
 import Amazonka.Core
+import Amazonka.Data
 import Amazonka.Prelude
 import qualified Data.Text as Text
 

--- a/lib/services/amazonka-s3/src/Amazonka/S3/Internal.hs
+++ b/lib/services/amazonka-s3/src/Amazonka/S3/Internal.hs
@@ -16,9 +16,18 @@
 -- Portability : non-portable (GHC extensions)
 module Amazonka.S3.Internal
   ( Region (..),
+
+    -- * BucketName
     BucketName (..),
+    _BucketName,
+
+    -- * ETag
     ETag (..),
+    _ETag,
+
+    -- * Object Version ID
     ObjectVersionId (..),
+    _ObjectVersionId,
 
     -- * Bucket Location
     LocationConstraint (..),
@@ -39,10 +48,11 @@ where
 
 import Amazonka.Core
 import Amazonka.Core.Lens.Internal (IndexedTraversal', iso, prism, traversed, _1, _2)
+import Amazonka.Data
 import Amazonka.Prelude
 import qualified Data.Text as Text
 
-newtype BucketName = BucketName Text
+newtype BucketName = BucketName {fromBucketName :: Text}
   deriving
     ( Eq,
       Ord,
@@ -60,13 +70,16 @@ newtype BucketName = BucketName Text
       FromJSON
     )
 
+_BucketName :: Iso' BucketName Text
+_BucketName = iso fromBucketName BucketName
+
 instance Hashable BucketName
 
 instance NFData BucketName
 
 -- FIXME: Add the difference between weak + strong ETags and their respective
 -- equalities if necessary, see: https://github.com/brendanhay/amazonka/issues/76
-newtype ETag = ETag ByteString
+newtype ETag = ETag {fromETag :: ByteString}
   deriving
     ( Eq,
       Ord,
@@ -82,12 +95,15 @@ newtype ETag = ETag ByteString
       ToQuery,
       ToLog
     )
+
+_ETag :: Iso' ETag ByteString
+_ETag = iso fromETag ETag
 
 instance Hashable ETag
 
 instance NFData ETag
 
-newtype ObjectVersionId = ObjectVersionId Text
+newtype ObjectVersionId = ObjectVersionId {fromObjectVersionId :: Text}
   deriving
     ( Eq,
       Ord,
@@ -103,6 +119,9 @@ newtype ObjectVersionId = ObjectVersionId Text
       ToQuery,
       ToLog
     )
+
+_ObjectVersionId :: Iso' ObjectVersionId Text
+_ObjectVersionId = iso fromObjectVersionId ObjectVersionId
 
 instance Hashable ObjectVersionId
 


### PR DESCRIPTION
Selectively re-export bits of `Amazonka.Data` through `Amazonka.Core`, to avoid picking up serialisation classes/helpers which are only really of interest to service bindings. While it's important for library clients to get access to `Amazonka.Data.Body`, `_Base64`, `_Sensitive`, etc., it's very odd for for them to see Aeson's classes and functions re-exported by module `Amazonka`.

Please have a look at the changed examples to get a feel for how this looks in practice; there shouldn't be much of a change for library consumers. `ToText` and `ToByteString` are no longer exported by `Amazonka`; I think the examples make it look like a noisier problem than it will be in "real" code.

Once again, this means a full regeneration of everything; the branch is [`endgame/amazonka/finer-data-exports-gen`](https://github.com/endgame/amazonka/tree/finer-data-exports-gen).

Ping @ysangkok who reported this issue.

Closes #777 
Fixes #728