### PR TITLE
Parse more timezones

### DIFF
--- a/lib/amazonka-core/src/Amazonka/Data/Time.hs
+++ b/lib/amazonka-core/src/Amazonka/Data/Time.hs
@@ -88,19 +88,7 @@ instance TimeFormat BasicTime where
 instance TimeFormat AWSTime where
   format _ = "%Y%m%dT%H%M%SZ"
 
-instance FromText BasicTime where
-  fromText = A.parseOnly ((parseUnixTimestamp <|> parseFormattedTime) <* A.endOfInput)
-
-instance FromText AWSTime where
-  fromText = A.parseOnly ((parseUnixTimestamp <|> parseFormattedTime) <* A.endOfInput)
-
-instance FromText RFC822 where
-  fromText = A.parseOnly ((parseUnixTimestamp <|> parseFormattedTime) <* A.endOfInput)
-
-instance FromText ISO8601 where
-  fromText = A.parseOnly ((parseUnixTimestamp <|> parseFormattedTime) <* A.endOfInput)
-
-instance FromText POSIX where
+instance FromText (Time fmt) where
   fromText = A.parseOnly ((parseUnixTimestamp <|> parseFormattedTime) <* A.endOfInput)
 
 parseFormattedTime :: A.Parser (Time a)

--- a/lib/amazonka-core/src/Amazonka/Data/Time.hs
+++ b/lib/amazonka-core/src/Amazonka/Data/Time.hs
@@ -53,7 +53,8 @@ newtype Time (a :: Format) = Time {fromTime :: UTCTime}
 
 instance Hashable (Time a) where
   hashWithSalt salt (Time (Time.UTCTime (Time.ModifiedJulianDay d) t)) =
-    salt `hashWithSalt` d
+    salt
+      `hashWithSalt` d
       `hashWithSalt` toRational t
 
 _Time :: Iso' (Time a) UTCTime
@@ -76,7 +77,7 @@ class TimeFormat a where
   format :: proxy a -> String
 
 instance TimeFormat RFC822 where
-  format _ = "%a, %d %b %Y %H:%M:%S GMT"
+  format _ = "%a, %d %b %Y %H:%M:%S %Z"
 
 instance TimeFormat ISO8601 where
   format _ = iso8601DateFormat (Just "%XZ")
@@ -130,7 +131,8 @@ parseFormattedTime = do
 parseUnixTimestamp :: A.Parser (Time a)
 parseUnixTimestamp =
   Time . posixSecondsToUTCTime . realToFrac
-    <$> AText.double <* AText.endOfInput
+    <$> AText.double
+    <* AText.endOfInput
     <|> fail "Failure parsing Unix Timestamp"
 
 instance ToText RFC822 where
@@ -150,7 +152,15 @@ instance ToText POSIX where
 
 renderFormattedTime :: forall a. TimeFormat (Time a) => Time a -> String
 renderFormattedTime (Time t) =
-  formatTime defaultTimeLocale (format (Proxy @(Time a))) t
+  formatTime
+    defaultTimeLocale
+    (format (Proxy @(Time a)))
+    -- Convert `t` to a GMT `ZonedTime`, because otherwise the
+    -- `FormatTime` instance for `UTCTime` converts to UTC `ZonedTime`
+    -- for us. While they are the same offset, a UTC `ZonedTime` emits
+    -- `UTC` instead of `GMT` when formatted by `RFC822`'s
+    -- `TimeFormat`, which is not a valid `zone` in RFC 822's grammar.
+    (Time.utcToZonedTime (read "GMT") t)
 
 instance FromXML RFC822 where
   parseXML = parseXMLText "RFC822"

--- a/lib/amazonka-core/src/Amazonka/Endpoint.hs
+++ b/lib/amazonka-core/src/Amazonka/Endpoint.hs
@@ -19,7 +19,7 @@ import qualified Data.CaseInsensitive as CI
 
 -- | A convenience function for overriding the 'Service' 'Endpoint'.
 --
--- /See:/ 'serviceEndpoint'.
+-- /See:/ 'endpoint'.
 setEndpoint ::
   -- | Whether to use HTTPS (ie. SSL).
   Bool ->

--- a/lib/amazonka-core/src/Amazonka/Sign/V4/Base.hs
+++ b/lib/amazonka-core/src/Amazonka/Sign/V4/Base.hs
@@ -51,7 +51,7 @@ instance ToLog V4 where
         "  signature         = " <> build metaSignature,
         "  string to sign    = {",
         build metaStringToSign,
-        "}",
+        "  }",
         "  canonical request = {",
         build metaCanonicalRequest,
         "  }",

--- a/lib/amazonka-core/test/Test/Amazonka/Data/Time.hs
+++ b/lib/amazonka-core/test/Test/Amazonka/Data/Time.hs
@@ -22,8 +22,16 @@ tests =
         [ testGroup
             "deserialise"
             [ testFromText
-                "rfc822"
+                "rfc822 - UTC"
+                "Fri, 07 Nov 2014 04:42:13 UTC"
+                (time :: RFC822),
+              testFromText
+                "rfc822 - GMT"
                 "Fri, 07 Nov 2014 04:42:13 GMT"
+                (time :: RFC822),
+              testFromText
+                "rfc822 - PST"
+                "Fri, 06 Nov 2014 20:42:13 PST"
                 (time :: RFC822),
               testFromText
                 "iso8601"

--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -106,6 +106,8 @@ Released: **?**, Compare: [2.0.0-rc1](https://github.com/brendanhay/amazonka/com
 
 ### Changed
 
+- `amazonka-core`: Parse more timezone names than just `"GMT"`, per RFC822
+[\#868](https://github.com/brendanhay/amazonka/pull/868)
 - `amazonka-ec2`, `amazonka-route53`, `amazonka-s3`: Provide handwritten `Iso'`s and `Lens'`s for manually-written types, that match the new generator's conventions
 [\#859](https://github.com/brendanhay/amazonka/pull/859)
 - `amazonka-redshift`: Deprecate `getAccountId` as Redshift uses service-principal credentials to deliver logs to S3. Also provide `getCloudTrailAccountId`


### PR DESCRIPTION
Change the format string for RFC822 to use `%Z` for any timezone instead of the literal `GMT`. The use of `GMT` in that format string goes as far back as I can trace (at least 8 years), so I'm surprised to see errors beginning now. Regardless, it's valid RFC 822 so let's support it.

Fixes #866 