### PR TITLE
amazonka: Remove redundant `Typeable` constraints from Hooks

### DIFF
--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -20,7 +20,7 @@
     ```
 
 - `amazonka`: Add `(Typeable req, Typeable (AWSResponse req))` to the superclasses of `class AWSRequest`.
-  `Typeable` is required for any nontrivial use of `AWSRequest` because Amazonka routes requests through the hooks system in `Amazonka.Env.Hooks`, so this reduces a little visual clutter. (Thanks @dalpd) [\#993](https://github.com/brendanhay/amazonka/pull/993),[\#994](https://github.com/brendanhay/amazonka/pull/994)
+  `Typeable` is required for any nontrivial use of `AWSRequest` because Amazonka routes requests through the hooks system in `Amazonka.Env.Hooks`, so this reduces a little visual clutter. (Thanks @dalpd) [\#993](https://github.com/brendanhay/amazonka/pull/993),[\#994](https://github.com/brendanhay/amazonka/pull/994),[\#1015](https://github.com/brendanhay/amazonka/pull/1015)
 - New package `amazonka-dynamodb-attributevalue`: `amazonka-dynamodb`and `amazonka-dynamodb-streams` now share a common `AttributeValue` type, removing the need to manually convert between them. Each SDK re-exports it, so no code changes should be necessary, but manual conversion between the "regular" and "streams" `AttributeValue` can be removed. (thanks @dalpd)
 [\#992](https://github.com/brendanhay/amazonka/pull/992)
 - `amazonka`: Add support for `AWS_SHARED_CREDENTIALS_FILE` and `AWS_CONFIG_FILE` environment variables to override the

--- a/lib/amazonka/src/Amazonka/Env/Hooks.hs
+++ b/lib/amazonka/src/Amazonka/Env/Hooks.hs
@@ -235,7 +235,7 @@ data Hooks = Hooks
     -- is configured. This is always the first hook that runs, and
     -- argument is usually a request record type like @amazonka-s3@'s
     -- @GetObjectRequest@.
-    request :: forall a. (AWSRequest a, Typeable a) => Hook a,
+    request :: forall a. (AWSRequest a) => Hook a,
     -- | Called after the request has been configured into an abstract
     -- HTTP request, but before it is converted to a signed
     -- @Network.HTTP.Client.'Network.HTTP.Client.Request'@.
@@ -243,14 +243,14 @@ data Hooks = Hooks
     -- If you want to add additional headers (e.g., a
     -- [Trace ID for AWS X-Ray](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader)),
     -- do it with this hook.
-    configuredRequest :: forall a. (AWSRequest a, Typeable a) => Hook (Request a),
+    configuredRequest :: forall a. (AWSRequest a) => Hook (Request a),
     -- | Called at the start of waiter processing, just after the
     -- request is configured.
-    wait :: forall a. (AWSRequest a, Typeable a) => Hook (Wait a),
+    wait :: forall a. (AWSRequest a) => Hook (Wait a),
     -- | Called just after a request is signed, containing signature
     -- metadata and a
     -- @Network.HTTP.Client.'Network.HTTP.Client.Request'@.
-    signedRequest :: forall a. (AWSRequest a, Typeable a) => Hook_ (Signed a),
+    signedRequest :: forall a. (AWSRequest a) => Hook_ (Signed a),
     -- | Called on a
     -- @Network.HTTP.Client.'Network.HTTP.Client.Request'@, just
     -- before it is sent. While you can retrieve a 'ClientRequest'
@@ -266,7 +266,7 @@ data Hooks = Hooks
     -- with @()@ to prevent its accidental consumption by hooks.
     clientResponse ::
       forall a.
-      (AWSRequest a, Typeable a) =>
+      (AWSRequest a) =>
       Hook_ (Request a, ClientResponse ()),
     -- | Called on the raw response body, after it has been sunk from
     -- the @Network.HTTP.Client.'Network.HTTP.Client.Response'@.
@@ -278,20 +278,20 @@ data Hooks = Hooks
     -- like @Amazonka.S3.Types.defaultService@.
     requestRetry ::
       forall a.
-      (AWSRequest a, Typeable a) =>
+      (AWSRequest a) =>
       Hook_ (Request a, Text, Retry.RetryStatus),
     -- | Called when Amazonka decides to retry a request while
     -- resolving an 'Amazonka.await' operation.
     awaitRetry ::
       forall a.
-      (AWSRequest a, Typeable a) =>
+      (AWSRequest a) =>
       Hook_ (Request a, Wait a, Accept, Retry.RetryStatus),
     -- | Called when a response from AWS is successfully
     -- deserialised. Because the 'AWSResponse' type family is not
     -- injective, we include the original request.
     response ::
       forall a.
-      (AWSRequest a, Typeable a) =>
+      (AWSRequest a) =>
       Hook_ (Request a, ClientResponse (AWSResponse a)),
     -- | Called whenever an AWS request returns an 'Error', even when
     -- the corresponding request is retried.
@@ -301,13 +301,13 @@ data Hooks = Hooks
     -- behavior may change in a future version.
     error ::
       forall a.
-      (AWSRequest a, Typeable a) =>
+      (AWSRequest a) =>
       Hook_ (Finality, Request a, Error)
   }
 
 {-# INLINE requestHook #-}
 requestHook ::
-  (forall a. (AWSRequest a, Typeable a) => Hook a -> Hook a) ->
+  (forall a. (AWSRequest a) => Hook a -> Hook a) ->
   Hooks ->
   Hooks
 requestHook f hooks@Hooks {request} =
@@ -442,13 +442,13 @@ noHook_ _ _ _ = pure ()
 -- | Unconditionally add a @'Hook' a@ to the chain of hooks. If you
 -- need to do something with specific request types, you want
 -- 'addHookFor', instead.
-addHook :: (Typeable a) => Hook a -> Hook a -> Hook a
+addHook :: Hook a -> Hook a -> Hook a
 addHook newHook oldHook env = oldHook env >=> newHook env
 
 -- | Unconditionally add a @'Hook_' a@ to the chain of hooks. If you
 -- need to do something with specific request types, you want
 -- 'addHookFor_', instead.
-addHook_ :: (Typeable a) => Hook_ a -> Hook_ a -> Hook_ a
+addHook_ :: Hook_ a -> Hook_ a -> Hook_ a
 addHook_ newHook oldHook env a = oldHook env a *> newHook env a
 
 -- | Like 'addHook', adds an unconditional hook, but it also captures

--- a/lib/amazonka/src/Amazonka/HTTP.hs
+++ b/lib/amazonka/src/Amazonka/HTTP.hs
@@ -28,15 +28,12 @@ import Control.Monad.Trans.Resource (liftResourceT, transResourceT)
 import qualified Control.Retry as Retry
 import Data.Foldable (traverse_)
 import qualified Data.Time as Time
-import Data.Typeable (Typeable)
 import qualified Network.HTTP.Conduit as Client.Conduit
 
 retryRequest ::
   forall m a withAuth.
   ( MonadResource m,
     AWSRequest a,
-    Typeable a,
-    Typeable (AWSResponse a),
     Foldable withAuth
   ) =>
   Env' withAuth ->
@@ -75,7 +72,6 @@ retryRequest env@Env {hooks} rq = do
 awaitRequest ::
   ( MonadResource m,
     AWSRequest a,
-    Typeable a,
     Foldable withAuth
   ) =>
   Env' withAuth ->
@@ -110,7 +106,6 @@ awaitRequest env@Env {hooks} w rq = do
 httpRequest ::
   ( MonadResource m,
     AWSRequest a,
-    Typeable a,
     Foldable withAuth
   ) =>
   Env' withAuth ->
@@ -156,7 +151,7 @@ httpRequest env@Env {hooks, manager, region} cfgRq =
 -- service overrides from `env` and running hooks on the configured
 -- (Request a).
 configureRequest ::
-  (AWSRequest a, Typeable a, MonadIO m) => Env' withAuth -> a -> m (Request a)
+  (AWSRequest a, MonadIO m) => Env' withAuth -> a -> m (Request a)
 configureRequest env@Env {overrides, hooks} =
   liftIO
     . Hooks.configuredRequest hooks env


### PR DESCRIPTION
Closes #1014 