### PR TITLE
s3: make the timestamps use rfc822

### DIFF
--- a/configs/annexes/s3.json
+++ b/configs/annexes/s3.json
@@ -4,14 +4,35 @@
     },
     "documentation": "Amazon Simple Storage Service is storage for the Internet. Amazon S3 has a simple web services interface that you can use to store and retrieve any amount of data, at any time, from anywhere on the web. It gives any developer access to the same highly scalable, reliable, fast, inexpensive data storage infrastructure that Amazon uses to run its own global network of web sites. The service aims to maximize benefits of scale and to pass those benefits on to developers.",
     "shapes": {
+        "AbortDate": {
+            "timestampFormat": "rfc822"
+        },
         "CompletedPartList": {
             "min": 1
+        },
+        "CopySourceIfModifiedSince": {
+            "timestampFormat": "rfc822"
+        },
+        "CopySourceIfUnmodifiedSince": {
+            "timestampFormat": "rfc822"
+        },
+        "Expires": {
+            "timestampFormat": "rfc822"
         },
         "GetBucketLocationOutput": {
             "required": [
                 "LocationConstraint"
             ],
             "payload": "LocationConstraint"
+        },
+        "IfModifiedSince": {
+            "timestampFormat": "rfc822"
+        },
+        "IfUnmodifiedSince": {
+            "timestampFormat": "rfc822"
+        },
+        "LastModified": {
+            "timestampFormat": "rfc822"
         },
         "ObjectStorageClass": {
             "enum": [

--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -155,6 +155,8 @@ Released: **?**, Compare: [2.0.0-rc1](https://github.com/brendanhay/amazonka/com
 
 ### Fixed
 
+- `amazonka-s3`: Properly format timestamps
+[\#881](https://github.com/brendanhay/amazonka/pull/881)
 - `amazonka`: Take per-shape `timestampFormat` annotations into account.
 [\#882](https://github.com/brendanhay/amazonka/pull/882)
 - `amazonka-core`: Only consider 2xx and 304 responses as successful


### PR DESCRIPTION
** depends on #882 **

** todo: regen S3 after #882 is merged and a tree-wide regen is done **

AWS does not explicitly specify that it is the required format, but RFC3339-formatted dates are ignored, all dates are formatted with RFC822 in responses, and examples also use RFC822 dates. Considering the age of S3, it makes sense.

Fixes #879

As for annotating S3 shapes, i've split the change in two commits. The first one is for fields where i'm reasonably sure it's okay (because i've tested it), the second one for fields where i'm less sure, even though it makes sense. All cache related headers tend to be RFC822-formatted since they are specified by HTTP RFCs, which require this format.
