### PR TITLE
Script upload of release tarballs

### DIFF
--- a/examples/examples.cabal
+++ b/examples/examples.cabal
@@ -1,15 +1,14 @@
-cabal-version:      2.2
-name:               examples
-version:            2.0
-synopsis:           Basic examples for various Amazonka libraries.
-homepage:           https://github.com/brendanhay/amazonka
-license:            MPL-2.0
-license-file:       LICENSE
-author:             Brendan Hay
-maintainer:         Brendan Hay <brendan.g.hay+amazonka@gmail.com>
-copyright:          Copyright (c) 2013-2021 Brendan Hay
-build-type:         Simple
-extra-source-files: README.md
+cabal-version: 2.2
+name:          examples
+version:       2.0
+synopsis:      Basic examples for various Amazonka libraries.
+homepage:      https://github.com/brendanhay/amazonka
+license:       MPL-2.0
+license-file:  LICENSE
+author:        Brendan Hay
+maintainer:    Brendan Hay <brendan.g.hay+amazonka@gmail.com>
+copyright:     Copyright (c) 2013-2021 Brendan Hay
+build-type:    Simple
 
 source-repository head
   type:     git
@@ -32,7 +31,7 @@ library
     SQS
 
   build-depends:
-    , amazonka              >=2.0   && <2.1
+    , amazonka              >=2.0 && <2.1
     , amazonka-apigateway
     , amazonka-dynamodb
     , amazonka-ec2

--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,9 @@
             pkgs.hlint
             pkgs.nixpkgs-fmt
 
+            # Releases
+            pkgs.gh
+
             # This is regrettable (long build times), but ormolu
             # 0.5.0.1 generates really ugly pyramids of `Prelude.seq`
             # or `Prelude.hashWithSalt` applications when generating code.

--- a/scripts/release-tarballs
+++ b/scripts/release-tarballs
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Usage: release-tarballs TAG
+#
+# Creates cabal sdist tarballs for all libraries and attaches them to the
+# specified GitHub release TAG as artefacts.
+
+# Note: this could be rolled into a proper release script to tag and utilise
+# `gh release create`.
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+say() {
+	echo >&2 "$@"
+}
+
+if [ $# -ne 1 ]; then
+	echo "Usage: release-tarballs TAG"
+	exit 1
+fi
+
+tag="$1"
+out="./dist-newstyle/sdist"
+
+rm -rf "$out"
+
+cabal sdist all --out="$out"
+
+gh release upload "$tag" "$out"/amazonka*.tar.gz


### PR DESCRIPTION
Adds the beginnings of a scripted release process which currently only uploads/associates `cabal sdist` tarballs with an existing release tag. TBD if we want to commit to do this as part of a release process.