### PR TITLE
Removing: ap-south-2 redundancy.

### DIFF
--- a/lib/amazonka-core/src/Amazonka/Types.hs
+++ b/lib/amazonka-core/src/Amazonka/Types.hs
@@ -881,9 +881,6 @@ pattern Melbourne = Region' "ap-southeast-4"
 pattern Mumbai :: Region
 pattern Mumbai = Region' "ap-south-1"
 
-pattern Hyderabad :: Region
-pattern Hyderabad = Region' "ap-south-2"
-
 pattern Osaka :: Region
 pattern Osaka = Region' "ap-northeast-3"
 

--- a/lib/services/amazonka-s3/src/Amazonka/S3/Internal.hs
+++ b/lib/services/amazonka-s3/src/Amazonka/S3/Internal.hs
@@ -290,7 +290,6 @@ getWebsiteEndpoint = \case
   Jakarta -> Just "s3-website.ap-southeast-3.amazonaws.com"
   Melbourne -> Just "s3-website.ap-southeast-4.amazonaws.com"
   Mumbai -> Just "s3-website.ap-south-1.amazonaws.com"
-  Hyderabad -> Just "s3-website.ap-south-2.amazonaws.com."
   Osaka -> Just "s3-website.ap-northeast-3.amazonaws.com"
   Seoul -> Just "s3-website.ap-northeast-2.amazonaws.com"
   Singapore -> Just "s3-website-ap-southeast-1.amazonaws.com"


### PR DESCRIPTION
It was already present in the code, somehow my old [fix](https://github.com/brendanhay/amazonka/pull/900) was redundant.