### PR TITLE
Gen cabal template

### DIFF
--- a/configs/templates/cabal.ede
+++ b/configs/templates/cabal.ede
@@ -52,7 +52,7 @@ library
       {% endfor %}
 
     build-depends:
-          amazonka-core == {{ clientVersion }}.*
+          amazonka-core == {{ libraryVersion }}.*
         , base >= 4.12 && < 5
       {% for dep in extraDependencies %}
         , {{ dep.value }}
@@ -75,8 +75,8 @@ test-suite {{ libraryName }}-test
         , Test.Amazonka.{{ serviceAbbrev }}.Internal
 
     build-depends:
-          amazonka-core == {{ clientVersion }}.*
-        , amazonka-test == {{ clientVersion }}.*
+          amazonka-core == {{ libraryVersion }}.*
+        , amazonka-test == {{ libraryVersion }}.*
         , {{ libraryName }}
         , base
         , bytestring

--- a/configs/templates/cabal.ede
+++ b/configs/templates/cabal.ede
@@ -42,12 +42,7 @@ library
 
     exposed-modules:
           Amazonka.{{ serviceAbbrev }}
-
-      {% for module in exposedModules %}
-        , {{ module.value }}
-      {% endfor %}
-
-      {% for module in otherModules %}
+      {% for module in modules %}
         , {{ module.value }}
       {% endfor %}
 

--- a/gen/amazonka-gen.cabal
+++ b/gen/amazonka-gen.cabal
@@ -24,7 +24,6 @@ common base
     -fwarn-incomplete-record-updates -funbox-strict-fields
 
   default-extensions:
-    NoImplicitPrelude
     ConstraintKinds
     DataKinds
     DefaultSignatures
@@ -45,6 +44,7 @@ common base
     MultiParamTypeClasses
     MultiWayIf
     NamedFieldPuns
+    NoImplicitPrelude
     OverloadedStrings
     PackageImports
     PatternSynonyms
@@ -75,6 +75,7 @@ library
     , ede                   >=0.3
     , filepath              >=1.4
     , free                  >=5
+    , generic-lens          ^>=2.2.2.0
     , hashable              >=1.3
     , haskell-src-exts      ^>=1.23
     , lens                  >=4.0
@@ -100,6 +101,8 @@ library
     Gen.Import
     Gen.IO
     Gen.JSON
+    Gen.Output.Template
+    Gen.Output.Template.CabalFile
     Gen.Prelude
     Gen.Protocol
     Gen.Text

--- a/gen/bin/gen.hs
+++ b/gen/bin/gen.hs
@@ -14,6 +14,7 @@ import qualified Gen.AST as AST
 import Gen.IO
 import qualified Gen.JSON as JSON
 import Gen.Output.Template (Templates (..))
+import qualified Gen.Output.Template.CabalFile as CabalFile
 import Gen.Prelude
 import qualified Gen.Tree as Tree
 import Gen.Types hiding (config, info, retry, service)
@@ -130,7 +131,8 @@ main = do
   templates <- do
     title ("Loading templates from " ++ _optionTemplates)
 
-    cabalTemplate <- load "cabal.ede"
+    cabalTemplate <-
+      readTypedTemplate CabalFile.arguments _optionTemplates "cabal.ede"
     tocTemplate <- load "toc.ede"
     waitersTemplate <- load "waiters.ede"
     readmeTemplate <- load "readme.ede"

--- a/gen/bin/gen.hs
+++ b/gen/bin/gen.hs
@@ -13,6 +13,7 @@ import qualified Data.Version as Version
 import qualified Gen.AST as AST
 import Gen.IO
 import qualified Gen.JSON as JSON
+import Gen.Output.Template (Templates (..))
 import Gen.Prelude
 import qualified Gen.Tree as Tree
 import Gen.Types hiding (config, info, retry, service)
@@ -97,7 +98,7 @@ versionReader = Options.eitherReader (Right . Version . Text.pack)
 options :: Options.ParserInfo Options
 options = Options.info (Options.helper <*> parser) Options.fullDesc
 
-validate :: MonadIO m => Options -> m Options
+validate :: (MonadIO m) => Options -> m Options
 validate o = flip State.execStateT o $ do
   sequence_
     [ check optionOutput,
@@ -112,7 +113,7 @@ validate o = flip State.execStateT o $ do
     check :: (MonadIO m, MonadState s m) => Lens' s FilePath -> m ()
     check l = State.gets (Lens.view l) >>= canon >>= Lens.assign l
 
-    canon :: MonadIO m => FilePath -> m FilePath
+    canon :: (MonadIO m) => FilePath -> m FilePath
     canon = UnliftIO.canonicalizePath
 
 main :: IO ()

--- a/gen/src/Gen/IO.hs
+++ b/gen/src/Gen/IO.hs
@@ -69,10 +69,10 @@ readTemplate ::
   FilePath ->
   FilePath ->
   m EDE.Template
-readTemplate dir name =
+readTemplate dir file =
   liftIO $
-    readBSFile (dir </> name)
-      >>= EDE.parseWith EDE.defaultSyntax (EDE.includeFile dir) (fromString name)
+    readBSFile (dir </> file)
+      >>= EDE.parseWith EDE.defaultSyntax (EDE.includeFile dir) (Text.pack file)
       >>= EDE.result (UnliftIO.throwString . show) pure
 
 readTypedTemplate ::
@@ -81,8 +81,8 @@ readTypedTemplate ::
   FilePath ->
   FilePath ->
   m (Template input)
-readTypedTemplate arguments dir name =
+readTypedTemplate arguments dir file =
   liftIO $
-    readBSFile (dir </> name)
-      >>= Template.parseWith arguments (EDE.includeFile dir) (Text.pack name)
+    readBSFile (dir </> file)
+      >>= Template.parseWith arguments (EDE.includeFile dir) (Text.pack file)
       >>= either UnliftIO.throwString pure

--- a/gen/src/Gen/IO.hs
+++ b/gen/src/Gen/IO.hs
@@ -11,21 +11,21 @@ import qualified Text.EDE as EDE
 import qualified UnliftIO
 import qualified UnliftIO.Directory as UnliftIO
 
-title :: MonadIO m => String -> m ()
+title :: (MonadIO m) => String -> m ()
 title = liftIO . putStrLn
 
-say :: MonadIO m => String -> m ()
+say :: (MonadIO m) => String -> m ()
 say = title . mappend " -> "
 
-done :: MonadIO m => m ()
+done :: (MonadIO m) => m ()
 done = liftIO (putStrLn "")
 
-readBSFile :: MonadIO m => FilePath -> m ByteString
+readBSFile :: (MonadIO m) => FilePath -> m ByteString
 readBSFile path =
   say ("Reading " ++ path)
     >> liftIO (ByteString.readFile path)
 
-writeLTFile :: UnliftIO.MonadUnliftIO m => FilePath -> Text.Lazy.Text -> m ()
+writeLTFile :: (UnliftIO.MonadUnliftIO m) => FilePath -> Text.Lazy.Text -> m ()
 writeLTFile path text = do
   say ("Writing " ++ path)
   UnliftIO.withFile path IO.WriteMode $ \handle ->
@@ -33,20 +33,20 @@ writeLTFile path text = do
       IO.hSetEncoding handle IO.utf8
       Text.Lazy.IO.hPutStr handle text
 
-touchFile :: UnliftIO.MonadUnliftIO m => FilePath -> Text.Lazy.Text -> m ()
+touchFile :: (UnliftIO.MonadUnliftIO m) => FilePath -> Text.Lazy.Text -> m ()
 touchFile path text = do
   exists <- UnliftIO.doesFileExist path
   unless exists $
     writeLTFile path text
 
-createDir :: MonadIO m => FilePath -> m ()
+createDir :: (MonadIO m) => FilePath -> m ()
 createDir dir = do
   exists <- UnliftIO.doesDirectoryExist dir
   unless exists $ do
     say ("Creating " ++ dir)
     UnliftIO.createDirectoryIfMissing True dir
 
-copyDir :: MonadIO m => FilePath -> FilePath -> m ()
+copyDir :: (MonadIO m) => FilePath -> FilePath -> m ()
 copyDir src dst =
   UnliftIO.listDirectory src >>= mapM_ copy
   where
@@ -62,7 +62,7 @@ copyDir src dst =
       UnliftIO.copyFile fsrc fdst
 
 readTemplate ::
-  MonadIO m =>
+  (MonadIO m) =>
   FilePath ->
   FilePath ->
   m Template

--- a/gen/src/Gen/Output/Template.hs
+++ b/gen/src/Gen/Output/Template.hs
@@ -1,11 +1,39 @@
 {-# LANGUAGE OverloadedLabels #-}
 
-module Gen.Output.Template (Template (..), parseWith, render) where
+module Gen.Output.Template
+  ( Templates (..),
+    Template (..),
+    parseWith,
+    render,
+  )
+where
 
 import qualified Data.Aeson as Aeson
 import Data.Generics.Labels ()
 import Gen.Prelude
 import qualified Text.EDE as EDE
+
+-- | All the EDE templates that the generator cares about.
+data Templates = Templates
+  { cabalTemplate :: EDE.Template,
+    tocTemplate :: EDE.Template,
+    waitersTemplate :: EDE.Template,
+    licenseTemplate :: EDE.Template,
+    readmeTemplate :: EDE.Template,
+    operationTemplate :: EDE.Template,
+    typesTemplate :: EDE.Template,
+    lensTemplate :: EDE.Template,
+    sumTemplate :: EDE.Template,
+    productTemplate :: EDE.Template,
+    bootProductTemplate :: EDE.Template,
+    testMainTemplate :: EDE.Template,
+    testNamespaceTemplate :: EDE.Template,
+    testInternalTemplate :: EDE.Template,
+    fixturesTemplate :: EDE.Template,
+    fixtureRequestTemplate :: EDE.Template,
+    blankTemplate :: EDE.Template
+  }
+  deriving (Generic)
 
 -- | A type-safe template that knows the type of its arguments and how
 -- to pass them to EDE.

--- a/gen/src/Gen/Output/Template.hs
+++ b/gen/src/Gen/Output/Template.hs
@@ -10,12 +10,13 @@ where
 
 import qualified Data.Aeson as Aeson
 import Data.Generics.Labels ()
+import Gen.Output.Template.CabalFile (CabalFile)
 import Gen.Prelude
 import qualified Text.EDE as EDE
 
 -- | All the EDE templates that the generator cares about.
 data Templates = Templates
-  { cabalTemplate :: EDE.Template,
+  { cabalTemplate :: Template CabalFile,
     tocTemplate :: EDE.Template,
     waitersTemplate :: EDE.Template,
     licenseTemplate :: EDE.Template,

--- a/gen/src/Gen/Output/Template.hs
+++ b/gen/src/Gen/Output/Template.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE OverloadedLabels #-}
+
+module Gen.Output.Template (Template (..), parseWith, render) where
+
+import qualified Data.Aeson as Aeson
+import Data.Generics.Labels ()
+import Gen.Prelude
+import qualified Text.EDE as EDE
+
+-- | A type-safe template that knows the type of its arguments and how
+-- to pass them to EDE.
+data Template input = Template
+  { edeTemplate :: EDE.Template,
+    arguments :: input -> HashMap Text Aeson.Value
+  }
+  deriving (Generic)
+
+instance Contravariant Template where
+  contramap f = #arguments %~ (. f)
+
+parseWith ::
+  (Monad m) =>
+  (input -> HashMap Text Aeson.Value) ->
+  EDE.Resolver m ->
+  Text ->
+  ByteString ->
+  m (Either String (Template input))
+parseWith arguments resolver name template = do
+  eTemplate <- EDE.eitherParseWith EDE.defaultSyntax resolver name template
+  pure $ eTemplate <&> \edeTemplate -> Template {..}
+
+render :: Template a -> a -> Either String TextLazy
+render Template {edeTemplate, arguments} =
+  EDE.eitherRender edeTemplate . arguments

--- a/gen/src/Gen/Output/Template/CabalFile.hs
+++ b/gen/src/Gen/Output/Template/CabalFile.hs
@@ -9,7 +9,7 @@ import Data.Aeson (toJSON)
 import qualified Data.Aeson as Aeson
 import qualified Data.HashMap.Strict as HashMap
 import Gen.Prelude
-import Gen.Types.Config (Library)
+import Gen.Types.Config (Library, exposedModules, otherModules)
 import qualified Gen.Types.Config as Config
 import Gen.Types.NS (unNS)
 import Gen.Types.Service (metadata, service)
@@ -22,8 +22,7 @@ data CabalFile = CabalFile
     serviceAbbrev :: Text,
     serviceFullName :: Text,
     apiVersion :: Text,
-    exposedModules :: [Text],
-    otherModules :: [Text],
+    modules :: [Text],
     extraDependencies :: [Text]
   }
   deriving (Generic)
@@ -36,8 +35,7 @@ arguments CabalFile {..} =
       ("serviceAbbrev", toJSON serviceAbbrev),
       ("serviceFullName", toJSON serviceFullName),
       ("apiVersion", toJSON apiVersion),
-      ("exposedModules", toJSON exposedModules),
-      ("otherModules", toJSON otherModules),
+      ("modules", toJSON modules),
       ("extraDependencies", toJSON extraDependencies)
     ]
 
@@ -49,7 +47,6 @@ fromLibrary lib =
       serviceAbbrev = lib ^. service . metadata . Service.serviceAbbrev,
       serviceFullName = lib ^. service . metadata . Service.serviceFullName,
       apiVersion = lib ^. service . metadata . Service.apiVersion,
-      exposedModules = unNS <$> lib ^. Config.exposedModules,
-      otherModules = unNS <$> lib ^. Config.otherModules,
+      modules = unNS <$> lib ^. exposedModules <> lib ^. otherModules,
       extraDependencies = lib ^. Config.config . Config.extraDependencies
     }

--- a/gen/src/Gen/Output/Template/CabalFile.hs
+++ b/gen/src/Gen/Output/Template/CabalFile.hs
@@ -22,7 +22,6 @@ data CabalFile = CabalFile
     serviceAbbrev :: Text,
     serviceFullName :: Text,
     apiVersion :: Text,
-    clientVersion :: Text,
     exposedModules :: [Text],
     otherModules :: [Text],
     extraDependencies :: [Text]
@@ -37,7 +36,6 @@ arguments CabalFile {..} =
       ("serviceAbbrev", toJSON serviceAbbrev),
       ("serviceFullName", toJSON serviceFullName),
       ("apiVersion", toJSON apiVersion),
-      ("clientVersion", toJSON clientVersion),
       ("exposedModules", toJSON exposedModules),
       ("otherModules", toJSON otherModules),
       ("extraDependencies", toJSON extraDependencies)
@@ -51,7 +49,6 @@ fromLibrary lib =
       serviceAbbrev = lib ^. service . metadata . Service.serviceAbbrev,
       serviceFullName = lib ^. service . metadata . Service.serviceFullName,
       apiVersion = lib ^. service . metadata . Service.apiVersion,
-      clientVersion = Config.semver $ Config._version' lib,
       exposedModules = unNS <$> lib ^. Config.exposedModules,
       otherModules = unNS <$> lib ^. Config.otherModules,
       extraDependencies = lib ^. Config.config . Config.extraDependencies

--- a/gen/src/Gen/Output/Template/CabalFile.hs
+++ b/gen/src/Gen/Output/Template/CabalFile.hs
@@ -1,0 +1,31 @@
+module Gen.Output.Template.CabalFile where
+
+import Data.Aeson (toJSON)
+import qualified Data.Aeson as Aeson
+import qualified Data.HashMap.Strict as HashMap
+import Gen.Prelude
+
+data CabalFile = CabalFile
+  { libraryName :: Text,
+    libraryVersion :: Text,
+    serviceAbbrev :: Text,
+    serviceFullName :: Text,
+    apiVersion :: Text,
+    exposedModules :: [Text],
+    otherModules :: [Text],
+    extraDependencies :: [Text]
+  }
+  deriving (Generic)
+
+arguments :: CabalFile -> HashMap Text Aeson.Value
+arguments CabalFile {..} =
+  HashMap.fromList
+    [ ("libraryName", toJSON libraryName),
+      ("libraryVersion", toJSON libraryVersion),
+      ("serviceAbbrev", toJSON serviceAbbrev),
+      ("serviceFullName", toJSON serviceFullName),
+      ("apiVersion", toJSON apiVersion),
+      ("exposedModules", toJSON exposedModules),
+      ("otherModules", toJSON otherModules),
+      ("extraDependencies", toJSON extraDependencies)
+    ]

--- a/gen/src/Gen/Output/Template/CabalFile.hs
+++ b/gen/src/Gen/Output/Template/CabalFile.hs
@@ -1,16 +1,28 @@
-module Gen.Output.Template.CabalFile where
+module Gen.Output.Template.CabalFile
+  ( CabalFile (..),
+    arguments,
+    fromLibrary,
+  )
+where
 
 import Data.Aeson (toJSON)
 import qualified Data.Aeson as Aeson
 import qualified Data.HashMap.Strict as HashMap
 import Gen.Prelude
+import Gen.Types.Config (Library)
+import qualified Gen.Types.Config as Config
+import Gen.Types.NS (unNS)
+import Gen.Types.Service (metadata, service)
+import qualified Gen.Types.Service as Service
 
+-- | Arguments for the @cabal.ede@ template.
 data CabalFile = CabalFile
   { libraryName :: Text,
     libraryVersion :: Text,
     serviceAbbrev :: Text,
     serviceFullName :: Text,
     apiVersion :: Text,
+    clientVersion :: Text,
     exposedModules :: [Text],
     otherModules :: [Text],
     extraDependencies :: [Text]
@@ -25,7 +37,22 @@ arguments CabalFile {..} =
       ("serviceAbbrev", toJSON serviceAbbrev),
       ("serviceFullName", toJSON serviceFullName),
       ("apiVersion", toJSON apiVersion),
+      ("clientVersion", toJSON clientVersion),
       ("exposedModules", toJSON exposedModules),
       ("otherModules", toJSON otherModules),
       ("extraDependencies", toJSON extraDependencies)
     ]
+
+fromLibrary :: Library -> CabalFile
+fromLibrary lib =
+  CabalFile
+    { libraryName = lib ^. Config.libraryName,
+      libraryVersion = Config.semver $ Config._version' lib,
+      serviceAbbrev = lib ^. service . metadata . Service.serviceAbbrev,
+      serviceFullName = lib ^. service . metadata . Service.serviceFullName,
+      apiVersion = lib ^. service . metadata . Service.apiVersion,
+      clientVersion = Config.semver $ Config._version' lib,
+      exposedModules = unNS <$> lib ^. Config.exposedModules,
+      otherModules = unNS <$> lib ^. Config.otherModules,
+      extraDependencies = lib ^. Config.config . Config.extraDependencies
+    }

--- a/gen/src/Gen/Tree.hs
+++ b/gen/src/Gen/Tree.hs
@@ -14,6 +14,7 @@ import Data.Set.Lens (setOf)
 import qualified Data.Text as Text
 import Gen.Import
 import qualified Gen.JSON as JSON
+import Gen.Output.Template (Templates (..))
 import Gen.Prelude hiding (mod)
 import Gen.Types
 import System.Directory.Tree

--- a/gen/src/Gen/Types/Config.hs
+++ b/gen/src/Gen/Types/Config.hs
@@ -19,7 +19,6 @@ import Gen.Types.NS
 import Gen.Types.Service
 import Gen.Types.TypeOf
 import qualified System.FilePath as FilePath
-import Text.EDE (Template)
 
 data Replace = Replace
   { _replaceName :: Id,
@@ -198,26 +197,6 @@ exposedModules = Lens.to f
             x ^. waitersNS
           ]
             ++ x ^.. operations . Lens.each . Lens.to (operationNS ns . Lens.view opName)
-
-data Templates = Templates
-  { cabalTemplate :: Template,
-    tocTemplate :: Template,
-    waitersTemplate :: Template,
-    licenseTemplate :: Template,
-    readmeTemplate :: Template,
-    operationTemplate :: Template,
-    typesTemplate :: Template,
-    lensTemplate :: Template,
-    sumTemplate :: Template,
-    productTemplate :: Template,
-    bootProductTemplate :: Template,
-    testMainTemplate :: Template,
-    testNamespaceTemplate :: Template,
-    testInternalTemplate :: Template,
-    fixturesTemplate :: Template,
-    fixtureRequestTemplate :: Template,
-    blankTemplate :: Template
-  }
 
 data Model = Model
   { _modelName :: Text,

--- a/gen/src/Gen/Types/NS.hs
+++ b/gen/src/Gen/Types/NS.hs
@@ -10,6 +10,9 @@ newtype NS = NS [Text]
 mkNS :: Text -> NS
 mkNS = NS . Text.splitOn "."
 
+unNS :: NS -> Text
+unNS (NS xs) = Text.intercalate "." xs
+
 nsToPath :: NS -> FilePath
 nsToPath (NS xs) = Text.unpack (Text.intercalate "/" xs) <.> "hs"
 
@@ -34,4 +37,4 @@ instance FromJSON NS where
   parseJSON = Aeson.withText "NS" (pure . mkNS)
 
 instance ToJSON NS where
-  toJSON (NS xs) = Aeson.toJSON (Text.intercalate "." xs)
+  toJSON = Aeson.toJSON . unNS


### PR DESCRIPTION
I was talking with a colleague about the generator today. I think one of the big reasons the generator is hard to untangle is that many of its types are pulling double or triple duty: first, they represent the JSON files are they are read in from `botocore` (and merged with our annexes); second, they represent the service as the generator understands them (as a service with endpoints and operations that send/receive shapes in formats); third, they represent (via their `ToJSON` instances) the input to the various `.ede` templates used to generate the output files.

I hope to eventually deal with #888 by starting at the output and refactoring backwards, until the types currently in `amazonka-gen` aren't participating in output any more. This PR is the first step in that plan. It introduces the `Gen.Output` namespace and a `Gen.Output.Template.Template` type, representing a template that tracks the type of the record it needs to consume. `Gen.Output.Template.CabalFile` then represents the fields needed by `cabal.ede`, and its only job is to get them into the `HashMap Text Aeson.Value` that EDE requires.

This then revealed some easy opportunities for simplification, so I did them too.

The hope is that once the current types are no longer overloaded, we can simplify them by removing type variables, instances, etc., and eventually replace them (e.g., by replacing the cofree comonadic shape functor with a type that only refers to shapes by name; when everything looks at it from that perspective, #888 becomes impossible).

The current goal is to have three phases — "input", "model", and "output":

* "Input" should read the source IDL as accurately as possible. Currently this is `botocore` and we have https://github/bellroy/hs-botocore to eventually swap in here;
* "Model" will be our playground to describe AWS services. I expect this to be aware of request and response shapes, but also Haskell-specific things like what types to use in a representation, which deriving clauses we need to generate, and which module names to import (and whether to import them `{-# SOURCE #-}` or not); and
* "Output" will be where we set up the output directory tree, feed data to EDE templates, etc. Because each template will eventually have its own record to track its inputs, we may want to include a thin layer of type-safety here. Future work might have an argument record contain a `[ModuleName]` naming the `exposed-modules` instead of a `[Text]`, but the main point is to keep this as simple as possible.

This PR does not change the output of the generator at all; I re-ran it over the repo and got a clean diff.

