### PR TITLE
Gen sorted interfaces

### DIFF
--- a/gen/src/Gen/AST/Cofree.hs
+++ b/gen/src/Gen/AST/Cofree.hs
@@ -4,7 +4,7 @@ import qualified Control.Comonad as Comonad
 import qualified Control.Lens as Lens
 import qualified Control.Monad.Except as Except
 import qualified Control.Monad.State.Strict as State
-import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import Gen.Prelude
@@ -20,19 +20,19 @@ cofree x = go
 attach ::
   (Traversable t, HasId a, Monoid b) =>
   (a -> b -> c) ->
-  HashMap Id b ->
+  Map Id b ->
   Cofree t a ->
   Cofree t c
 attach ctor m = fmap go
   where
-    go x = ctor x . fromMaybe mempty $ HashMap.lookup (identifier x) m
+    go x = ctor x . fromMaybe mempty $ Map.lookup (identifier x) m
 
 -- | Allows the new annotation to be memoised separately
 -- from the pre-existing annotation.
 annotate ::
   (Traversable t, MonadState s m, HasId a, Show b) =>
   (a -> b -> c) ->
-  Lens' s (HashMap Id b) ->
+  Lens' s (Map Id b) ->
   (Cofree t a -> m b) ->
   Cofree t a ->
   m (Cofree t c)
@@ -42,15 +42,15 @@ annotate ctor l f = sequenceA . Comonad.extend go
 
 memoise ::
   (MonadState s m, HasId a, Show b) =>
-  Lens' s (HashMap Id b) ->
+  Lens' s (Map Id b) ->
   (a -> m b) ->
   a ->
   m b
-memoise l f x = Lens.uses l (HashMap.lookup n) >>= maybe go return
+memoise l f x = Lens.uses l (Map.lookup n) >>= maybe go pure
   where
     go = do
       r <- f x
-      l %= HashMap.insert n r
+      l %= Map.insert n r
       pure r
 
     n = identifier x
@@ -58,7 +58,7 @@ memoise l f x = Lens.uses l (HashMap.lookup n) >>= maybe go return
 -- | Memoise the set of shapes constructed so far. Because we don't
 -- return 'Ptr' unless we see an 'Id' for the second time in a
 -- traversal, this is safe.
-type MemoE = StateT (HashMap Id (Shape Id)) (Either String)
+type MemoE = StateT (Map Id (Shape Id)) (Either String)
 
 runMemoE :: MemoE a -> Either String a
 runMemoE = flip State.evalStateT mempty
@@ -73,20 +73,20 @@ runMemoE = flip State.evalStateT mempty
 elaborate ::
   forall a.
   Show a =>
-  HashMap Id (ShapeF a) ->
-  Either String (HashMap Id (Shape Id))
-elaborate m = runMemoE $ HashMap.traverseWithKey (shape mempty) m
+  Map Id (ShapeF a) ->
+  Either String (Map Id (Shape Id))
+elaborate m = runMemoE $ Map.traverseWithKey (shape mempty) m
   where
     shape :: Set Id -> Id -> ShapeF a -> MemoE (Shape Id)
     shape seen n s
       | n `elem` seen = pure $! n :< Ptr (s ^. info) (pointerTo n s)
       | otherwise = do
-        ms <- State.gets (HashMap.lookup n)
+        ms <- State.gets (Map.lookup n)
         case ms of
           Just x -> pure x
           Nothing -> do
             x <- (n :<) <$> Lens.traverseOf references (ref (Set.insert n seen)) s
-            State.modify' (HashMap.insert n x)
+            State.modify' (Map.insert n x)
             pure x
 
     ref :: Set Id -> RefF a -> MemoE (RefF (Shape Id))
@@ -96,7 +96,7 @@ elaborate m = runMemoE $ HashMap.traverseWithKey (shape mempty) m
       pure $ r & refAnn .~ s
 
     findShape :: Id -> MemoE (ShapeF a)
-    findShape n = case HashMap.lookup n m of
+    findShape n = case Map.lookup n m of
       Nothing ->
         Except.throwError $
           unwords

--- a/gen/src/Gen/AST/Data/Field.hs
+++ b/gen/src/Gen/AST/Data/Field.hs
@@ -77,7 +77,7 @@ mkFields ::
   StructF (Shape Solved) ->
   [Field]
 mkFields (Lens.view metadata -> m) s st =
-  sortFields rs $ zipWith mk [1 ..] $ Map.toList (st ^. members)
+  sortFields rs $ zipWith mk [1 ..] $ Map.toAscList (st ^. members)
   where
     mk :: Int -> (Id, Ref) -> Field
     mk i (k, v) =
@@ -107,15 +107,11 @@ mkFields (Lens.view metadata -> m) s st =
       Uni x -> Just x
       Bi -> Nothing
 
--- | Ensures that isStreaming fields appear last in the parameter ordering,
--- but doesn't affect the rest of the order which is determined by parsing
--- of the JSON service definition.
+-- | Ensures that isStreaming fields appear last in the parameter ordering.
 sortFields :: [Id] -> [Field] -> [Field]
 sortFields xs =
   zipWith (Lens.set fieldOrdinal) [1 ..]
-    -- FIXME: optimise
-    . List.sortBy (Ord.comparing isStreaming)
-    . List.sortBy (Ord.comparing idx)
+    . List.sortBy (Ord.comparing isStreaming <> Ord.comparing idx)
   where
     idx x = fromMaybe (-1) (List.elemIndex (_fieldId x) xs)
 

--- a/gen/src/Gen/AST/Data/Field.hs
+++ b/gen/src/Gen/AST/Data/Field.hs
@@ -4,7 +4,7 @@ module Gen.AST.Data.Field where
 
 import qualified Control.Comonad.Cofree as Cofree
 import qualified Control.Lens as Lens
-import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Map.Strict as Map
 import qualified Data.List as List
 import qualified Data.Ord as Ord
 import qualified Data.Text as Text
@@ -77,8 +77,7 @@ mkFields ::
   StructF (Shape Solved) ->
   [Field]
 mkFields (Lens.view metadata -> m) s st =
-  sortFields rs $
-    zipWith mk [1 ..] $ HashMap.toList (st ^. members)
+  sortFields rs $ zipWith mk [1 ..] $ Map.toList (st ^. members)
   where
     mk :: Int -> (Id, Ref) -> Field
     mk i (k, v) =

--- a/gen/src/Gen/AST/Data/Syntax.hs
+++ b/gen/src/Gen/AST/Data/Syntax.hs
@@ -6,7 +6,7 @@ import qualified Control.Comonad as Comonad
 import qualified Control.Lens as Lens
 import qualified Data.Char as Char
 import qualified Data.Foldable as Fold
-import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Map.Strict as Map
 import Data.List (find)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as Text
@@ -803,8 +803,8 @@ requestF c meta h r is =
 
     selectedPlugins =
       -- Lookup a specific operationPlugins key before the wildcard.
-      HashMap.lookup (identifier r) (c ^. operationPlugins)
-        <|> HashMap.lookup (mkId "*") (c ^. operationPlugins)
+      Map.lookup (identifier r) (c ^. operationPlugins)
+        <|> Map.lookup (mkId "*") (c ^. operationPlugins)
 
     e = Exts.app v (Exts.app (var "overrides") (var $ meta ^. serviceConfig))
 

--- a/gen/src/Gen/AST/Override.hs
+++ b/gen/src/Gen/AST/Override.hs
@@ -8,15 +8,15 @@ where
 import qualified Control.Comonad as Comonad
 import qualified Control.Lens as Lens
 import qualified Control.Monad.State.Strict as State
-import qualified Data.HashMap.Strict as HashMap
 import qualified Data.List as List
+import qualified Data.Map.Strict as Map
 import Gen.Prelude
 import Gen.Types
 
 data Env = Env
-  { _renamed :: HashMap Id Id,
-    _replaced :: HashMap Id Replace,
-    _memo :: HashMap Id (Shape Related)
+  { _renamed :: Map Id Id,
+    _replaced :: Map Id Replace,
+    _memo :: Map Id (Shape Related)
   }
 
 $(Lens.makeLenses ''Env)
@@ -24,17 +24,18 @@ $(Lens.makeLenses ''Env)
 -- | Apply the override rules to shapes and their respective fields.
 override ::
   Functor f =>
-  HashMap Id Override ->
+  Map Id Override ->
   Service f (RefF a) (Shape Related) b ->
   Service f (RefF a) (Shape Related) b
 override ovs svc =
-  svc & operations . Lens.each %~ operation
+  svc
+    & operations . Lens.each %~ operation
     & shapes .~ State.evalState ss (Env rename replace mempty)
   where
     ss =
-      fmap HashMap.fromList
+      fmap Map.fromList
         . traverse (uncurry (overrideShape ovs))
-        . HashMap.toList
+        . Map.toList
         $ svc ^. shapes
 
     operation :: Functor f => Operation f (RefF a) b -> Operation f (RefF a) b
@@ -46,22 +47,22 @@ override ovs svc =
 
     ref :: RefF a -> RefF a
     ref r
-      | Just x <- HashMap.lookup ptr rename = r & refShape .~ x
-      | Just x <- HashMap.lookup ptr replace = r & refShape .~ x ^. replaceName
+      | Just x <- Map.lookup ptr rename = r & refShape .~ x
+      | Just x <- Map.lookup ptr replace = r & refShape .~ x ^. replaceName
       | otherwise = r
       where
         ptr = r ^. refShape
 
-    rename :: HashMap Id Id
+    rename :: Map Id Id
     rename = vMapMaybe _renamedTo ovs
 
-    replace :: HashMap Id Replace
+    replace :: Map Id Replace
     replace = vMapMaybe _replacedBy ovs
 
 type MemoS = State Env
 
 overrideShape ::
-  HashMap Id Override ->
+  Map Id Override ->
   Id ->
   Shape Related ->
   MemoS (Id, Shape Related)
@@ -78,7 +79,7 @@ overrideShape ovs n c@(_ :< s) = go -- env memo n >>= maybe go (return . (n,))
           | x == n -> (n,) <$> shape
           | otherwise -> overrideShape ovs x c
 
-    Override {..} = fromMaybe defaultOverride (HashMap.lookup n ovs)
+    Override {..} = fromMaybe defaultOverride (Map.lookup n ovs)
 
     pointer :: Replace -> MemoS (Shape Related)
     pointer r =
@@ -108,7 +109,7 @@ overrideShape ovs n c@(_ :< s) = go -- env memo n >>= maybe go (return . (n,))
     fields :: ShapeF a -> ShapeF a
     fields = _Struct . members . kvTraversal %~ first f
       where
-        f k = maybe k (replaceId k) (HashMap.lookup k _renamedFields)
+        f k = maybe k (replaceId k) (Map.lookup k _renamedFields)
 
     retype :: ShapeF a -> MemoS (ShapeF a)
     retype x = do
@@ -119,14 +120,14 @@ overrideShape ovs n c@(_ :< s) = go -- env memo n >>= maybe go (return . (n,))
             maybe
               v
               (flip (Lens.set refShape) v . g)
-              (HashMap.lookup (v ^. refShape) m)
+              (Map.lookup (v ^. refShape) m)
 
       pure $! x
         & references
         %~ f _replaceName rp . f id rn
 
-env :: MonadState Env m => Getter Env (HashMap Id a) -> Id -> m (Maybe a)
-env l n = Lens.uses l (HashMap.lookup n)
+env :: MonadState Env m => Getter Env (Map Id a) -> Id -> m (Maybe a)
+env l n = Lens.uses l (Map.lookup n)
 
 save :: Shape Related -> MemoS (Shape Related)
-save x = memo %= HashMap.insert (identifier x) x >> return x
+save x = x <$ (memo %= Map.insert (identifier x) x)

--- a/gen/src/Gen/AST/Prefix.hs
+++ b/gen/src/Gen/AST/Prefix.hs
@@ -10,7 +10,7 @@ import qualified Control.Monad.Except as Except
 import qualified Control.Monad.State.Strict as State
 import qualified Data.CaseInsensitive as CI
 import qualified Data.Char as Char
-import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Map.Strict as Map
 import qualified Data.HashSet as HashSet
 import qualified Data.Text as Text
 import Gen.AST.Cofree
@@ -18,10 +18,10 @@ import Gen.Prelude
 import Gen.Text
 import Gen.Types
 
-type Seen = HashMap (CI Text) (HashSet (CI Text))
+type Seen = Map (CI Text) (HashSet (CI Text))
 
 data Env = Env
-  { _memo :: HashMap Id (Maybe Text),
+  { _memo :: Map Id (Maybe Text),
     _branches :: Seen,
     _fields :: Seen
   }
@@ -30,14 +30,14 @@ $(Lens.makeLenses ''Env)
 
 type MemoP = StateT Env (Either String)
 
-prefixes :: HashMap Id (Shape Related) -> Either String (HashMap Id (Shape Prefixed))
+prefixes :: Map Id (Shape Related) -> Either String (Map Id (Shape Prefixed))
 prefixes ss = State.evalStateT (traverse assignPrefix ss) env
   where
     env = Env mempty mempty (smartCtors ss)
 
 -- | Record projected smart constructors in set of seen field names.
-smartCtors :: HashMap Id (Shape a) -> Seen
-smartCtors = HashMap.fromListWith (<>) . mapMaybe go . HashMap.toList
+smartCtors :: Map Id (Shape a) -> Seen
+smartCtors = Map.fromListWith (<>) . mapMaybe go . Map.toList
   where
     go :: (Id, Shape a) -> Maybe (CI Text, HashSet (CI Text))
     go (s, _ :< Struct {}) = Just (k, HashSet.singleton v)
@@ -80,7 +80,7 @@ assignPrefix = annotate Prefixed memo go
       let line x =
             "\n" ++ Text.unpack (CI.original x)
               ++ " => "
-              ++ show (HashMap.lookup x s)
+              ++ show (Map.lookup x s)
 
       Except.throwError $
         "Error prefixing: " ++ Text.unpack n
@@ -89,7 +89,7 @@ assignPrefix = annotate Prefixed memo go
           ++ concatMap line (acronymPrefixes r n)
     --
     unique r seen n (h : hs) ks = do
-      m <- Lens.uses seen (HashMap.lookup h)
+      m <- Lens.uses seen (Map.lookup h)
       -- Find if this particular naming heuristic is used already, and if
       -- it is, then is there overlap with this set of ks?
       case m of
@@ -97,14 +97,14 @@ assignPrefix = annotate Prefixed memo go
           | overlap ys ks ->
             unique r seen n hs ks
         _ -> do
-          seen %= HashMap.insertWith (<>) h ks
+          seen %= Map.insertWith (<>) h ks
           return (CI.original h)
 
 overlap :: (Eq a, Hashable a) => HashSet a -> HashSet a -> Bool
 overlap xs ys = not . HashSet.null $ HashSet.intersection xs ys
 
-keys :: HashMap Id a -> HashSet (CI Text)
-keys = HashSet.fromList . map (CI.mk . typeId) . HashMap.keys
+keys :: Map Id a -> HashSet (CI Text)
+keys = HashSet.fromList . map (CI.mk . typeId) . Map.keys
 
 acronymPrefixes :: Relation -> Text -> [CI Text]
 acronymPrefixes _relation name = [CI.mk (upperHead name)]

--- a/gen/src/Gen/AST/Subst.hs
+++ b/gen/src/Gen/AST/Subst.hs
@@ -8,7 +8,7 @@ where
 import qualified Control.Lens as Lens
 import qualified Control.Monad.Except as Except
 import qualified Control.Monad.State.Strict as State
-import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Map.Strict as Map
 import qualified Data.List as List
 import qualified Data.Text as Text
 import Gen.AST.Override
@@ -16,8 +16,8 @@ import Gen.Prelude
 import Gen.Types
 
 data Env a = Env
-  { _overrides :: HashMap Id Override,
-    _memo :: HashMap Id (Shape a)
+  { _overrides :: Map Id Override,
+    _memo :: Map Id (Shape a)
   }
 
 $(Lens.makeLenses ''Env)
@@ -70,10 +70,10 @@ substitute svc@Service {..} = do
     -- operation with the same name.
     name :: Direction -> Id -> Id
     name Input n
-      | HashMap.member n _shapes = mkId (typeId (appendId n "'"))
+      | Map.member n _shapes = mkId (typeId (appendId n "'"))
       | otherwise = n
     name Output n
-      | HashMap.member rs _operations = mkId (typeId (appendId n "Response'"))
+      | Map.member rs _operations = mkId (typeId (appendId n "Response'"))
       | otherwise = rs
       where
         rs = mkId (typeId (appendId n "Response"))
@@ -130,10 +130,10 @@ addStatus Output _k = go
         where
           mstatus =
             List.find ((Just StatusCode ==) . Lens.view refLocation . snd) $
-              HashMap.toList (st ^. members)
+              Map.toList (st ^. members)
 
           missing =
-            st & required' %~ Lens.cons n & members %~ HashMap.insert n ref
+            st & required' %~ Lens.cons n & members %~ Map.insert n ref
 
           exists (name, _) =
             st & required' %~ Lens.cons name
@@ -150,19 +150,19 @@ addStatus Output _k = go
         other
 
 save :: Id -> Shape a -> MemoS a ()
-save n s = memo %= HashMap.insert n s
+save n s = memo %= Map.insert n s
 
 rename :: Id -> Id -> MemoS a ()
-rename x y = overrides %= HashMap.insert x (defaultOverride & renamedTo ?~ y)
+rename x y = overrides %= Map.insert x (defaultOverride & renamedTo ?~ y)
 
-safe :: Show a => Id -> HashMap Id a -> Either String a
+safe :: Show a => Id -> Map Id a -> Either String a
 safe n ss =
   note
     ( "Missing shape " ++ Text.unpack (memberId n)
         ++ ", possible matches: "
         ++ partial n ss
     )
-    (HashMap.lookup n ss)
+    (Map.lookup n ss)
 
 verify ::
   (MonadState (Env a) m, MonadError String m) =>
@@ -170,7 +170,7 @@ verify ::
   String ->
   m ()
 verify n msg = do
-  p <- Lens.uses memo (HashMap.member n)
+  p <- Lens.uses memo (Map.member n)
 
   when p . Except.throwError $
     msg ++ " for " ++ Text.unpack (memberId n)

--- a/gen/src/Gen/Types/Config.hs
+++ b/gen/src/Gen/Types/Config.hs
@@ -46,7 +46,7 @@ data Override = Override
     -- | Optional fields
     _optionalFields :: [Id],
     -- | Rename fields
-    _renamedFields :: HashMap Id Id
+    _renamedFields :: Map Id Id
   }
   deriving (Eq, Show)
 
@@ -99,9 +99,9 @@ data Config = Config
     -- Using a wildcard key of @*@ in the configuration results in the plugins
     -- being applied to _all_ operations. The wildcard is only applied if no
     -- matching operation name is found in the map.
-    _operationPlugins :: HashMap Id [Text],
+    _operationPlugins :: Map Id [Text],
     _typeModules :: [NS],
-    _typeOverrides :: HashMap Id Override,
+    _typeOverrides :: Map Id Override,
     _ignoredWaiters :: HashSet Id,
     _ignoredPaginators :: HashSet Id,
     _extraDependencies :: [Text]

--- a/gen/src/Gen/Types/Data.hs
+++ b/gen/src/Gen/Types/Data.hs
@@ -49,7 +49,7 @@ data Prod = Prod'
   }
   deriving (Eq, Show)
 
-prodToJSON :: ToJSON a => Solved -> Prod -> HashMap Text a -> [Pair]
+prodToJSON :: ToJSON a => Solved -> Prod -> Map Text a -> [Pair]
 prodToJSON s Prod' {..} is =
   [ "type" .= Text.pack "product",
     "name" .= _prodName,
@@ -68,7 +68,7 @@ data Sum = Sum'
     _sumDoc :: Maybe Help,
     _sumDecl :: Rendered,
     _sumCtor :: Text,
-    _sumCtors :: HashMap Text Text
+    _sumCtors :: Map Text Text
   }
   deriving (Eq, Show)
 
@@ -103,7 +103,7 @@ instance ToJSON Gen where
 
 data SData
   = -- | A product type (record).
-    Prod !Solved Prod (HashMap Text Rendered)
+    Prod !Solved Prod (Map Text Rendered)
   | -- | A nullary sum type.
     Sum !Solved Sum [Text]
   | -- | A function declaration.

--- a/gen/src/Gen/Types/Id.hs
+++ b/gen/src/Gen/Types/Id.hs
@@ -29,7 +29,7 @@ import qualified Control.Comonad as Comonad
 import qualified Control.Lens as Lens
 import qualified Data.Aeson as Aeson
 import qualified Data.Char as Char
-import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
 import Gen.Prelude
 import Gen.Text
@@ -73,11 +73,11 @@ mkId t = Id t (format t)
 format :: Text -> Text
 format = upperHead . Text.dropWhile (not . Char.isAlpha)
 
-partial :: Show a => Id -> HashMap Id a -> String
+partial :: Show a => Id -> Map Id a -> String
 partial p m =
   let text = Text.take 3 (memberId p)
-      matches = HashMap.filterWithKey (const . Text.isPrefixOf text . memberId) m
-   in fromString (show (HashMap.toList matches))
+      matches = Map.filterWithKey (const . Text.isPrefixOf text . memberId) m
+   in fromString (show (Map.toList matches))
 
 representation :: Lens' Id Text
 representation =

--- a/gen/src/Gen/Types/Map.hs
+++ b/gen/src/Gen/Types/Map.hs
@@ -1,35 +1,32 @@
 module Gen.Types.Map where
 
 import qualified Control.Lens as Lens
-import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Map.Strict as Map
 import qualified Data.Tuple as Tuple
 import Gen.Prelude
 
 vMapMaybe ::
-  (Eq k, Hashable k) =>
+  (Ord k) =>
   (a -> Maybe b) ->
-  HashMap k a ->
-  HashMap k b
+  Map k a ->
+  Map k b
 vMapMaybe f =
   runIdentity
     . kvTraverseMaybe (const (pure . f))
 
-kvInvert :: (Eq v, Hashable v) => HashMap k v -> HashMap v k
+kvInvert :: (Ord v) => Map k v -> Map v k
 kvInvert = kvTraversal %~ Tuple.swap
 
 kvTraverseMaybe ::
-  (Applicative f, Eq k, Hashable k) =>
+  (Applicative f, Ord k) =>
   (k -> a -> f (Maybe b)) ->
-  HashMap k a ->
-  f (HashMap k b)
+  Map k a ->
+  f (Map k b)
 kvTraverseMaybe f =
-  fmap (HashMap.map fromJust . HashMap.filter isJust)
-    . HashMap.traverseWithKey f
+  fmap (Map.map fromJust . Map.filter isJust)
+    . Map.traverseWithKey f
 
 kvTraversal ::
-  (Eq k', Hashable k') =>
-  Lens.Traversal (HashMap k v) (HashMap k' v') (k, v) (k', v')
-kvTraversal f =
-  fmap HashMap.fromList
-    . traverse f
-    . HashMap.toList
+  (Ord k') =>
+  Lens.Traversal (Map k v) (Map k' v') (k, v) (k', v')
+kvTraversal f = fmap Map.fromList . traverse f . Map.toList

--- a/gen/src/Gen/Types/Retry.hs
+++ b/gen/src/Gen/Types/Retry.hs
@@ -63,7 +63,7 @@ instance FromJSON Delay where
 data Retry = Retry'
   { _retryAttempts :: Integer,
     _retryDelay :: Delay,
-    _retryPolicies :: HashMap Text Policy
+    _retryPolicies :: Map Text Policy
   }
   deriving (Eq, Show)
 
@@ -98,8 +98,8 @@ instance FromJSON (Retry -> Retry) where
 
 parseRetry :: Text -> Aeson.Object -> Aeson.Types.Parser Retry
 parseRetry svc o = do
-  p <- o .: "definitions" :: Aeson.Types.Parser (HashMap Text Policy)
-  r <- o .: "retry" :: Aeson.Types.Parser (HashMap Text Aeson.Object)
+  p <- o .: "definitions" :: Aeson.Types.Parser (Map Text Policy)
+  r <- o .: "retry" :: Aeson.Types.Parser (Map Text Aeson.Object)
 
   -- Since the __default__ policy is everything in
   -- definitions, just add them all rather than dealing


### PR DESCRIPTION
Switch the generator from `HashMap` to `Map`, which means that all the `toList` calls come out in sorted order. This will keep the ordering of fields predictable and should give us better diffs in future generator runs.

While it might be nice to follow botocore's ordering for struct fields, I can't see a good way to do that: https://github.com/haskell/aeson/issues/984

A full regeneration is on the `endgame:gen-sorted-interfaces-gen` branch (#863). Please try it and let me know if you think this is better than the arbitrary "however `HashMap.toList` sorted them" that we used to have.

Closes #825 .