### PR TITLE
Gen sorted outputs gen

### DIFF
--- a/lib/services/amazonka-apigateway/gen/Amazonka/APIGateway/Types/CacheClusterSize.hs
+++ b/lib/services/amazonka-apigateway/gen/Amazonka/APIGateway/Types/CacheClusterSize.hs
@@ -59,7 +59,7 @@ newtype CacheClusterSize = CacheClusterSize'
     )
 
 pattern CacheClusterSize_ :: CacheClusterSize
-pattern CacheClusterSize_ = CacheClusterSize' "6.1"
+pattern CacheClusterSize_ = CacheClusterSize' "1.6"
 
 {-# COMPLETE
   CacheClusterSize_,

--- a/lib/services/amazonka-cloudhsm/gen/Amazonka/CloudHSM/Types/ClientVersion.hs
+++ b/lib/services/amazonka-cloudhsm/gen/Amazonka/CloudHSM/Types/ClientVersion.hs
@@ -58,7 +58,7 @@ newtype ClientVersion = ClientVersion'
     )
 
 pattern ClientVersion_ :: ClientVersion
-pattern ClientVersion_ = ClientVersion' "5.3"
+pattern ClientVersion_ = ClientVersion' "5.1"
 
 {-# COMPLETE
   ClientVersion_,

--- a/lib/services/amazonka-emr-containers/gen/Amazonka/EMRContainers/CreateManagedEndpoint.hs
+++ b/lib/services/amazonka-emr-containers/gen/Amazonka/EMRContainers/CreateManagedEndpoint.hs
@@ -83,7 +83,7 @@ data CreateManagedEndpoint = CreateManagedEndpoint'
     -- | The client idempotency token for this create call.
     clientToken :: Prelude.Text
   }
-  deriving (Prelude.Eq, Prelude.Read, Prelude.Show, Prelude.Generic)
+  deriving (Prelude.Eq, Prelude.Show, Prelude.Generic)
 
 -- |
 -- Create a value of 'CreateManagedEndpoint' with all optional fields omitted.

--- a/lib/services/amazonka-emr-containers/gen/Amazonka/EMRContainers/DescribeManagedEndpoint.hs
+++ b/lib/services/amazonka-emr-containers/gen/Amazonka/EMRContainers/DescribeManagedEndpoint.hs
@@ -144,7 +144,7 @@ data DescribeManagedEndpointResponse = DescribeManagedEndpointResponse'
     -- | The response's http status code.
     httpStatus :: Prelude.Int
   }
-  deriving (Prelude.Eq, Prelude.Read, Prelude.Show, Prelude.Generic)
+  deriving (Prelude.Eq, Prelude.Show, Prelude.Generic)
 
 -- |
 -- Create a value of 'DescribeManagedEndpointResponse' with all optional fields omitted.

--- a/lib/services/amazonka-emr-containers/gen/Amazonka/EMRContainers/ListManagedEndpoints.hs
+++ b/lib/services/amazonka-emr-containers/gen/Amazonka/EMRContainers/ListManagedEndpoints.hs
@@ -242,7 +242,7 @@ data ListManagedEndpointsResponse = ListManagedEndpointsResponse'
     -- | The response's http status code.
     httpStatus :: Prelude.Int
   }
-  deriving (Prelude.Eq, Prelude.Read, Prelude.Show, Prelude.Generic)
+  deriving (Prelude.Eq, Prelude.Show, Prelude.Generic)
 
 -- |
 -- Create a value of 'ListManagedEndpointsResponse' with all optional fields omitted.

--- a/lib/services/amazonka-emr-containers/gen/Amazonka/EMRContainers/Types/ConfigurationOverrides.hs
+++ b/lib/services/amazonka-emr-containers/gen/Amazonka/EMRContainers/Types/ConfigurationOverrides.hs
@@ -36,7 +36,7 @@ data ConfigurationOverrides = ConfigurationOverrides'
     -- | The configurations for monitoring.
     monitoringConfiguration :: Prelude.Maybe MonitoringConfiguration
   }
-  deriving (Prelude.Eq, Prelude.Read, Prelude.Show, Prelude.Generic)
+  deriving (Prelude.Eq, Prelude.Show, Prelude.Generic)
 
 -- |
 -- Create a value of 'ConfigurationOverrides' with all optional fields omitted.

--- a/lib/services/amazonka-emr-containers/gen/Amazonka/EMRContainers/Types/Endpoint.hs
+++ b/lib/services/amazonka-emr-containers/gen/Amazonka/EMRContainers/Types/Endpoint.hs
@@ -73,7 +73,7 @@ data Endpoint = Endpoint'
     -- | The ID of the endpoint\'s virtual cluster.
     virtualClusterId :: Prelude.Maybe Prelude.Text
   }
-  deriving (Prelude.Eq, Prelude.Read, Prelude.Show, Prelude.Generic)
+  deriving (Prelude.Eq, Prelude.Show, Prelude.Generic)
 
 -- |
 -- Create a value of 'Endpoint' with all optional fields omitted.

--- a/lib/services/amazonka-emr-containers/gen/Amazonka/EMRContainers/Types/ParametricConfigurationOverrides.hs
+++ b/lib/services/amazonka-emr-containers/gen/Amazonka/EMRContainers/Types/ParametricConfigurationOverrides.hs
@@ -37,7 +37,7 @@ data ParametricConfigurationOverrides = ParametricConfigurationOverrides'
     -- | The configurations for monitoring.
     monitoringConfiguration :: Prelude.Maybe ParametricMonitoringConfiguration
   }
-  deriving (Prelude.Eq, Prelude.Read, Prelude.Show, Prelude.Generic)
+  deriving (Prelude.Eq, Prelude.Show, Prelude.Generic)
 
 -- |
 -- Create a value of 'ParametricConfigurationOverrides' with all optional fields omitted.

--- a/lib/services/amazonka-emr-serverless/gen/Amazonka/EMRServerless/Types/ConfigurationOverrides.hs
+++ b/lib/services/amazonka-emr-serverless/gen/Amazonka/EMRServerless/Types/ConfigurationOverrides.hs
@@ -36,7 +36,7 @@ data ConfigurationOverrides = ConfigurationOverrides'
     -- | The override configurations for monitoring.
     monitoringConfiguration :: Prelude.Maybe MonitoringConfiguration
   }
-  deriving (Prelude.Eq, Prelude.Read, Prelude.Show, Prelude.Generic)
+  deriving (Prelude.Eq, Prelude.Show, Prelude.Generic)
 
 -- |
 -- Create a value of 'ConfigurationOverrides' with all optional fields omitted.


### PR DESCRIPTION
Regenerate `amazonka-emr-containers` and `amazonka-emr-serverless` so that they build again. Changes to `amazonka-apigateway` and `amazonka-cloudhsm` are due to #889 .