### PR TITLE
Revert "Gen sorted interfaces"

### DIFF
--- a/gen/src/Gen/AST.hs
+++ b/gen/src/Gen/AST.hs
@@ -5,7 +5,7 @@ import qualified Control.Lens as Lens
 import qualified Control.Monad.Except as Except
 import Control.Monad.State.Strict (execState, modify)
 import qualified Control.Monad.State.Strict as State
-import qualified Data.Map.Strict as Map
+import qualified Data.HashMap.Strict as HashMap
 import qualified Data.HashSet as HashSet
 import qualified Data.Set as Set
 import qualified Data.Text as Text
@@ -69,13 +69,13 @@ rewrite _versions' _config' s' = do
   pure $ Library {_versions', _config', _service', _cuts', _instance'}
 
 deprecate :: Service f a b c -> Service f a b c
-deprecate = operations %~ Map.filter (not . Lens.view opDeprecated)
+deprecate = operations %~ HashMap.filter (not . Lens.view opDeprecated)
 
 ignore :: Config -> Service f a b c -> Service f a b c
 ignore c srv =
   srv
-    & waiters %~ Map.filterWithKey (const . validWaiter)
-    & operations %~ Map.mapWithKey (\k v -> if validPager k then v else (opPager .~ Nothing) v)
+    & waiters %~ HashMap.filterWithKey (const . validWaiter)
+    & operations %~ HashMap.mapWithKey (\k v -> if validPager k then v else (opPager .~ Nothing) v)
   where
     validWaiter k = not $ HashSet.member k (c ^. ignoredWaiters)
     validPager k = not $ HashSet.member k (c ^. ignoredPaginators)
@@ -116,12 +116,12 @@ renderShapes cfg svc = do
       >>= separate (svc ^. operations)
 
   -- Prune anything that is an orphan, or not an exception
-  let prune = Map.filter $ \s -> not (isOrphan s) || s ^. infoException
+  let prune = HashMap.filter $ \s -> not (isOrphan s) || s ^. infoException
 
   -- Convert shape ASTs into a rendered Haskell AST declaration,
   xs <- traverse (operationData cfg svc) x
   ys <- kvTraverseMaybe (const (shapeData svc)) (prune y)
-  zs <- Map.traverseWithKey (waiterData svc x) (svc ^. waiters)
+  zs <- HashMap.traverseWithKey (waiterData svc x) (svc ^. waiters)
 
   return
     $! svc
@@ -130,7 +130,7 @@ renderShapes cfg svc = do
         _waiters = zs
       }
 
-type MemoR = StateT (Map Id Relation, HashSet (Id, Direction, Id)) (Either String)
+type MemoR = StateT (HashMap Id Relation, HashSet (Id, Direction, Id)) (Either String)
 
 -- | Determine the relation for operation payloads, both input and output.
 --
@@ -138,9 +138,9 @@ type MemoR = StateT (Map Id Relation, HashSet (Id, Direction, Id)) (Either Strin
 -- used by 'setDefaults'.
 relations ::
   Show a =>
-  Map Id (Operation Maybe (RefF b) c) ->
-  Map Id (ShapeF a) ->
-  Either String (Map Id Relation)
+  HashMap Id (Operation Maybe (RefF b) c) ->
+  HashMap Id (ShapeF a) ->
+  Either String (HashMap Id Relation)
 relations os ss = fst <$> State.execStateT (traverse go os) (mempty, mempty)
   where
     -- FIXME: opName here is incorrect as a parent.
@@ -152,7 +152,7 @@ relations os ss = fst <$> State.execStateT (traverse go os) (mempty, mempty)
     count :: Maybe Id -> Direction -> Maybe Id -> MemoR ()
     count _ _ Nothing = pure ()
     count p d (Just n) = do
-      Lens._1 %= Map.insertWith (<>) n (mkRelation p d)
+      Lens._1 %= HashMap.insertWith (<>) n (mkRelation p d)
 
       check p d n $ do
         s <- lift (safe n)
@@ -181,7 +181,7 @@ relations os ss = fst <$> State.execStateT (traverse go os) (mempty, mempty)
             ++ ", possible matches: "
             ++ partial n ss
         )
-        (Map.lookup n ss)
+        (HashMap.lookup n ss)
 
 -- FIXME: Necessary to update the Relation?
 solve ::
@@ -193,26 +193,26 @@ solve cfg ss = State.evalState (go ss) (replaced typeOf cfg)
   where
     go = traverse (annotate Solved id (pure . typeOf))
 
-    replaced :: (Replace -> a) -> Config -> Map Id a
+    replaced :: (Replace -> a) -> Config -> HashMap Id a
     replaced f =
-      Map.fromList
+      HashMap.fromList
         . map (_replaceName &&& f)
-        . Map.elems
+        . HashMap.elems
         . vMapMaybe _replacedBy
         . _typeOverrides
 
-type MemoS a = StateT (Map Id a) (Either String)
+type MemoS a = StateT (HashMap Id a) (Either String)
 
 -- | Filter the ids representing operation input/outputs from the supplied map,
 -- and attach the associated shape to the appropriate operation.
 separate ::
   (Show a, HasRelation a) =>
-  Map Id (Operation Identity (RefF b) c) ->
-  Map Id a ->
+  HashMap Id (Operation Identity (RefF b) c) ->
+  HashMap Id a ->
   Either
     String
-    ( Map Id (Operation Identity (RefF a) c), -- Operations.
-      Map Id a -- Data Types.
+    ( HashMap Id (Operation Identity (RefF a) c), -- Operations.
+      HashMap Id a -- Data Types.
     )
 separate os = State.runStateT (traverse go os)
   where
@@ -234,16 +234,16 @@ separate os = State.runStateT (traverse go os)
     remove d n = do
       s <- State.get
 
-      case Map.lookup n s of
+      case HashMap.lookup n s of
         Nothing ->
           Except.throwError $
             "Failure separating operation wrapper " ++ Text.unpack (memberId n)
               ++ " from "
-              ++ show (Map.map (const ()) s)
+              ++ show (HashMap.map (const ()) s)
         --
         Just x -> do
           when (d == Input || not (isShared x)) $
-            State.modify' (Map.delete n)
+            State.modify' (HashMap.delete n)
 
           pure x
 

--- a/gen/src/Gen/AST/Data.hs
+++ b/gen/src/Gen/AST/Data.hs
@@ -12,7 +12,7 @@ import qualified Control.Lens as Lens
 import qualified Control.Monad.Trans.State as State
 import qualified Data.ByteString.Char8 as ByteString.Char8
 import qualified Data.Char as Char
-import qualified Data.Map.Strict as Map
+import qualified Data.HashMap.Strict as HashMap
 import qualified Data.List as List
 import qualified Data.Set as Set
 import qualified Data.Text as Text
@@ -46,8 +46,8 @@ operationData cfg m o = do
 
   yis' <- renderInsts p yn (responseInsts ys)
   xis' <-
-    maybe id (Map.insert "AWSPager") mpage
-      . Map.insert "AWSRequest" cls
+    maybe id (HashMap.insert "AWSPager") mpage
+      . HashMap.insert "AWSRequest" cls
       <$> renderInsts p xn xis
 
   pure
@@ -126,9 +126,9 @@ sumData ::
   Protocol ->
   Solved ->
   Info ->
-  Map Id Text ->
+  HashMap Id Text ->
   Either String SData
-sumData p s i vs = Sum s <$> mk <*> fmap Map.keys insts
+sumData p s i vs = Sum s <$> mk <*> fmap HashMap.keys insts
   where
     mk =
       Sum' (typeId n) (i ^. infoDocumentation)
@@ -327,8 +327,8 @@ prodData m s st = (,fields) <$> mk
 
     n = s ^. annId
 
-renderInsts :: Protocol -> Id -> [Inst] -> Either String (Map Text Text.Lazy.Text)
-renderInsts p n = fmap Map.fromList . traverse go
+renderInsts :: Protocol -> Id -> [Inst] -> Either String (HashMap Text Text.Lazy.Text)
+renderInsts p n = fmap HashMap.fromList . traverse go
   where
     go i = (instToText i,) <$> pp Print (instanceD p n i)
 
@@ -354,12 +354,12 @@ serviceData m r =
 waiterData ::
   HasMetadata a Identity =>
   a ->
-  Map Id (Operation Identity Ref b) ->
+  HashMap Id (Operation Identity Ref b) ->
   Id ->
   Waiter Id ->
   Either String WData
 waiterData m os n w = do
-  o <- note (missingErr key (_opName <$> os)) $ Map.lookup key os
+  o <- note (missingErr key (HashMap.map _opName os)) $ HashMap.lookup key os
   wf <- waiterFields m o w
   c <-
     Fun' (smartCtorId n) help
@@ -458,7 +458,7 @@ notation m = go
     field' :: Id -> Shape Solved -> Either String Field
     field' n = \case
       a :< Struct st ->
-        note (missingErr n (identifier a) (Map.keys (st ^. members)))
+        note (missingErr n (identifier a) (HashMap.keys (st ^. members)))
           . List.find ((n ==) . _fieldId)
           $ mkFields m a st
       _ -> Left (descendErr n)

--- a/gen/src/Gen/AST/Data/Syntax.hs
+++ b/gen/src/Gen/AST/Data/Syntax.hs
@@ -6,7 +6,7 @@ import qualified Control.Comonad as Comonad
 import qualified Control.Lens as Lens
 import qualified Data.Char as Char
 import qualified Data.Foldable as Fold
-import qualified Data.Map.Strict as Map
+import qualified Data.HashMap.Strict as HashMap
 import Data.List (find)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as Text
@@ -802,8 +802,8 @@ requestF c meta h r is =
 
     selectedPlugins =
       -- Lookup a specific operationPlugins key before the wildcard.
-      Map.lookup (identifier r) (c ^. operationPlugins)
-        <|> Map.lookup (mkId "*") (c ^. operationPlugins)
+      HashMap.lookup (identifier r) (c ^. operationPlugins)
+        <|> HashMap.lookup (mkId "*") (c ^. operationPlugins)
 
     e = Exts.app v (Exts.app (var "overrides") (var $ meta ^. serviceConfig))
 

--- a/gen/src/Gen/AST/Override.hs
+++ b/gen/src/Gen/AST/Override.hs
@@ -8,15 +8,15 @@ where
 import qualified Control.Comonad as Comonad
 import qualified Control.Lens as Lens
 import qualified Control.Monad.State.Strict as State
+import qualified Data.HashMap.Strict as HashMap
 import qualified Data.List as List
-import qualified Data.Map.Strict as Map
 import Gen.Prelude
 import Gen.Types
 
 data Env = Env
-  { _renamed :: Map Id Id,
-    _replaced :: Map Id Replace,
-    _memo :: Map Id (Shape Related)
+  { _renamed :: HashMap Id Id,
+    _replaced :: HashMap Id Replace,
+    _memo :: HashMap Id (Shape Related)
   }
 
 $(Lens.makeLenses ''Env)
@@ -24,18 +24,17 @@ $(Lens.makeLenses ''Env)
 -- | Apply the override rules to shapes and their respective fields.
 override ::
   Functor f =>
-  Map Id Override ->
+  HashMap Id Override ->
   Service f (RefF a) (Shape Related) b ->
   Service f (RefF a) (Shape Related) b
 override ovs svc =
-  svc
-    & operations . Lens.each %~ operation
+  svc & operations . Lens.each %~ operation
     & shapes .~ State.evalState ss (Env rename replace mempty)
   where
     ss =
-      fmap Map.fromList
+      fmap HashMap.fromList
         . traverse (uncurry (overrideShape ovs))
-        . Map.toList
+        . HashMap.toList
         $ svc ^. shapes
 
     operation :: Functor f => Operation f (RefF a) b -> Operation f (RefF a) b
@@ -47,22 +46,22 @@ override ovs svc =
 
     ref :: RefF a -> RefF a
     ref r
-      | Just x <- Map.lookup ptr rename = r & refShape .~ x
-      | Just x <- Map.lookup ptr replace = r & refShape .~ x ^. replaceName
+      | Just x <- HashMap.lookup ptr rename = r & refShape .~ x
+      | Just x <- HashMap.lookup ptr replace = r & refShape .~ x ^. replaceName
       | otherwise = r
       where
         ptr = r ^. refShape
 
-    rename :: Map Id Id
+    rename :: HashMap Id Id
     rename = vMapMaybe _renamedTo ovs
 
-    replace :: Map Id Replace
+    replace :: HashMap Id Replace
     replace = vMapMaybe _replacedBy ovs
 
 type MemoS = State Env
 
 overrideShape ::
-  Map Id Override ->
+  HashMap Id Override ->
   Id ->
   Shape Related ->
   MemoS (Id, Shape Related)
@@ -79,7 +78,7 @@ overrideShape ovs n c@(_ :< s) = go -- env memo n >>= maybe go (return . (n,))
           | x == n -> (n,) <$> shape
           | otherwise -> overrideShape ovs x c
 
-    Override {..} = fromMaybe defaultOverride (Map.lookup n ovs)
+    Override {..} = fromMaybe defaultOverride (HashMap.lookup n ovs)
 
     pointer :: Replace -> MemoS (Shape Related)
     pointer r =
@@ -109,7 +108,7 @@ overrideShape ovs n c@(_ :< s) = go -- env memo n >>= maybe go (return . (n,))
     fields :: ShapeF a -> ShapeF a
     fields = _Struct . members . kvTraversal %~ first f
       where
-        f k = maybe k (replaceId k) (Map.lookup k _renamedFields)
+        f k = maybe k (replaceId k) (HashMap.lookup k _renamedFields)
 
     retype :: ShapeF a -> MemoS (ShapeF a)
     retype x = do
@@ -120,14 +119,14 @@ overrideShape ovs n c@(_ :< s) = go -- env memo n >>= maybe go (return . (n,))
             maybe
               v
               (flip (Lens.set refShape) v . g)
-              (Map.lookup (v ^. refShape) m)
+              (HashMap.lookup (v ^. refShape) m)
 
       pure $! x
         & references
         %~ f _replaceName rp . f id rn
 
-env :: MonadState Env m => Getter Env (Map Id a) -> Id -> m (Maybe a)
-env l n = Lens.uses l (Map.lookup n)
+env :: MonadState Env m => Getter Env (HashMap Id a) -> Id -> m (Maybe a)
+env l n = Lens.uses l (HashMap.lookup n)
 
 save :: Shape Related -> MemoS (Shape Related)
-save x = x <$ (memo %= Map.insert (identifier x) x)
+save x = memo %= HashMap.insert (identifier x) x >> return x

--- a/gen/src/Gen/Types/Config.hs
+++ b/gen/src/Gen/Types/Config.hs
@@ -46,7 +46,7 @@ data Override = Override
     -- | Optional fields
     _optionalFields :: [Id],
     -- | Rename fields
-    _renamedFields :: Map Id Id
+    _renamedFields :: HashMap Id Id
   }
   deriving (Eq, Show)
 
@@ -99,9 +99,9 @@ data Config = Config
     -- Using a wildcard key of @*@ in the configuration results in the plugins
     -- being applied to _all_ operations. The wildcard is only applied if no
     -- matching operation name is found in the map.
-    _operationPlugins :: Map Id [Text],
+    _operationPlugins :: HashMap Id [Text],
     _typeModules :: [NS],
-    _typeOverrides :: Map Id Override,
+    _typeOverrides :: HashMap Id Override,
     _ignoredWaiters :: HashSet Id,
     _ignoredPaginators :: HashSet Id,
     _extraDependencies :: [Text]

--- a/gen/src/Gen/Types/Data.hs
+++ b/gen/src/Gen/Types/Data.hs
@@ -49,7 +49,7 @@ data Prod = Prod'
   }
   deriving (Eq, Show)
 
-prodToJSON :: ToJSON a => Solved -> Prod -> Map Text a -> [Pair]
+prodToJSON :: ToJSON a => Solved -> Prod -> HashMap Text a -> [Pair]
 prodToJSON s Prod' {..} is =
   [ "type" .= Text.pack "product",
     "name" .= _prodName,
@@ -68,7 +68,7 @@ data Sum = Sum'
     _sumDoc :: Maybe Help,
     _sumDecl :: Rendered,
     _sumCtor :: Text,
-    _sumCtors :: Map Text Text
+    _sumCtors :: HashMap Text Text
   }
   deriving (Eq, Show)
 
@@ -103,7 +103,7 @@ instance ToJSON Gen where
 
 data SData
   = -- | A product type (record).
-    Prod !Solved Prod (Map Text Rendered)
+    Prod !Solved Prod (HashMap Text Rendered)
   | -- | A nullary sum type.
     Sum !Solved Sum [Text]
   | -- | A function declaration.

--- a/gen/src/Gen/Types/Id.hs
+++ b/gen/src/Gen/Types/Id.hs
@@ -29,7 +29,7 @@ import qualified Control.Comonad as Comonad
 import qualified Control.Lens as Lens
 import qualified Data.Aeson as Aeson
 import qualified Data.Char as Char
-import qualified Data.Map.Strict as Map
+import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Text as Text
 import Gen.Prelude
 import Gen.Text
@@ -73,11 +73,11 @@ mkId t = Id t (format t)
 format :: Text -> Text
 format = upperHead . Text.dropWhile (not . Char.isAlpha)
 
-partial :: Show a => Id -> Map Id a -> String
+partial :: Show a => Id -> HashMap Id a -> String
 partial p m =
   let text = Text.take 3 (memberId p)
-      matches = Map.filterWithKey (const . Text.isPrefixOf text . memberId) m
-   in fromString (show (Map.toList matches))
+      matches = HashMap.filterWithKey (const . Text.isPrefixOf text . memberId) m
+   in fromString (show (HashMap.toList matches))
 
 representation :: Lens' Id Text
 representation =

--- a/gen/src/Gen/Types/Map.hs
+++ b/gen/src/Gen/Types/Map.hs
@@ -1,32 +1,35 @@
 module Gen.Types.Map where
 
 import qualified Control.Lens as Lens
-import qualified Data.Map.Strict as Map
+import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Tuple as Tuple
 import Gen.Prelude
 
 vMapMaybe ::
-  (Ord k) =>
+  (Eq k, Hashable k) =>
   (a -> Maybe b) ->
-  Map k a ->
-  Map k b
+  HashMap k a ->
+  HashMap k b
 vMapMaybe f =
   runIdentity
     . kvTraverseMaybe (const (pure . f))
 
-kvInvert :: (Ord v) => Map k v -> Map v k
+kvInvert :: (Eq v, Hashable v) => HashMap k v -> HashMap v k
 kvInvert = kvTraversal %~ Tuple.swap
 
 kvTraverseMaybe ::
-  (Applicative f, Ord k) =>
+  (Applicative f, Eq k, Hashable k) =>
   (k -> a -> f (Maybe b)) ->
-  Map k a ->
-  f (Map k b)
+  HashMap k a ->
+  f (HashMap k b)
 kvTraverseMaybe f =
-  fmap (Map.map fromJust . Map.filter isJust)
-    . Map.traverseWithKey f
+  fmap (HashMap.map fromJust . HashMap.filter isJust)
+    . HashMap.traverseWithKey f
 
 kvTraversal ::
-  (Ord k') =>
-  Lens.Traversal (Map k v) (Map k' v') (k, v) (k', v')
-kvTraversal f = fmap Map.fromList . traverse f . Map.toList
+  (Eq k', Hashable k') =>
+  Lens.Traversal (HashMap k v) (HashMap k' v') (k, v) (k', v')
+kvTraversal f =
+  fmap HashMap.fromList
+    . traverse f
+    . HashMap.toList

--- a/gen/src/Gen/Types/Retry.hs
+++ b/gen/src/Gen/Types/Retry.hs
@@ -63,7 +63,7 @@ instance FromJSON Delay where
 data Retry = Retry'
   { _retryAttempts :: Integer,
     _retryDelay :: Delay,
-    _retryPolicies :: Map Text Policy
+    _retryPolicies :: HashMap Text Policy
   }
   deriving (Eq, Show)
 
@@ -98,8 +98,8 @@ instance FromJSON (Retry -> Retry) where
 
 parseRetry :: Text -> Aeson.Object -> Aeson.Types.Parser Retry
 parseRetry svc o = do
-  p <- o .: "definitions" :: Aeson.Types.Parser (Map Text Policy)
-  r <- o .: "retry" :: Aeson.Types.Parser (Map Text Aeson.Object)
+  p <- o .: "definitions" :: Aeson.Types.Parser (HashMap Text Policy)
+  r <- o .: "retry" :: Aeson.Types.Parser (HashMap Text Aeson.Object)
 
   -- Since the __default__ policy is everything in
   -- definitions, just add them all rather than dealing

--- a/gen/src/Gen/Types/Service.hs
+++ b/gen/src/Gen/Types/Service.hs
@@ -7,7 +7,7 @@ import qualified Control.Comonad.Cofree as Cofree
 import qualified Control.Lens as Lens
 import Data.Aeson ((.!=), (.:), (.:?), (.=))
 import qualified Data.Aeson as Aeson
-import qualified Data.Map.Strict as Map
+import qualified Data.HashMap.Strict as HashMap
 import qualified Data.List as List
 import qualified Data.Text as Text
 import Gen.Prelude
@@ -248,7 +248,7 @@ instance FromJSON (Info -> MapF ()) where
 
 data StructF a = StructF
   { _structInfo :: Info,
-    _members :: Map Id (RefF a),
+    _members :: HashMap Id (RefF a),
     -- | List so it can be used for ordering.
     _required' :: [Id],
     _payload :: Maybe Id
@@ -272,11 +272,11 @@ instance FromJSON (Info -> StructF ()) where
     p <- o .:? "payload"
     return $ \i -> StructF i (body p ms) r p
     where
-      -- This ensures that the field referenced by a possible
+      -- This ensure that the field referenced by a possible
       -- "payload":<id> has a location set.
-      body :: Maybe Id -> Map Id (RefF a) -> Map Id (RefF a)
+      body :: Maybe Id -> HashMap Id (RefF a) -> HashMap Id (RefF a)
       body Nothing = id
-      body (Just p) = Map.mapWithKey f
+      body (Just p) = HashMap.mapWithKey f
         where
           f n r
             | p == n = r & refLocation ?~ Body
@@ -287,7 +287,7 @@ data ShapeF a
   | List (ListF a)
   | Map (MapF a)
   | Struct (StructF a)
-  | Enum Info (Map Id Text)
+  | Enum Info (HashMap Id Text)
   | Lit Info Lit
   deriving (Functor, Foldable, Traversable)
 
@@ -340,7 +340,7 @@ instance FromJSON (ShapeF ()) where
       "json" -> pure (Lit i Json)
       "string" -> pure (maybe (Lit i Text) f m)
         where
-          f = Enum i . Map.fromList . map (first mkId . renameBranch)
+          f = Enum i . HashMap.fromList . map (first mkId . renameBranch)
       _ -> fail $ "Unknown Shape type: " ++ Text.unpack t
 
 data Operation f a b = Operation
@@ -440,9 +440,9 @@ serviceError m =
 data Service f a b c = Service
   { _metadata' :: Metadata f,
     _documentation :: Help,
-    _operations :: Map Id (Operation f a (Pager Id)),
-    _shapes :: Map Id b,
-    _waiters :: Map Id c,
+    _operations :: HashMap Id (Operation f a (Pager Id)),
+    _shapes :: HashMap Id b,
+    _waiters :: HashMap Id c,
     _retry :: Retry
   }
   deriving (Generic)
@@ -459,16 +459,16 @@ instance FromJSON (Service Maybe (RefF ()) (ShapeF ()) (Waiter Id)) where
       p <- o .:? "pagination" .!= mempty
       Service m
         <$> o .: "documentation"
-        <*> (o .: "operations" <&> fmap (pager p))
+        <*> (o .: "operations" <&> HashMap.map (pager p))
         <*> o .: "shapes"
         <*> o .:? "waiters" .!= mempty
         <*> parseRetry (m ^. serviceAbbrev) o
     where
       pager ::
-        Map Id (Pager Id) ->
+        HashMap Id (Pager Id) ->
         Operation f a () ->
         Operation f a (Pager Id)
-      pager ps o = o & opPager .~ Map.lookup (o ^. opName) ps
+      pager ps o = o & opPager .~ HashMap.lookup (o ^. opName) ps
 
 type Shape = Cofree ShapeF
 


### PR DESCRIPTION
Using Data.Map.Map to sort gen outputs caused the ordering of certain fields inside the containers to change, breaking (at least) `amazonka-emr-containers`. The generator tries to calculate the set of derivable typeclasses through a `Ptr`, and takes a guess instead of looking up the actual pointed-to type.

I have spent a week and a half trying to make this work, and [have decided to give up](https://github.com/endgame/amazonka/commit/bdcba74b64d536d303be99cf9ecdd781766c770d). More fundamental changes are needed, and they can be done after 2.0. The bug is still present, but the relative ordering of `StructF` vs `Ptr` versions of `ShapeF` within a `HashMap` hasn't triggered any broken service bindings... yet.

Reverts brendanhay/amazonka#862
Closes #880
Related to #888