### PR TITLE
Support setting endpoints from environment variables

### DIFF
--- a/lib/amazonka-core/src/Amazonka/Endpoint.hs
+++ b/lib/amazonka-core/src/Amazonka/Endpoint.hs
@@ -110,9 +110,9 @@ defaultEndpoint Service {endpointPrefix = p} r = go (CI.mk p)
 -- * @AWS_ENDPOINT_URL_<SERVICE>@
 --
 -- The latter takes precedence over the former.
-customEndpoints :: IO (Service -> Service)
+customEndpoints :: (MonadIO m) => m (Service -> Service)
 customEndpoints = do
-  environment <- Environment.getEnvironment
+  environment <- liftIO Environment.getEnvironment
   let globalUrl = lookup "AWS_ENDPOINT_URL" environment >>= Client.parseUrlThrow
   let serviceUrls = mapMaybe (\(k, v) -> (,v) . map Char.toLower <$> removePrefix "AWS_ENDPOINT_URL_" k) environment
   let override s =


### PR DESCRIPTION
Partially solves https://github.com/brendanhay/amazonka/issues/980.

The added `customEndpoints` loads environment variables `AWS_ENDPOINT_URL` and `AWS_ENDPOINT_URL_<SERVICE>` if any to provide a function to override default endpoints.

Intended to be used as follows:

```haskell
main = do
  env <- AWS.overrideService <$>
    AWS.customEndpoints <*>
    AWS.newEnv AWS.discover
```