### PR TITLE
gen: Sort waiters, error checks, and lenses in generated output

### DIFF
--- a/gen/src/Gen/AST.hs
+++ b/gen/src/Gen/AST.hs
@@ -189,17 +189,17 @@ solve ::
   Config ->
   t (Shape Prefixed) ->
   t (Shape Solved)
-solve cfg ss = State.evalState (go ss) (replaced typeOf cfg)
+solve cfg ss = State.evalState (go ss) types
   where
     go = traverse (annotate Solved id (pure . typeOf))
 
-    replaced :: (Replace -> a) -> Config -> HashMap Id a
-    replaced f =
+    types :: HashMap Id TType
+    types =
       HashMap.fromList
-        . map (_replaceName &&& f)
+        . map (_replaceName &&& typeOf)
         . HashMap.elems
         . vMapMaybe _replacedBy
-        . _typeOverrides
+        $ _typeOverrides cfg
 
 type MemoS a = StateT (HashMap Id a) (Either String)
 

--- a/gen/src/Gen/AST/Data/Field.hs
+++ b/gen/src/Gen/AST/Data/Field.hs
@@ -77,8 +77,10 @@ mkFields ::
   StructF (Shape Solved) ->
   [Field]
 mkFields (Lens.view metadata -> m) s st =
-  sortFields rs $
-    zipWith mk [1 ..] $ HashMap.toList (st ^. members)
+  sortFields rs
+    . zipWith mk [1 ..]
+    . List.sortOn fst
+    $ HashMap.toList (st ^. members)
   where
     mk :: Int -> (Id, Ref) -> Field
     mk i (k, v) =

--- a/gen/src/Gen/Types/Config.hs
+++ b/gen/src/Gen/Types/Config.hs
@@ -172,7 +172,7 @@ instance ToJSON Library where
             "operations"
               .= List.sortOn _opName (l ^.. operations . Lens.each),
             "shapes" .= List.sort (l ^.. shapes . Lens.each),
-            "waiters" .= (l ^.. waiters . Lens.each)
+            "waiters" .= List.sortOn _waitName (l ^.. waiters . Lens.each)
           ]
 
 -- FIXME: Remove explicit construction of getters, just use functions.

--- a/gen/src/Gen/Types/Data.hs
+++ b/gen/src/Gen/Types/Data.hs
@@ -6,7 +6,7 @@ import qualified Control.Lens as Lens
 import Data.Aeson ((.=))
 import qualified Data.Aeson as Aeson
 import Data.Aeson.Types (Pair)
-import qualified Data.Function as Function
+import Data.Ord (comparing)
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import Gen.Prelude
@@ -113,9 +113,9 @@ data SData
 instance Ord SData where
   compare a b =
     case (a, b) of
-      (Prod _ x _, Prod _ y _) -> Function.on compare _prodName x y
-      (Sum _ x _, Sum _ y _) -> Function.on compare _sumName x y
-      (Fun _, Fun _) -> EQ
+      (Prod _ x _, Prod _ y _) -> comparing _prodName x y
+      (Sum _ x _, Sum _ y _) -> comparing _sumName x y
+      (Fun x, Fun y) -> comparing _funName x y
       (Prod {}, _) -> GT
       (_, Prod {}) -> LT
       (Sum {}, _) -> GT

--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -109,6 +109,8 @@ Released: **?**, Compare: [2.0.0-rc1](https://github.com/brendanhay/amazonka/com
 
 ### Changed
 
+- `gen` / `amazonka-*`: Sort generated code so that outputs are stable across regenerations.
+[\#890](https://github.com/brendanhay/amazonka/pull/890)
 - `amazonka-core`/`amazonka`: Various time-related data types and the `_Time` `Iso'` are re-exported by `Amazonka.Core` and therefore `Amazonka`.
 [\#884](https://github.com/brendanhay/amazonka/pull/884)
 - `amazonka-core`: service error matchers are now `AsError a => Fold a ServiceError` instead of `AsError a => Getting (First ServiceError) a ServiceError`. This makes them more flexible (e.g., usable with `Control.Lens.has`), but existing uses should be unaffected.


### PR DESCRIPTION
Same output as https://github.com/brendanhay/amazonka/pull/862, but sticks to `HashMap` internally to avoid triggering https://github.com/brendanhay/amazonka/issue/888

A couple of enums change value in a strange way, because the generator cannot handle enums-of-numeric values. See
https://github.com/brendanhay/amazonka/issues/889