### PR TITLE
Change Item in GetItemResponse to optional

### DIFF
--- a/configs/services/dynamodb.json
+++ b/configs/services/dynamodb.json
@@ -35,11 +35,6 @@
                 "underive": []
             }
         },
-        "GetItemOutput": {
-            "requiredFields": [
-                "Item"
-            ]
-        },
         "PutRequest": {
             "replacedBy": {
                 "name": "",

--- a/lib/services/amazonka-dynamodb/gen/Amazonka/DynamoDB/GetItem.hs
+++ b/lib/services/amazonka-dynamodb/gen/Amazonka/DynamoDB/GetItem.hs
@@ -48,8 +48,8 @@ module Amazonka.DynamoDB.GetItem
 
     -- * Response Lenses
     getItemResponse_consumedCapacity,
-    getItemResponse_httpStatus,
     getItemResponse_item,
+    getItemResponse_httpStatus,
   )
 where
 
@@ -325,8 +325,8 @@ instance Core.AWSRequest GetItem where
       ( \s h x ->
           GetItemResponse'
             Prelude.<$> (x Data..?> "ConsumedCapacity")
-            Prelude.<*> (Prelude.pure (Prelude.fromEnum s))
             Prelude.<*> (x Data..?> "Item" Core..!@ Prelude.mempty)
+            Prelude.<*> (Prelude.pure (Prelude.fromEnum s))
       )
 
 instance Prelude.Hashable GetItem where
@@ -399,11 +399,11 @@ data GetItemResponse = GetItemResponse'
     -- <https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html Read\/Write Capacity Mode>
     -- in the /Amazon DynamoDB Developer Guide/.
     consumedCapacity :: Prelude.Maybe ConsumedCapacity,
-    -- | The response's http status code.
-    httpStatus :: Prelude.Int,
     -- | A map of attribute names to @AttributeValue@ objects, as specified by
     -- @ProjectionExpression@.
-    item :: Prelude.HashMap Prelude.Text AttributeValue
+    item :: Prelude.Maybe (Prelude.HashMap Prelude.Text AttributeValue),
+    -- | The response's http status code.
+    httpStatus :: Prelude.Int
   }
   deriving (Prelude.Eq, Prelude.Read, Prelude.Show, Prelude.Generic)
 
@@ -423,10 +423,10 @@ data GetItemResponse = GetItemResponse'
 -- <https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html Read\/Write Capacity Mode>
 -- in the /Amazon DynamoDB Developer Guide/.
 --
--- 'httpStatus', 'getItemResponse_httpStatus' - The response's http status code.
---
 -- 'item', 'getItemResponse_item' - A map of attribute names to @AttributeValue@ objects, as specified by
 -- @ProjectionExpression@.
+--
+-- 'httpStatus', 'getItemResponse_httpStatus' - The response's http status code.
 newGetItemResponse ::
   -- | 'httpStatus'
   Prelude.Int ->
@@ -435,8 +435,8 @@ newGetItemResponse pHttpStatus_ =
   GetItemResponse'
     { consumedCapacity =
         Prelude.Nothing,
-      httpStatus = pHttpStatus_,
-      item = Prelude.mempty
+      item = Prelude.Nothing,
+      httpStatus = pHttpStatus_
     }
 
 -- | The capacity units consumed by the @GetItem@ operation. The data
@@ -449,17 +449,17 @@ newGetItemResponse pHttpStatus_ =
 getItemResponse_consumedCapacity :: Lens.Lens' GetItemResponse (Prelude.Maybe ConsumedCapacity)
 getItemResponse_consumedCapacity = Lens.lens (\GetItemResponse' {consumedCapacity} -> consumedCapacity) (\s@GetItemResponse' {} a -> s {consumedCapacity = a} :: GetItemResponse)
 
+-- | A map of attribute names to @AttributeValue@ objects, as specified by
+-- @ProjectionExpression@.
+getItemResponse_item :: Lens.Lens' GetItemResponse (Prelude.Maybe (Prelude.HashMap Prelude.Text AttributeValue))
+getItemResponse_item = Lens.lens (\GetItemResponse' {item} -> item) (\s@GetItemResponse' {} a -> s {item = a} :: GetItemResponse) Prelude.. Lens.mapping Lens.coerced
+
 -- | The response's http status code.
 getItemResponse_httpStatus :: Lens.Lens' GetItemResponse Prelude.Int
 getItemResponse_httpStatus = Lens.lens (\GetItemResponse' {httpStatus} -> httpStatus) (\s@GetItemResponse' {} a -> s {httpStatus = a} :: GetItemResponse)
 
--- | A map of attribute names to @AttributeValue@ objects, as specified by
--- @ProjectionExpression@.
-getItemResponse_item :: Lens.Lens' GetItemResponse (Prelude.HashMap Prelude.Text AttributeValue)
-getItemResponse_item = Lens.lens (\GetItemResponse' {item} -> item) (\s@GetItemResponse' {} a -> s {item = a} :: GetItemResponse) Prelude.. Lens.coerced
-
 instance Prelude.NFData GetItemResponse where
   rnf GetItemResponse' {..} =
     Prelude.rnf consumedCapacity
-      `Prelude.seq` Prelude.rnf httpStatus
       `Prelude.seq` Prelude.rnf item
+      `Prelude.seq` Prelude.rnf httpStatus

--- a/lib/services/amazonka-dynamodb/gen/Amazonka/DynamoDB/Lens.hs
+++ b/lib/services/amazonka-dynamodb/gen/Amazonka/DynamoDB/Lens.hs
@@ -222,8 +222,8 @@ module Amazonka.DynamoDB.Lens
     getItem_tableName,
     getItem_key,
     getItemResponse_consumedCapacity,
-    getItemResponse_httpStatus,
     getItemResponse_item,
+    getItemResponse_httpStatus,
 
     -- ** ImportTable
     importTable_clientToken,


### PR DESCRIPTION
The description at the top of [this page](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_GetItem.html#API_GetItem_ResponseElements) says:
> If there is no matching item, GetItem does not return any data and there will be no Item element in the response.

`Item` was marked as "required" by [this commit](https://github.com/brendanhay/amazonka/commit/c8e3ac72d1d1dc17ebc7e831872638d194cbe2b4). @endgame Do you know if there are some reasons behind that change?

Fixes #895 