### PR TITLE
Support for GHC 9.6 and recent hackage (mtl, bytestring, transformers, aeson fixs)

### DIFF
--- a/amazonka/src/Control/Monad/Trans/AWS.hs
+++ b/amazonka/src/Control/Monad/Trans/AWS.hs
@@ -243,8 +243,8 @@ instance MonadBaseControl b m => MonadBaseControl b (AWST' r m) where
     restoreM     = defaultRestoreM
 
 instance MonadUnliftIO m => MonadUnliftIO (AWST' r m) where
-    askUnliftIO = AWST' $ (\(UnliftIO f) -> UnliftIO $ f . unAWST)
-        <$> askUnliftIO
+    withRunInIO inner = (AWST' $ (\(UnliftIO f) -> UnliftIO $ f . unAWST) <$> askUnliftIO) >>= \u -> liftIO (inner (unliftIO u)) 
+
 
 instance MonadResource m => MonadResource (AWST' r m) where
     liftResourceT = lift . liftResourceT

--- a/amazonka/src/Control/Monad/Trans/AWS.hs
+++ b/amazonka/src/Control/Monad/Trans/AWS.hs
@@ -168,6 +168,7 @@ import Control.Monad.State.Class
 import Control.Monad.Trans.Control
 import Control.Monad.Trans.Resource
 import Control.Monad.Writer.Class
+import Control.Monad (MonadPlus(..), (>=>), liftM)
 
 import Data.Conduit      hiding (await)
 import Data.Conduit.Lazy (MonadActive (..))

--- a/amazonka/src/Network/AWS.hs
+++ b/amazonka/src/Network/AWS.hs
@@ -160,7 +160,6 @@ import Control.Monad.Trans.AWS      (AWST)
 import Control.Monad.Trans.Class    (lift)
 import Control.Monad.Trans.Except   (ExceptT)
 import Control.Monad.Trans.Identity (IdentityT)
-import Control.Monad.Trans.List     (ListT)
 import Control.Monad.Trans.Maybe    (MaybeT)
 import Control.Monad.Trans.Reader   (ReaderT)
 import Control.Monad.Trans.Resource
@@ -204,7 +203,6 @@ instance MonadAWS AWS where
     liftAWS = id
 
 instance MonadAWS m => MonadAWS (IdentityT   m) where liftAWS = lift . liftAWS
-instance MonadAWS m => MonadAWS (ListT       m) where liftAWS = lift . liftAWS
 instance MonadAWS m => MonadAWS (MaybeT      m) where liftAWS = lift . liftAWS
 instance MonadAWS m => MonadAWS (ExceptT   e m) where liftAWS = lift . liftAWS
 instance MonadAWS m => MonadAWS (ReaderT   r m) where liftAWS = lift . liftAWS

--- a/amazonka/src/Network/AWS/Internal/Logger.hs
+++ b/amazonka/src/Network/AWS/Internal/Logger.hs
@@ -29,7 +29,7 @@ module Network.AWS.Internal.Logger
 
 import           Control.Monad
 import           Control.Monad.IO.Class
-import qualified Data.ByteString.Lazy.Builder as Build
+import qualified Data.ByteString.Builder as Build
 import           Data.Monoid
 import           Network.AWS.Data.Log
 import           Network.AWS.Types

--- a/core/src/Network/AWS/Data/Body.hs
+++ b/core/src/Network/AWS/Data/Body.hs
@@ -28,7 +28,7 @@ import qualified Data.ByteString.Char8        as BS8
 import qualified Data.ByteString.Lazy         as LBS
 import qualified Data.ByteString.Lazy.Char8   as LBS8
 import           Data.Conduit
-import           Data.HashMap.Strict          (HashMap)
+import           Data.HashMap.Strict          (HashMap, mapKeys)
 import           Data.Monoid
 import           Data.String
 import           Data.Text                    (Text)
@@ -43,6 +43,9 @@ import           Network.AWS.Data.XML         (encodeXML)
 import           Network.AWS.Lens             (AReview, Lens', lens, to, un)
 import           Network.HTTP.Conduit
 import           Text.XML                     (Element)
+
+import qualified Data.Aeson.KeyMap
+import qualified Data.Aeson.Key
 
 default (Builder)
 
@@ -195,7 +198,7 @@ instance ToHashedBody Element        where toHashed = toHashed . encodeXML
 instance ToHashedBody QueryString    where toHashed = toHashed . toBS
 
 instance ToHashedBody (HashMap Text Value) where
-    toHashed = toHashed . Object
+    toHashed = toHashed . Object . Data.Aeson.KeyMap.fromHashMap . mapKeys Data.Aeson.Key.fromText
 
 -- | Anything that can be converted to a streaming request 'Body'.
 class ToBody a where

--- a/core/src/Network/AWS/Data/ByteString.hs
+++ b/core/src/Network/AWS/Data/ByteString.hs
@@ -28,7 +28,7 @@ import           Data.ByteString              (ByteString)
 import           Data.ByteString.Builder      (Builder)
 import qualified Data.ByteString.Char8        as BS8
 import qualified Data.ByteString.Lazy         as LBS
-import qualified Data.ByteString.Lazy.Builder as Build
+import qualified Data.ByteString.Builder as Build
 import           Data.CaseInsensitive         (CI)
 import qualified Data.CaseInsensitive         as CI
 import           Data.Char

--- a/core/src/Network/AWS/Data/JSON.hs
+++ b/core/src/Network/AWS/Data/JSON.hs
@@ -40,6 +40,9 @@ import           Data.Aeson.Types
 import qualified Data.HashMap.Strict   as Map
 import           Network.AWS.Data.Text
 
+import qualified Data.Aeson.KeyMap
+import qualified Data.Aeson.Key
+
 parseJSONText :: FromText a => String -> Value -> Parser a
 parseJSONText n = withText n (either fail return . fromText)
 
@@ -51,12 +54,12 @@ eitherParseJSON = parseEither parseJSON . Object
 
 (.:>) :: FromJSON a => Object -> Text -> Either String a
 (.:>) o k =
-    case Map.lookup k o of
+    case Data.Aeson.KeyMap.lookup (Data.Aeson.Key.fromText k) o of
         Nothing -> Left $ "key " ++ show k ++ " not present"
         Just v  -> parseEither parseJSON v
 
 (.?>) :: FromJSON a => Object -> Text -> Either String (Maybe a)
 (.?>) o k =
-    case Map.lookup k o of
+    case Data.Aeson.KeyMap.lookup (Data.Aeson.Key.fromText k) o of
         Nothing -> Right Nothing
         Just v  -> parseEither parseJSON v

--- a/core/src/Network/AWS/Data/Log.hs
+++ b/core/src/Network/AWS/Data/Log.hs
@@ -19,7 +19,7 @@ module Network.AWS.Data.Log where
 import qualified Data.ByteString              as BS
 import           Data.ByteString.Builder      (Builder)
 import qualified Data.ByteString.Lazy         as LBS
-import qualified Data.ByteString.Lazy.Builder as Build
+import qualified Data.ByteString.Builder as Build
 import           Data.CaseInsensitive         (CI)
 import qualified Data.CaseInsensitive         as CI
 import           Data.Int


### PR DESCRIPTION
This branch allows the compilation with GHC 9.6 on amazonka (before the version 2, hence the merge on `master`).

It is not tested for backward compatibility, but I'm opening this MR for reference so users may cherry-pick on it.

If you are interested in a merge, please tell me what could be the requirements (boundaries check, ensuring backward compatibilities, ...) and I'll do it.