### PR TITLE
GHC 9.8

### DIFF
--- a/configs/templates/types.ede
+++ b/configs/templates/types.ede
@@ -1,7 +1,7 @@
-{-# LANGUAGE DisambiguateRecordFields #-}
-{-# LANGUAGE NoImplicitPrelude        #-}
-{-# LANGUAGE OverloadedStrings        #-}
-{-# LANGUAGE StrictData               #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NoImplicitPrelude     #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE StrictData            #-}
 
 {-# OPTIONS_GHC -fno-warn-unused-matches #-}
 

--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1687709756,
-        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -74,11 +74,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687793116,
-        "narHash": "sha256-6xRgZ2E9r/BNam87vMkHJ/0EPTTKzeNwhw3abKilEE4=",
+        "lastModified": 1704626572,
+        "narHash": "sha256-VwRTEKzK4wSSv64G+g3RLF3t6yBHrhR2VK3kZ5UWisU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9e4e0807d2142d17f463b26a8b796b3fe20a3011",
+        "rev": "24fe8bb4f552ad3926274d29e083b79d84707da6",
         "type": "github"
       },
       "original": {
@@ -117,11 +117,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1687779420,
-        "narHash": "sha256-noueZE/Z5qx6NF/grg46qlpZ/1nuPpc92RvqgCmRaLI=",
+        "lastModified": 1704725188,
+        "narHash": "sha256-qq8NbkhRZF1vVYQFt1s8Mbgo8knj+83+QlL5LBnYGpI=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "1fa438eee82f35bdd4bc30a9aacd7648d757b388",
+        "rev": "ea96f0c05924341c551a797aaba8126334c505d2",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,7 @@
         ghc92 = pkgs.haskell.packages."ghc92";
         ghc94 = pkgs.haskell.packages."ghc94";
         ghc96 = pkgs.haskell.packages."ghc96";
+        ghc98 = pkgs.haskell.packages."ghc98";
 
         # The default ghc to use when entering `nix develop`.
         ghcDefault = ghc94;
@@ -75,20 +76,10 @@
             pkgs.haskell-language-server
             pkgs.hlint
             pkgs.nixpkgs-fmt
+            pkgs.ormolu
 
             # Releases
             pkgs.gh
-
-            # This is regrettable (long build times), but ormolu
-            # 0.5.0.1 generates really ugly pyramids of `Prelude.seq`
-            # or `Prelude.hashWithSalt` applications when generating code.
-            #
-            # When this assertion fails, check if pkgs.ormolu is newer
-            # than 0.7.0.0 and see if we can switch back to it.
-            (
-              assert (pkgs.ormolu.version == "0.5.0.1");
-              pkgs.haskell.packages.ghc96.ormolu_0_7_0_0
-            )
 
             pkgs.parallel
           ];
@@ -147,6 +138,7 @@
           ghc92 = mkDevShell ghc92;
           ghc94 = mkDevShell ghc94;
           ghc96 = mkDevShell ghc96;
+          ghc98 = mkDevShell ghc98;
           default = mkDevShell ghcDefault;
         };
       });

--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Fixed
 
+- `amazonka-*`: GHC 9.8 support
+[\#9xx](https://github.com/brendanhay/amazonka/pull/9xx)
 - `amazonka`: Allow reading the AWS config file when the credentials file is missing [\#951](https://github.com/brendanhay/amazonka/pull/951).
   This is useful when you are using a role-based authentication method or AWS IAM Identity Center (formerly AWS SSO) which does not require a credentials file.
   Before this fix you had to create an empty credentials file for these methods to work correctly.


### PR DESCRIPTION
Tweak the Nix and the ede templates so that service definitions compile with GHC 9.8.

Regenerated services to follow in a separate PR.

@brendanhay We will need to add upper bounds to the existing 2.0 service definitions because they don't build with GHC 9.8. Do you have any tooling to help with this? Given the stuff already on `main`, this deserves a major release, but since there's so many packages to upload, it's probably worth batching it with a couple of additional fixes. Also, can you please add me to the maintainer group for the uploaded packages?

See also: https://gitlab.haskell.org/ghc/ghc/-/issues/24317
Fixes: #969 