### PR TITLE
gen: Use hashable ==1.3.* when generating bindings

### DIFF
--- a/gen/amazonka-gen.cabal
+++ b/gen/amazonka-gen.cabal
@@ -75,7 +75,7 @@ library
     , ede                   >=0.3
     , filepath              >=1.4
     , free                  >=5
-    , hashable              >=1.4
+    , hashable              >=1.3
     , haskell-src-exts      ^>=1.23
     , lens                  >=4.0
     , mtl                   >=2.2


### PR DESCRIPTION
Workaround e.g. #919 when generating, so we can potentially bump botocore and/or continue nursing the current generator along until we get to making something better.

Closes #919