### PR TITLE
DisambiguateRecordFields -> DuplicateRecordFields in Types

### DIFF
--- a/configs/templates/types.ede
+++ b/configs/templates/types.ede
@@ -1,4 +1,4 @@
-{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE DuplicateRecordFields    #-}
 {-# LANGUAGE NoImplicitPrelude        #-}
 {-# LANGUAGE OverloadedStrings        #-}
 {-# LANGUAGE StrictData               #-}


### PR DESCRIPTION
Fixes a bunch of build errors with GHC 9.10:

```
gen/Amazonka/EC2/Types.hs:6983:5: error: [GHC-97219]
    Duplicate record field ‘dPDTimeoutAction’ in export list:
       ‘VpnTunnelOptionsSpecification(..)’ exports the field ‘dPDTimeoutAction’
       belonging to the constructor ‘VpnTunnelOptionsSpecification'’
         imported from ‘Amazonka.EC2.Types.VpnTunnelOptionsSpecification’ at gen/Amazonka/EC2/Types.hs:7993:1-55
         (and originally defined
            at gen/Amazonka/EC2/Types/VpnTunnelOptionsSpecification.hs:46:5-20)
       ‘ModifyVpnTunnelOptionsSpecification(..)’ exports the field ‘dPDTimeoutAction’
       belonging to the constructor ‘ModifyVpnTunnelOptionsSpecification'’
         imported from ‘Amazonka.EC2.Types.ModifyVpnTunnelOptionsSpecification’ at gen/Amazonka/EC2/Types.hs:7564:1-61
         (and originally defined
            at gen/Amazonka/EC2/Types/ModifyVpnTunnelOptionsSpecification.hs:46:5-20)
    Suggested fix: Perhaps you intended to use DuplicateRecordFields
     |
6983 |     VpnTunnelOptionsSpecification (..),
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```