### PR TITLE
Throw dedicated error for attempting EC2 auth not on EC2

### DIFF
--- a/lib/amazonka/src/Amazonka/Auth.hs
+++ b/lib/amazonka/src/Amazonka/Auth.hs
@@ -115,7 +115,7 @@ discover =
       fromContainerEnv,
       \env -> do
         onEC2 <- isEC2 $ manager env
-        unless onEC2 $ throwM CredentialChainExhausted
+        unless onEC2 $ throwM NotOnEC2Instance
         fromDefaultInstanceProfile env
     ]
 


### PR DESCRIPTION
As discussed in #981:

Each link in the discover chain should throw an `AuthError` to trigger
moving onto the next link in the chain. If all links fail, then a
`CredentialChainExhausted` error is thrown.

In the case of the final link, attempting an EC2 instance profile, the
code was throwing `CredentialChainExhausted` if run not on EC2. Throwing
when not on EC2 is important (to avoid an unnecessary and slow network
request) but throwing this particular exception is surprising and only
functions because this is the last link in said chain. If any other
authentication mechanisms were added after it, they would never be
reached.

To address this, a new constructor was added to `AuthError` to use
instead. The name is very much up for debate. This is also the first
case of a nullary constructor besides `CredentialChainExhausted`, so I
wasn't sure what to do in `AsAuthError` -- please advise.

The original discussion mentioned introduce two new errors:

> One to say "we don't think we're on a network with an IMDS" and one
> for "IMDS fetch failed"?

I did think about this and found that the second case is already
throwing a specific error (`RetrievalError`), so I only changed the
first case.
