### PR TITLE
invert order of method discovery in credential chain

### DIFF
--- a/lib/amazonka/src/Amazonka/Auth.hs
+++ b/lib/amazonka/src/Amazonka/Auth.hs
@@ -109,14 +109,14 @@ discover ::
   m Env
 discover =
   runCredentialChain
-    [ fromKeysEnv,
-      fromFileEnv,
-      fromWebIdentityEnv,
-      fromContainerEnv,
-      \env -> do
+    [ \env -> do
         onEC2 <- isEC2 $ manager env
         unless onEC2 $ throwM CredentialChainExhausted
-        fromDefaultInstanceProfile env
+        fromDefaultInstanceProfile env,
+      fromWebIdentityEnv,
+      fromContainerEnv,
+      fromFileEnv,
+      fromKeysEnv
     ]
 
 -- | Compose a list of credential-providing functions by testing each


### PR DESCRIPTION
As referenced in issue https://github.com/brendanhay/amazonka/issues/1018
inverting the order of methods in the credential chain ensures the fastest methods are executed first (keys, file, container, webidentity, http request when in EC2).
This allows for fast env discovery in low latency apps, like clis and lambda.