### PR TITLE
amazonka: Stop using `Dual (Endo Service)` for overrides

### DIFF
--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -106,6 +106,8 @@ Released: **?**, Compare: [2.0.0-rc1](https://github.com/brendanhay/amazonka/com
 
 ### Changed
 
+- `amazonka`: The `override :: Dual (Endo Service)` has been replaced by `overrides :: Service -> Service`.
+[\#870](https://github.com/brendanhay/amazonka/pull/870)
 - `amazonka-core`: `Endpoint` now has a `basePath :: RawPath`. Handy with `amazonka-apigatewaymanagementapi`.
 [\#869](https://github.com/brendanhay/amazonka/pull/869)
 - `amazonka-core`: Parse more timezone names than just `"GMT"`, per RFC822

--- a/lib/amazonka/src/Amazonka.hs
+++ b/lib/amazonka/src/Amazonka.hs
@@ -163,7 +163,6 @@ import Amazonka.Send
     sendUnsignedEither,
   )
 import Control.Monad.Trans.Resource (runResourceT)
-import Data.Monoid (Dual (..), Endo (..))
 
 -- $usage
 -- The key functions dealing with the request/response lifecycle are:
@@ -442,7 +441,7 @@ presign ::
   m ClientRequest
 presign env time expires rq =
   Presign.presignWith
-    (appEndo (getDual (Env.override env)))
+    (Env.overrides env)
     (runIdentity $ Env.auth env)
     (Env.region env)
     time

--- a/lib/amazonka/src/Amazonka/HTTP.hs
+++ b/lib/amazonka/src/Amazonka/HTTP.hs
@@ -28,7 +28,6 @@ import Control.Exception as Exception
 import Control.Monad.Trans.Resource (liftResourceT, transResourceT)
 import qualified Control.Retry as Retry
 import qualified Data.List as List
-import Data.Monoid (Dual (..), Endo (..))
 import qualified Data.Time as Time
 import qualified Network.HTTP.Conduit as Client.Conduit
 
@@ -158,7 +157,7 @@ httpRequest env@Env {..} x =
     proxy _ = Proxy
 
 configureRequest :: AWSRequest a => Env' withAuth -> a -> Request a
-configureRequest Env {override = overrides} = request (appEndo (getDual overrides))
+configureRequest Env {overrides} = request overrides
 
 retryStream :: Request a -> Retry.RetryPolicy
 retryStream Request {body} =

--- a/lib/amazonka/src/Amazonka/Lens.hs
+++ b/lib/amazonka/src/Amazonka/Lens.hs
@@ -44,7 +44,7 @@ module Amazonka.Lens
     env_region,
     env_logger,
     env_retryCheck,
-    env_override,
+    env_overrides,
     env_manager,
     env_auth,
 


### PR DESCRIPTION
Instead unwrap the newtypes so that this is just a function.

This seems significantly simpler.