### PR TITLE
Adding ap-south-2 (Hyderabad) region

### DIFF
--- a/lib/amazonka-core/src/Amazonka/Types.hs
+++ b/lib/amazonka-core/src/Amazonka/Types.hs
@@ -132,6 +132,7 @@ module Amazonka.Types
         Jakarta,
         Melbourne,
         Mumbai,
+        Hyderabad,
         Osaka,
         Seoul,
         Singapore,
@@ -880,6 +881,9 @@ pattern Melbourne = Region' "ap-southeast-4"
 pattern Mumbai :: Region
 pattern Mumbai = Region' "ap-south-1"
 
+pattern Hyderabad :: Region
+pattern Hyderabad = Region' "ap-south-2"
+
 pattern Osaka :: Region
 pattern Osaka = Region' "ap-northeast-3"
 
@@ -966,6 +970,7 @@ pattern Ningxia = Region' "cn-northwest-1"
   Jakarta,
   Melbourne,
   Mumbai,
+  Hyderabad,
   Osaka,
   Seoul,
   Singapore,

--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -118,6 +118,7 @@ Released: **?**, Compare: [2.0.0-rc1](https://github.com/brendanhay/amazonka/com
 ### Changed
 
 - `amazonka-core`/`amazonka-redshift`/`amazonka-route53`/`amazonka-s3`: Support Hyderabad region (`ap-south-2`).
+[\#900](https://github.com/brendanhay/amazonka/pull/900)
 - `amazonka-core`/`amazonka-redshift`/`amazonka-route53`/`amazonka-s3`: Support Melbourne region (`ap-southeast-4`).
 [\#897](https://github.com/brendanhay/amazonka/pull/897)
 - `amazonka`: Presigning functions do not require `MonadIO`.

--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -117,6 +117,7 @@ Released: **?**, Compare: [2.0.0-rc1](https://github.com/brendanhay/amazonka/com
 
 ### Changed
 
+- `amazonka-core`/`amazonka-redshift`/`amazonka-route53`/`amazonka-s3`: Support Hyderabad region (`ap-south-2`).
 - `amazonka-core`/`amazonka-redshift`/`amazonka-route53`/`amazonka-s3`: Support Melbourne region (`ap-southeast-4`).
 [\#897](https://github.com/brendanhay/amazonka/pull/897)
 - `amazonka`: Presigning functions do not require `MonadIO`.

--- a/lib/services/amazonka-redshift/src/Amazonka/Redshift/Internal.hs
+++ b/lib/services/amazonka-redshift/src/Amazonka/Redshift/Internal.hs
@@ -72,6 +72,7 @@ getCloudTrailAccountId = \case
   Jakarta -> Just "623197973179"
   Melbourne -> Just "945512339897"
   Mumbai -> Just "408097707231"
+  Hyderabad -> Just "297058826802"
   Osaka -> Just "398671365691"
   Seoul -> Just "713597048934"
   Singapore -> Just "960118270566"

--- a/lib/services/amazonka-route53/src/Amazonka/Route53/Internal.hs
+++ b/lib/services/amazonka-route53/src/Amazonka/Route53/Internal.hs
@@ -80,6 +80,7 @@ getHostedZoneId = \case
   Jakarta -> Just "Z01846753K324LI26A3VV"
   Melbourne -> Just "Z0312387243XT5FE14WFO"
   Mumbai -> Just "Z11RGJOFQNVJUP"
+  Hyderabad -> Just "Z02976202B4EZMXIPMXF7"
   Osaka -> Just "Z2YQB5RD63NC85"
   Seoul -> Just "Z3W03O7B5YMIYP"
   Singapore -> Just "Z3O0J2DXBE1FTB"

--- a/lib/services/amazonka-s3/src/Amazonka/S3/Internal.hs
+++ b/lib/services/amazonka-s3/src/Amazonka/S3/Internal.hs
@@ -290,6 +290,7 @@ getWebsiteEndpoint = \case
   Jakarta -> Just "s3-website.ap-southeast-3.amazonaws.com"
   Melbourne -> Just "s3-website.ap-southeast-4.amazonaws.com"
   Mumbai -> Just "s3-website.ap-south-1.amazonaws.com"
+  Hyderabad -> Just "s3-website.ap-south-2.amazonaws.com."
   Osaka -> Just "s3-website.ap-northeast-3.amazonaws.com"
   Seoul -> Just "s3-website.ap-northeast-2.amazonaws.com"
   Singapore -> Just "s3-website-ap-southeast-1.amazonaws.com"


### PR DESCRIPTION
Added quick fixes for supporting ap-south-2 region, we might have to add support in other places also.

Questions:
- Should we add ap-south-2 support in other places too? Like comments in Chime and Sagemaker lambda ARNs

  Example:
  `    -- -   @arn:aws:lambda:ap-south-1:565803892007:function:ACS-NamedEntityRecognition@`


  `    -- | The Region in which you create the meeting. Available values:
    -- @af-south-1@, @ap-northeast-1@, @ap-northeast-2@, @ap-south-1@,
    -- @ap-southeast-1@, @ap-southeast-2@, @ca-central-1@, @eu-central-1@,
    -- @eu-north-1@, @eu-south-1@, @eu-west-1@, @eu-west-2@, @eu-west-3@,
    -- @sa-east-1@, @us-east-1@, @us-east-2@, @us-west-1@, @us-west-2@.`

Some notes:
- I have not added Hyderabad in the following files because AWS has deprecated the service principals for them:
  - lib/services/amazonka-redshift/src/Amazonka/Redshift/Internal.hs
  - lib/services/amazonka-elb/src/Amazonka/ELB/Internal.hs