### PR TITLE
Per shape timestamp format

### DIFF
--- a/gen/src/Gen/AST/Data/Syntax.hs
+++ b/gen/src/Gen/AST/Data/Syntax.hs
@@ -912,7 +912,7 @@ external m f = directed False m (_fieldDirection f) f
 directed :: (HasMetadata a Identity, TypeOf b) => Bool -> a -> Maybe Direction -> b -> Type
 directed i m d (typeOf -> t) = case t of
   TType x _ -> tycon x
-  TLit x -> literal i (m ^. timestampFormat . _Identity) x
+  TLit x -> literal i (timestamp $ m ^. protocol) x
   TNatural -> tycon nat
   TStream -> tycon stream
   TSensitive x -> sensitive (go x)
@@ -956,7 +956,7 @@ mapping t e = infixE e "Prelude.." (go t)
 
 iso :: TType -> Maybe Exp
 iso = \case
-  TLit Time -> Just (var "Data._Time")
+  TLit (Time _) -> Just (var "Data._Time")
   TLit Base64 -> Just (var "Data._Base64")
   TMap {} -> Just (var "Lens.coerced")
   TList1 {} -> Just (var "Lens.coerced")
@@ -975,8 +975,8 @@ literal i ts = \case
   Base64
     | i -> tycon "Data.Base64"
     | otherwise -> tycon "Prelude.ByteString"
-  Time
-    | i -> tycon ("Data." <> tsToText ts)
+  Time shapeTs
+    | i -> tycon ("Data." <> tsToText (fromMaybe ts shapeTs))
     | otherwise -> tycon "Prelude.UTCTime"
   Json -> tycon "Prelude.ByteString"
 

--- a/gen/src/Gen/AST/Subst.hs
+++ b/gen/src/Gen/AST/Subst.hs
@@ -43,13 +43,7 @@ substitute svc@Service {..} = do
   where
     meta :: Metadata Maybe -> Metadata Identity
     meta m@Metadata {..} =
-      m
-        { _timestampFormat = Identity ts,
-          _checksumFormat = _checksumFormat .! SHA256
-        }
-
-    ts :: Timestamp
-    ts = fromMaybe (timestamp (svc ^. protocol)) (svc ^. timestampFormat)
+      m { _checksumFormat = _checksumFormat .! SHA256 }
 
     operation ::
       Operation Maybe (RefF ()) a ->

--- a/gen/src/Gen/Types/Ann.hs
+++ b/gen/src/Gen/Types/Ann.hs
@@ -95,6 +95,24 @@ derivingName = \case
   DNFData -> Nothing
   other -> Just (drop 1 (show other))
 
+data Timestamp
+  = RFC822
+  | ISO8601
+  | POSIX
+  deriving (Eq, Show, Generic)
+
+tsToText :: Timestamp -> Text
+tsToText = Text.pack . show
+
+instance FromJSON Timestamp where
+  parseJSON = Aeson.withText "timestamp" $ \case
+    "rfc822" -> pure RFC822
+    "iso8601" -> pure ISO8601
+    "unixTimestamp" -> pure POSIX
+    e -> fail ("Unknown Timestamp: " ++ Text.unpack e)
+
+instance ToJSON Timestamp where
+  toJSON = Aeson.toJSON . tsToText
 -- | Primitive types in AWS service definition files.
 --
 -- /See:/ 'Gen.Types.Service.ShapeF' for lists/maps/structs.
@@ -105,7 +123,7 @@ data Lit
   | Text
   | Base64
   | Bytes
-  | Time
+  | Time (Maybe Timestamp)
   | Bool
   | Json
   deriving (Eq, Show)

--- a/gen/src/Gen/Types/TypeOf.hs
+++ b/gen/src/Gen/Types/TypeOf.hs
@@ -101,7 +101,7 @@ derivingOf = uniq . typ . typeOf
       Text -> derivingBase <> string
       Base64 -> derivingBase
       Bytes -> derivingBase
-      Time -> DOrd : derivingBase
+      Time _ -> DOrd : derivingBase
       Bool -> derivingBase <> enum
       Json -> [DEq, DShow, DGeneric, DHashable, DNFData]
 

--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -155,6 +155,8 @@ Released: **?**, Compare: [2.0.0-rc1](https://github.com/brendanhay/amazonka/com
 
 ### Fixed
 
+- `amazonka`: Take per-shape `timestampFormat` annotations into account.
+[\#882](https://github.com/brendanhay/amazonka/pull/882)
 - `amazonka-core`: Only consider 2xx and 304 responses as successful
 [\#835](https://github.com/brendanhay/amazonka/pull/835)
 - `amazonka-core`: Allow customisation of S3 addressing styles like Boto 3 can (thanks @basvandijk, @ivb-supercede)

--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -155,7 +155,7 @@ Released: **?**, Compare: [2.0.0-rc1](https://github.com/brendanhay/amazonka/com
 
 ### Fixed
 
-- `amazonka`: Take per-shape `timestampFormat` annotations into account.
+- `gen`: Take per-shape `timestampFormat` annotations into account.
 [\#882](https://github.com/brendanhay/amazonka/pull/882)
 - `amazonka-core`: Only consider 2xx and 304 responses as successful
 [\#835](https://github.com/brendanhay/amazonka/pull/835)


### PR DESCRIPTION
As discovered in #881

- `timestampFormat` was not supported in shapes definitions
- `timestampFormat` is supported in service metadata but not used anywhere (neither botocore nor amazonka annexes) (it was quickly checked by turning it into a `Maybe Void`; no parse error was triggered)

This PR adds support for reading it in shape definition and removes support from reading it from service metadata.