### PR TITLE
Replace git:// with https:// in cabal files

### DIFF
--- a/configs/templates/cabal.ede
+++ b/configs/templates/cabal.ede
@@ -27,7 +27,7 @@ description:
 
 source-repository head
     type:              git
-    location:          git://github.com/brendanhay/amazonka.git
+    location:          https://github.com/brendanhay/amazonka.git
     subdir:            {{ libraryName }}
 
 library

--- a/examples/examples.cabal
+++ b/examples/examples.cabal
@@ -12,7 +12,7 @@ build-type:    Simple
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   examples
 
 library

--- a/gen/amazonka-gen.cabal
+++ b/gen/amazonka-gen.cabal
@@ -14,7 +14,7 @@ build-type:    Simple
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   gen
 
 common base

--- a/lib/amazonka-core/amazonka-core.cabal
+++ b/lib/amazonka-core/amazonka-core.cabal
@@ -21,7 +21,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   lib/amazonka-core
 
 common base

--- a/lib/amazonka-dynamodb-attributevalue/amazonka-dynamodb-attributevalue.cabal
+++ b/lib/amazonka-dynamodb-attributevalue/amazonka-dynamodb-attributevalue.cabal
@@ -20,7 +20,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   lib/amazonka-dynamodb-attributevalue
 
 common base

--- a/lib/amazonka-s3-encryption/amazonka-s3-encryption.cabal
+++ b/lib/amazonka-s3-encryption/amazonka-s3-encryption.cabal
@@ -42,7 +42,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   lib/amazonka-s3-encryption
 
 common base

--- a/lib/amazonka-test/amazonka-test.cabal
+++ b/lib/amazonka-test/amazonka-test.cabal
@@ -24,7 +24,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   lib/amazonka-test
 
 library

--- a/lib/amazonka/amazonka.cabal
+++ b/lib/amazonka/amazonka.cabal
@@ -30,7 +30,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   lib/amazonka
 
 common base

--- a/lib/services/amazonka-accessanalyzer/amazonka-accessanalyzer.cabal
+++ b/lib/services/amazonka-accessanalyzer/amazonka-accessanalyzer.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-accessanalyzer
 
 library

--- a/lib/services/amazonka-account/amazonka-account.cabal
+++ b/lib/services/amazonka-account/amazonka-account.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-account
 
 library

--- a/lib/services/amazonka-alexa-business/amazonka-alexa-business.cabal
+++ b/lib/services/amazonka-alexa-business/amazonka-alexa-business.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-alexa-business
 
 library

--- a/lib/services/amazonka-amp/amazonka-amp.cabal
+++ b/lib/services/amazonka-amp/amazonka-amp.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-amp
 
 library

--- a/lib/services/amazonka-amplify/amazonka-amplify.cabal
+++ b/lib/services/amazonka-amplify/amazonka-amplify.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-amplify
 
 library

--- a/lib/services/amazonka-amplifybackend/amazonka-amplifybackend.cabal
+++ b/lib/services/amazonka-amplifybackend/amazonka-amplifybackend.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-amplifybackend
 
 library

--- a/lib/services/amazonka-amplifyuibuilder/amazonka-amplifyuibuilder.cabal
+++ b/lib/services/amazonka-amplifyuibuilder/amazonka-amplifyuibuilder.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-amplifyuibuilder
 
 library

--- a/lib/services/amazonka-apigateway/amazonka-apigateway.cabal
+++ b/lib/services/amazonka-apigateway/amazonka-apigateway.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-apigateway
 
 library

--- a/lib/services/amazonka-apigatewaymanagementapi/amazonka-apigatewaymanagementapi.cabal
+++ b/lib/services/amazonka-apigatewaymanagementapi/amazonka-apigatewaymanagementapi.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-apigatewaymanagementapi
 
 library

--- a/lib/services/amazonka-apigatewayv2/amazonka-apigatewayv2.cabal
+++ b/lib/services/amazonka-apigatewayv2/amazonka-apigatewayv2.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-apigatewayv2
 
 library

--- a/lib/services/amazonka-appconfig/amazonka-appconfig.cabal
+++ b/lib/services/amazonka-appconfig/amazonka-appconfig.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-appconfig
 
 library

--- a/lib/services/amazonka-appconfigdata/amazonka-appconfigdata.cabal
+++ b/lib/services/amazonka-appconfigdata/amazonka-appconfigdata.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-appconfigdata
 
 library

--- a/lib/services/amazonka-appflow/amazonka-appflow.cabal
+++ b/lib/services/amazonka-appflow/amazonka-appflow.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-appflow
 
 library

--- a/lib/services/amazonka-appintegrations/amazonka-appintegrations.cabal
+++ b/lib/services/amazonka-appintegrations/amazonka-appintegrations.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-appintegrations
 
 library

--- a/lib/services/amazonka-application-autoscaling/amazonka-application-autoscaling.cabal
+++ b/lib/services/amazonka-application-autoscaling/amazonka-application-autoscaling.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-application-autoscaling
 
 library

--- a/lib/services/amazonka-application-insights/amazonka-application-insights.cabal
+++ b/lib/services/amazonka-application-insights/amazonka-application-insights.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-application-insights
 
 library

--- a/lib/services/amazonka-applicationcostprofiler/amazonka-applicationcostprofiler.cabal
+++ b/lib/services/amazonka-applicationcostprofiler/amazonka-applicationcostprofiler.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-applicationcostprofiler
 
 library

--- a/lib/services/amazonka-appmesh/amazonka-appmesh.cabal
+++ b/lib/services/amazonka-appmesh/amazonka-appmesh.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-appmesh
 
 library

--- a/lib/services/amazonka-apprunner/amazonka-apprunner.cabal
+++ b/lib/services/amazonka-apprunner/amazonka-apprunner.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-apprunner
 
 library

--- a/lib/services/amazonka-appstream/amazonka-appstream.cabal
+++ b/lib/services/amazonka-appstream/amazonka-appstream.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-appstream
 
 library

--- a/lib/services/amazonka-appsync/amazonka-appsync.cabal
+++ b/lib/services/amazonka-appsync/amazonka-appsync.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-appsync
 
 library

--- a/lib/services/amazonka-arc-zonal-shift/amazonka-arc-zonal-shift.cabal
+++ b/lib/services/amazonka-arc-zonal-shift/amazonka-arc-zonal-shift.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-arc-zonal-shift
 
 library

--- a/lib/services/amazonka-athena/amazonka-athena.cabal
+++ b/lib/services/amazonka-athena/amazonka-athena.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-athena
 
 library

--- a/lib/services/amazonka-auditmanager/amazonka-auditmanager.cabal
+++ b/lib/services/amazonka-auditmanager/amazonka-auditmanager.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-auditmanager
 
 library

--- a/lib/services/amazonka-autoscaling-plans/amazonka-autoscaling-plans.cabal
+++ b/lib/services/amazonka-autoscaling-plans/amazonka-autoscaling-plans.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-autoscaling-plans
 
 library

--- a/lib/services/amazonka-autoscaling/amazonka-autoscaling.cabal
+++ b/lib/services/amazonka-autoscaling/amazonka-autoscaling.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-autoscaling
 
 library

--- a/lib/services/amazonka-backup-gateway/amazonka-backup-gateway.cabal
+++ b/lib/services/amazonka-backup-gateway/amazonka-backup-gateway.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-backup-gateway
 
 library

--- a/lib/services/amazonka-backup/amazonka-backup.cabal
+++ b/lib/services/amazonka-backup/amazonka-backup.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-backup
 
 library

--- a/lib/services/amazonka-backupstorage/amazonka-backupstorage.cabal
+++ b/lib/services/amazonka-backupstorage/amazonka-backupstorage.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-backupstorage
 
 library

--- a/lib/services/amazonka-batch/amazonka-batch.cabal
+++ b/lib/services/amazonka-batch/amazonka-batch.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-batch
 
 library

--- a/lib/services/amazonka-billingconductor/amazonka-billingconductor.cabal
+++ b/lib/services/amazonka-billingconductor/amazonka-billingconductor.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-billingconductor
 
 library

--- a/lib/services/amazonka-braket/amazonka-braket.cabal
+++ b/lib/services/amazonka-braket/amazonka-braket.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-braket
 
 library

--- a/lib/services/amazonka-budgets/amazonka-budgets.cabal
+++ b/lib/services/amazonka-budgets/amazonka-budgets.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-budgets
 
 library

--- a/lib/services/amazonka-certificatemanager-pca/amazonka-certificatemanager-pca.cabal
+++ b/lib/services/amazonka-certificatemanager-pca/amazonka-certificatemanager-pca.cabal
@@ -36,7 +36,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-certificatemanager-pca
 
 library

--- a/lib/services/amazonka-certificatemanager/amazonka-certificatemanager.cabal
+++ b/lib/services/amazonka-certificatemanager/amazonka-certificatemanager.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-certificatemanager
 
 library

--- a/lib/services/amazonka-chime-sdk-identity/amazonka-chime-sdk-identity.cabal
+++ b/lib/services/amazonka-chime-sdk-identity/amazonka-chime-sdk-identity.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-chime-sdk-identity
 
 library

--- a/lib/services/amazonka-chime-sdk-media-pipelines/amazonka-chime-sdk-media-pipelines.cabal
+++ b/lib/services/amazonka-chime-sdk-media-pipelines/amazonka-chime-sdk-media-pipelines.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-chime-sdk-media-pipelines
 
 library

--- a/lib/services/amazonka-chime-sdk-meetings/amazonka-chime-sdk-meetings.cabal
+++ b/lib/services/amazonka-chime-sdk-meetings/amazonka-chime-sdk-meetings.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-chime-sdk-meetings
 
 library

--- a/lib/services/amazonka-chime-sdk-messaging/amazonka-chime-sdk-messaging.cabal
+++ b/lib/services/amazonka-chime-sdk-messaging/amazonka-chime-sdk-messaging.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-chime-sdk-messaging
 
 library

--- a/lib/services/amazonka-chime-sdk-voice/amazonka-chime-sdk-voice.cabal
+++ b/lib/services/amazonka-chime-sdk-voice/amazonka-chime-sdk-voice.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-chime-sdk-voice
 
 library

--- a/lib/services/amazonka-chime/amazonka-chime.cabal
+++ b/lib/services/amazonka-chime/amazonka-chime.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-chime
 
 library

--- a/lib/services/amazonka-cloud9/amazonka-cloud9.cabal
+++ b/lib/services/amazonka-cloud9/amazonka-cloud9.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-cloud9
 
 library

--- a/lib/services/amazonka-cloudcontrol/amazonka-cloudcontrol.cabal
+++ b/lib/services/amazonka-cloudcontrol/amazonka-cloudcontrol.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-cloudcontrol
 
 library

--- a/lib/services/amazonka-clouddirectory/amazonka-clouddirectory.cabal
+++ b/lib/services/amazonka-clouddirectory/amazonka-clouddirectory.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-clouddirectory
 
 library

--- a/lib/services/amazonka-cloudformation/amazonka-cloudformation.cabal
+++ b/lib/services/amazonka-cloudformation/amazonka-cloudformation.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-cloudformation
 
 library

--- a/lib/services/amazonka-cloudfront/amazonka-cloudfront.cabal
+++ b/lib/services/amazonka-cloudfront/amazonka-cloudfront.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-cloudfront
 
 library

--- a/lib/services/amazonka-cloudhsm/amazonka-cloudhsm.cabal
+++ b/lib/services/amazonka-cloudhsm/amazonka-cloudhsm.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-cloudhsm
 
 library

--- a/lib/services/amazonka-cloudhsmv2/amazonka-cloudhsmv2.cabal
+++ b/lib/services/amazonka-cloudhsmv2/amazonka-cloudhsmv2.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-cloudhsmv2
 
 library

--- a/lib/services/amazonka-cloudsearch-domains/amazonka-cloudsearch-domains.cabal
+++ b/lib/services/amazonka-cloudsearch-domains/amazonka-cloudsearch-domains.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-cloudsearch-domains
 
 library

--- a/lib/services/amazonka-cloudsearch/amazonka-cloudsearch.cabal
+++ b/lib/services/amazonka-cloudsearch/amazonka-cloudsearch.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-cloudsearch
 
 library

--- a/lib/services/amazonka-cloudtrail/amazonka-cloudtrail.cabal
+++ b/lib/services/amazonka-cloudtrail/amazonka-cloudtrail.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-cloudtrail
 
 library

--- a/lib/services/amazonka-cloudwatch-events/amazonka-cloudwatch-events.cabal
+++ b/lib/services/amazonka-cloudwatch-events/amazonka-cloudwatch-events.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-cloudwatch-events
 
 library

--- a/lib/services/amazonka-cloudwatch-logs/amazonka-cloudwatch-logs.cabal
+++ b/lib/services/amazonka-cloudwatch-logs/amazonka-cloudwatch-logs.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-cloudwatch-logs
 
 library

--- a/lib/services/amazonka-cloudwatch/amazonka-cloudwatch.cabal
+++ b/lib/services/amazonka-cloudwatch/amazonka-cloudwatch.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-cloudwatch
 
 library

--- a/lib/services/amazonka-codeartifact/amazonka-codeartifact.cabal
+++ b/lib/services/amazonka-codeartifact/amazonka-codeartifact.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-codeartifact
 
 library

--- a/lib/services/amazonka-codebuild/amazonka-codebuild.cabal
+++ b/lib/services/amazonka-codebuild/amazonka-codebuild.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-codebuild
 
 library

--- a/lib/services/amazonka-codecommit/amazonka-codecommit.cabal
+++ b/lib/services/amazonka-codecommit/amazonka-codecommit.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-codecommit
 
 library

--- a/lib/services/amazonka-codedeploy/amazonka-codedeploy.cabal
+++ b/lib/services/amazonka-codedeploy/amazonka-codedeploy.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-codedeploy
 
 library

--- a/lib/services/amazonka-codeguru-reviewer/amazonka-codeguru-reviewer.cabal
+++ b/lib/services/amazonka-codeguru-reviewer/amazonka-codeguru-reviewer.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-codeguru-reviewer
 
 library

--- a/lib/services/amazonka-codeguruprofiler/amazonka-codeguruprofiler.cabal
+++ b/lib/services/amazonka-codeguruprofiler/amazonka-codeguruprofiler.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-codeguruprofiler
 
 library

--- a/lib/services/amazonka-codepipeline/amazonka-codepipeline.cabal
+++ b/lib/services/amazonka-codepipeline/amazonka-codepipeline.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-codepipeline
 
 library

--- a/lib/services/amazonka-codestar-connections/amazonka-codestar-connections.cabal
+++ b/lib/services/amazonka-codestar-connections/amazonka-codestar-connections.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-codestar-connections
 
 library

--- a/lib/services/amazonka-codestar-notifications/amazonka-codestar-notifications.cabal
+++ b/lib/services/amazonka-codestar-notifications/amazonka-codestar-notifications.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-codestar-notifications
 
 library

--- a/lib/services/amazonka-codestar/amazonka-codestar.cabal
+++ b/lib/services/amazonka-codestar/amazonka-codestar.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-codestar
 
 library

--- a/lib/services/amazonka-cognito-identity/amazonka-cognito-identity.cabal
+++ b/lib/services/amazonka-cognito-identity/amazonka-cognito-identity.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-cognito-identity
 
 library

--- a/lib/services/amazonka-cognito-idp/amazonka-cognito-idp.cabal
+++ b/lib/services/amazonka-cognito-idp/amazonka-cognito-idp.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-cognito-idp
 
 library

--- a/lib/services/amazonka-cognito-sync/amazonka-cognito-sync.cabal
+++ b/lib/services/amazonka-cognito-sync/amazonka-cognito-sync.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-cognito-sync
 
 library

--- a/lib/services/amazonka-comprehend/amazonka-comprehend.cabal
+++ b/lib/services/amazonka-comprehend/amazonka-comprehend.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-comprehend
 
 library

--- a/lib/services/amazonka-comprehendmedical/amazonka-comprehendmedical.cabal
+++ b/lib/services/amazonka-comprehendmedical/amazonka-comprehendmedical.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-comprehendmedical
 
 library

--- a/lib/services/amazonka-compute-optimizer/amazonka-compute-optimizer.cabal
+++ b/lib/services/amazonka-compute-optimizer/amazonka-compute-optimizer.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-compute-optimizer
 
 library

--- a/lib/services/amazonka-config/amazonka-config.cabal
+++ b/lib/services/amazonka-config/amazonka-config.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-config
 
 library

--- a/lib/services/amazonka-connect-contact-lens/amazonka-connect-contact-lens.cabal
+++ b/lib/services/amazonka-connect-contact-lens/amazonka-connect-contact-lens.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-connect-contact-lens
 
 library

--- a/lib/services/amazonka-connect/amazonka-connect.cabal
+++ b/lib/services/amazonka-connect/amazonka-connect.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-connect
 
 library

--- a/lib/services/amazonka-connectcampaigns/amazonka-connectcampaigns.cabal
+++ b/lib/services/amazonka-connectcampaigns/amazonka-connectcampaigns.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-connectcampaigns
 
 library

--- a/lib/services/amazonka-connectcases/amazonka-connectcases.cabal
+++ b/lib/services/amazonka-connectcases/amazonka-connectcases.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-connectcases
 
 library

--- a/lib/services/amazonka-connectparticipant/amazonka-connectparticipant.cabal
+++ b/lib/services/amazonka-connectparticipant/amazonka-connectparticipant.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-connectparticipant
 
 library

--- a/lib/services/amazonka-controltower/amazonka-controltower.cabal
+++ b/lib/services/amazonka-controltower/amazonka-controltower.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-controltower
 
 library

--- a/lib/services/amazonka-cost-explorer/amazonka-cost-explorer.cabal
+++ b/lib/services/amazonka-cost-explorer/amazonka-cost-explorer.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-cost-explorer
 
 library

--- a/lib/services/amazonka-cur/amazonka-cur.cabal
+++ b/lib/services/amazonka-cur/amazonka-cur.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-cur
 
 library

--- a/lib/services/amazonka-customer-profiles/amazonka-customer-profiles.cabal
+++ b/lib/services/amazonka-customer-profiles/amazonka-customer-profiles.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-customer-profiles
 
 library

--- a/lib/services/amazonka-databrew/amazonka-databrew.cabal
+++ b/lib/services/amazonka-databrew/amazonka-databrew.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-databrew
 
 library

--- a/lib/services/amazonka-dataexchange/amazonka-dataexchange.cabal
+++ b/lib/services/amazonka-dataexchange/amazonka-dataexchange.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-dataexchange
 
 library

--- a/lib/services/amazonka-datapipeline/amazonka-datapipeline.cabal
+++ b/lib/services/amazonka-datapipeline/amazonka-datapipeline.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-datapipeline
 
 library

--- a/lib/services/amazonka-datasync/amazonka-datasync.cabal
+++ b/lib/services/amazonka-datasync/amazonka-datasync.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-datasync
 
 library

--- a/lib/services/amazonka-detective/amazonka-detective.cabal
+++ b/lib/services/amazonka-detective/amazonka-detective.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-detective
 
 library

--- a/lib/services/amazonka-devicefarm/amazonka-devicefarm.cabal
+++ b/lib/services/amazonka-devicefarm/amazonka-devicefarm.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-devicefarm
 
 library

--- a/lib/services/amazonka-devops-guru/amazonka-devops-guru.cabal
+++ b/lib/services/amazonka-devops-guru/amazonka-devops-guru.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-devops-guru
 
 library

--- a/lib/services/amazonka-directconnect/amazonka-directconnect.cabal
+++ b/lib/services/amazonka-directconnect/amazonka-directconnect.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-directconnect
 
 library

--- a/lib/services/amazonka-discovery/amazonka-discovery.cabal
+++ b/lib/services/amazonka-discovery/amazonka-discovery.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-discovery
 
 library

--- a/lib/services/amazonka-dlm/amazonka-dlm.cabal
+++ b/lib/services/amazonka-dlm/amazonka-dlm.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-dlm
 
 library

--- a/lib/services/amazonka-dms/amazonka-dms.cabal
+++ b/lib/services/amazonka-dms/amazonka-dms.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-dms
 
 library

--- a/lib/services/amazonka-docdb-elastic/amazonka-docdb-elastic.cabal
+++ b/lib/services/amazonka-docdb-elastic/amazonka-docdb-elastic.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-docdb-elastic
 
 library

--- a/lib/services/amazonka-docdb/amazonka-docdb.cabal
+++ b/lib/services/amazonka-docdb/amazonka-docdb.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-docdb
 
 library

--- a/lib/services/amazonka-drs/amazonka-drs.cabal
+++ b/lib/services/amazonka-drs/amazonka-drs.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-drs
 
 library

--- a/lib/services/amazonka-ds/amazonka-ds.cabal
+++ b/lib/services/amazonka-ds/amazonka-ds.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-ds
 
 library

--- a/lib/services/amazonka-dynamodb-dax/amazonka-dynamodb-dax.cabal
+++ b/lib/services/amazonka-dynamodb-dax/amazonka-dynamodb-dax.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-dynamodb-dax
 
 library

--- a/lib/services/amazonka-dynamodb-streams/amazonka-dynamodb-streams.cabal
+++ b/lib/services/amazonka-dynamodb-streams/amazonka-dynamodb-streams.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-dynamodb-streams
 
 library

--- a/lib/services/amazonka-dynamodb/amazonka-dynamodb.cabal
+++ b/lib/services/amazonka-dynamodb/amazonka-dynamodb.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-dynamodb
 
 library

--- a/lib/services/amazonka-ebs/amazonka-ebs.cabal
+++ b/lib/services/amazonka-ebs/amazonka-ebs.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-ebs
 
 library

--- a/lib/services/amazonka-ec2-instance-connect/amazonka-ec2-instance-connect.cabal
+++ b/lib/services/amazonka-ec2-instance-connect/amazonka-ec2-instance-connect.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-ec2-instance-connect
 
 library

--- a/lib/services/amazonka-ec2/amazonka-ec2.cabal
+++ b/lib/services/amazonka-ec2/amazonka-ec2.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-ec2
 
 library

--- a/lib/services/amazonka-ecr-public/amazonka-ecr-public.cabal
+++ b/lib/services/amazonka-ecr-public/amazonka-ecr-public.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-ecr-public
 
 library

--- a/lib/services/amazonka-ecr/amazonka-ecr.cabal
+++ b/lib/services/amazonka-ecr/amazonka-ecr.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-ecr
 
 library

--- a/lib/services/amazonka-ecs/amazonka-ecs.cabal
+++ b/lib/services/amazonka-ecs/amazonka-ecs.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-ecs
 
 library

--- a/lib/services/amazonka-efs/amazonka-efs.cabal
+++ b/lib/services/amazonka-efs/amazonka-efs.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-efs
 
 library

--- a/lib/services/amazonka-eks/amazonka-eks.cabal
+++ b/lib/services/amazonka-eks/amazonka-eks.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-eks
 
 library

--- a/lib/services/amazonka-elastic-inference/amazonka-elastic-inference.cabal
+++ b/lib/services/amazonka-elastic-inference/amazonka-elastic-inference.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-elastic-inference
 
 library

--- a/lib/services/amazonka-elasticache/amazonka-elasticache.cabal
+++ b/lib/services/amazonka-elasticache/amazonka-elasticache.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-elasticache
 
 library

--- a/lib/services/amazonka-elasticbeanstalk/amazonka-elasticbeanstalk.cabal
+++ b/lib/services/amazonka-elasticbeanstalk/amazonka-elasticbeanstalk.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-elasticbeanstalk
 
 library

--- a/lib/services/amazonka-elasticsearch/amazonka-elasticsearch.cabal
+++ b/lib/services/amazonka-elasticsearch/amazonka-elasticsearch.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-elasticsearch
 
 library

--- a/lib/services/amazonka-elastictranscoder/amazonka-elastictranscoder.cabal
+++ b/lib/services/amazonka-elastictranscoder/amazonka-elastictranscoder.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-elastictranscoder
 
 library

--- a/lib/services/amazonka-elb/amazonka-elb.cabal
+++ b/lib/services/amazonka-elb/amazonka-elb.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-elb
 
 library

--- a/lib/services/amazonka-elbv2/amazonka-elbv2.cabal
+++ b/lib/services/amazonka-elbv2/amazonka-elbv2.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-elbv2
 
 library

--- a/lib/services/amazonka-emr-containers/amazonka-emr-containers.cabal
+++ b/lib/services/amazonka-emr-containers/amazonka-emr-containers.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-emr-containers
 
 library

--- a/lib/services/amazonka-emr-serverless/amazonka-emr-serverless.cabal
+++ b/lib/services/amazonka-emr-serverless/amazonka-emr-serverless.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-emr-serverless
 
 library

--- a/lib/services/amazonka-emr/amazonka-emr.cabal
+++ b/lib/services/amazonka-emr/amazonka-emr.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-emr
 
 library

--- a/lib/services/amazonka-evidently/amazonka-evidently.cabal
+++ b/lib/services/amazonka-evidently/amazonka-evidently.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-evidently
 
 library

--- a/lib/services/amazonka-finspace-data/amazonka-finspace-data.cabal
+++ b/lib/services/amazonka-finspace-data/amazonka-finspace-data.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-finspace-data
 
 library

--- a/lib/services/amazonka-finspace/amazonka-finspace.cabal
+++ b/lib/services/amazonka-finspace/amazonka-finspace.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-finspace
 
 library

--- a/lib/services/amazonka-fis/amazonka-fis.cabal
+++ b/lib/services/amazonka-fis/amazonka-fis.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-fis
 
 library

--- a/lib/services/amazonka-fms/amazonka-fms.cabal
+++ b/lib/services/amazonka-fms/amazonka-fms.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-fms
 
 library

--- a/lib/services/amazonka-forecast/amazonka-forecast.cabal
+++ b/lib/services/amazonka-forecast/amazonka-forecast.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-forecast
 
 library

--- a/lib/services/amazonka-forecastquery/amazonka-forecastquery.cabal
+++ b/lib/services/amazonka-forecastquery/amazonka-forecastquery.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-forecastquery
 
 library

--- a/lib/services/amazonka-frauddetector/amazonka-frauddetector.cabal
+++ b/lib/services/amazonka-frauddetector/amazonka-frauddetector.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-frauddetector
 
 library

--- a/lib/services/amazonka-fsx/amazonka-fsx.cabal
+++ b/lib/services/amazonka-fsx/amazonka-fsx.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-fsx
 
 library

--- a/lib/services/amazonka-gamelift/amazonka-gamelift.cabal
+++ b/lib/services/amazonka-gamelift/amazonka-gamelift.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-gamelift
 
 library

--- a/lib/services/amazonka-gamesparks/amazonka-gamesparks.cabal
+++ b/lib/services/amazonka-gamesparks/amazonka-gamesparks.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-gamesparks
 
 library

--- a/lib/services/amazonka-glacier/amazonka-glacier.cabal
+++ b/lib/services/amazonka-glacier/amazonka-glacier.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-glacier
 
 library

--- a/lib/services/amazonka-globalaccelerator/amazonka-globalaccelerator.cabal
+++ b/lib/services/amazonka-globalaccelerator/amazonka-globalaccelerator.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-globalaccelerator
 
 library

--- a/lib/services/amazonka-glue/amazonka-glue.cabal
+++ b/lib/services/amazonka-glue/amazonka-glue.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-glue
 
 library

--- a/lib/services/amazonka-grafana/amazonka-grafana.cabal
+++ b/lib/services/amazonka-grafana/amazonka-grafana.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-grafana
 
 library

--- a/lib/services/amazonka-greengrass/amazonka-greengrass.cabal
+++ b/lib/services/amazonka-greengrass/amazonka-greengrass.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-greengrass
 
 library

--- a/lib/services/amazonka-greengrassv2/amazonka-greengrassv2.cabal
+++ b/lib/services/amazonka-greengrassv2/amazonka-greengrassv2.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-greengrassv2
 
 library

--- a/lib/services/amazonka-groundstation/amazonka-groundstation.cabal
+++ b/lib/services/amazonka-groundstation/amazonka-groundstation.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-groundstation
 
 library

--- a/lib/services/amazonka-guardduty/amazonka-guardduty.cabal
+++ b/lib/services/amazonka-guardduty/amazonka-guardduty.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-guardduty
 
 library

--- a/lib/services/amazonka-health/amazonka-health.cabal
+++ b/lib/services/amazonka-health/amazonka-health.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-health
 
 library

--- a/lib/services/amazonka-healthlake/amazonka-healthlake.cabal
+++ b/lib/services/amazonka-healthlake/amazonka-healthlake.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-healthlake
 
 library

--- a/lib/services/amazonka-honeycode/amazonka-honeycode.cabal
+++ b/lib/services/amazonka-honeycode/amazonka-honeycode.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-honeycode
 
 library

--- a/lib/services/amazonka-iam/amazonka-iam.cabal
+++ b/lib/services/amazonka-iam/amazonka-iam.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-iam
 
 library

--- a/lib/services/amazonka-identitystore/amazonka-identitystore.cabal
+++ b/lib/services/amazonka-identitystore/amazonka-identitystore.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-identitystore
 
 library

--- a/lib/services/amazonka-imagebuilder/amazonka-imagebuilder.cabal
+++ b/lib/services/amazonka-imagebuilder/amazonka-imagebuilder.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-imagebuilder
 
 library

--- a/lib/services/amazonka-importexport/amazonka-importexport.cabal
+++ b/lib/services/amazonka-importexport/amazonka-importexport.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-importexport
 
 library

--- a/lib/services/amazonka-inspector/amazonka-inspector.cabal
+++ b/lib/services/amazonka-inspector/amazonka-inspector.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-inspector
 
 library

--- a/lib/services/amazonka-inspector2/amazonka-inspector2.cabal
+++ b/lib/services/amazonka-inspector2/amazonka-inspector2.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-inspector2
 
 library

--- a/lib/services/amazonka-iot-analytics/amazonka-iot-analytics.cabal
+++ b/lib/services/amazonka-iot-analytics/amazonka-iot-analytics.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-iot-analytics
 
 library

--- a/lib/services/amazonka-iot-dataplane/amazonka-iot-dataplane.cabal
+++ b/lib/services/amazonka-iot-dataplane/amazonka-iot-dataplane.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-iot-dataplane
 
 library

--- a/lib/services/amazonka-iot-jobs-dataplane/amazonka-iot-jobs-dataplane.cabal
+++ b/lib/services/amazonka-iot-jobs-dataplane/amazonka-iot-jobs-dataplane.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-iot-jobs-dataplane
 
 library

--- a/lib/services/amazonka-iot-roborunner/amazonka-iot-roborunner.cabal
+++ b/lib/services/amazonka-iot-roborunner/amazonka-iot-roborunner.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-iot-roborunner
 
 library

--- a/lib/services/amazonka-iot/amazonka-iot.cabal
+++ b/lib/services/amazonka-iot/amazonka-iot.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-iot
 
 library

--- a/lib/services/amazonka-iot1click-devices/amazonka-iot1click-devices.cabal
+++ b/lib/services/amazonka-iot1click-devices/amazonka-iot1click-devices.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-iot1click-devices
 
 library

--- a/lib/services/amazonka-iot1click-projects/amazonka-iot1click-projects.cabal
+++ b/lib/services/amazonka-iot1click-projects/amazonka-iot1click-projects.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-iot1click-projects
 
 library

--- a/lib/services/amazonka-iotdeviceadvisor/amazonka-iotdeviceadvisor.cabal
+++ b/lib/services/amazonka-iotdeviceadvisor/amazonka-iotdeviceadvisor.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-iotdeviceadvisor
 
 library

--- a/lib/services/amazonka-iotevents-data/amazonka-iotevents-data.cabal
+++ b/lib/services/amazonka-iotevents-data/amazonka-iotevents-data.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-iotevents-data
 
 library

--- a/lib/services/amazonka-iotevents/amazonka-iotevents.cabal
+++ b/lib/services/amazonka-iotevents/amazonka-iotevents.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-iotevents
 
 library

--- a/lib/services/amazonka-iotfleethub/amazonka-iotfleethub.cabal
+++ b/lib/services/amazonka-iotfleethub/amazonka-iotfleethub.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-iotfleethub
 
 library

--- a/lib/services/amazonka-iotfleetwise/amazonka-iotfleetwise.cabal
+++ b/lib/services/amazonka-iotfleetwise/amazonka-iotfleetwise.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-iotfleetwise
 
 library

--- a/lib/services/amazonka-iotsecuretunneling/amazonka-iotsecuretunneling.cabal
+++ b/lib/services/amazonka-iotsecuretunneling/amazonka-iotsecuretunneling.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-iotsecuretunneling
 
 library

--- a/lib/services/amazonka-iotsitewise/amazonka-iotsitewise.cabal
+++ b/lib/services/amazonka-iotsitewise/amazonka-iotsitewise.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-iotsitewise
 
 library

--- a/lib/services/amazonka-iotthingsgraph/amazonka-iotthingsgraph.cabal
+++ b/lib/services/amazonka-iotthingsgraph/amazonka-iotthingsgraph.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-iotthingsgraph
 
 library

--- a/lib/services/amazonka-iottwinmaker/amazonka-iottwinmaker.cabal
+++ b/lib/services/amazonka-iottwinmaker/amazonka-iottwinmaker.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-iottwinmaker
 
 library

--- a/lib/services/amazonka-iotwireless/amazonka-iotwireless.cabal
+++ b/lib/services/amazonka-iotwireless/amazonka-iotwireless.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-iotwireless
 
 library

--- a/lib/services/amazonka-ivs/amazonka-ivs.cabal
+++ b/lib/services/amazonka-ivs/amazonka-ivs.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-ivs
 
 library

--- a/lib/services/amazonka-ivschat/amazonka-ivschat.cabal
+++ b/lib/services/amazonka-ivschat/amazonka-ivschat.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-ivschat
 
 library

--- a/lib/services/amazonka-kafka/amazonka-kafka.cabal
+++ b/lib/services/amazonka-kafka/amazonka-kafka.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-kafka
 
 library

--- a/lib/services/amazonka-kafkaconnect/amazonka-kafkaconnect.cabal
+++ b/lib/services/amazonka-kafkaconnect/amazonka-kafkaconnect.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-kafkaconnect
 
 library

--- a/lib/services/amazonka-kendra/amazonka-kendra.cabal
+++ b/lib/services/amazonka-kendra/amazonka-kendra.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-kendra
 
 library

--- a/lib/services/amazonka-keyspaces/amazonka-keyspaces.cabal
+++ b/lib/services/amazonka-keyspaces/amazonka-keyspaces.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-keyspaces
 
 library

--- a/lib/services/amazonka-kinesis-analytics/amazonka-kinesis-analytics.cabal
+++ b/lib/services/amazonka-kinesis-analytics/amazonka-kinesis-analytics.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-kinesis-analytics
 
 library

--- a/lib/services/amazonka-kinesis-firehose/amazonka-kinesis-firehose.cabal
+++ b/lib/services/amazonka-kinesis-firehose/amazonka-kinesis-firehose.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-kinesis-firehose
 
 library

--- a/lib/services/amazonka-kinesis-video-archived-media/amazonka-kinesis-video-archived-media.cabal
+++ b/lib/services/amazonka-kinesis-video-archived-media/amazonka-kinesis-video-archived-media.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-kinesis-video-archived-media
 
 library

--- a/lib/services/amazonka-kinesis-video-media/amazonka-kinesis-video-media.cabal
+++ b/lib/services/amazonka-kinesis-video-media/amazonka-kinesis-video-media.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-kinesis-video-media
 
 library

--- a/lib/services/amazonka-kinesis-video-signaling/amazonka-kinesis-video-signaling.cabal
+++ b/lib/services/amazonka-kinesis-video-signaling/amazonka-kinesis-video-signaling.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-kinesis-video-signaling
 
 library

--- a/lib/services/amazonka-kinesis-video-webrtc-storage/amazonka-kinesis-video-webrtc-storage.cabal
+++ b/lib/services/amazonka-kinesis-video-webrtc-storage/amazonka-kinesis-video-webrtc-storage.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-kinesis-video-webrtc-storage
 
 library

--- a/lib/services/amazonka-kinesis-video/amazonka-kinesis-video.cabal
+++ b/lib/services/amazonka-kinesis-video/amazonka-kinesis-video.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-kinesis-video
 
 library

--- a/lib/services/amazonka-kinesis/amazonka-kinesis.cabal
+++ b/lib/services/amazonka-kinesis/amazonka-kinesis.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-kinesis
 
 library

--- a/lib/services/amazonka-kinesisanalyticsv2/amazonka-kinesisanalyticsv2.cabal
+++ b/lib/services/amazonka-kinesisanalyticsv2/amazonka-kinesisanalyticsv2.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-kinesisanalyticsv2
 
 library

--- a/lib/services/amazonka-kms/amazonka-kms.cabal
+++ b/lib/services/amazonka-kms/amazonka-kms.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-kms
 
 library

--- a/lib/services/amazonka-lakeformation/amazonka-lakeformation.cabal
+++ b/lib/services/amazonka-lakeformation/amazonka-lakeformation.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-lakeformation
 
 library

--- a/lib/services/amazonka-lambda/amazonka-lambda.cabal
+++ b/lib/services/amazonka-lambda/amazonka-lambda.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-lambda
 
 library

--- a/lib/services/amazonka-lex-models/amazonka-lex-models.cabal
+++ b/lib/services/amazonka-lex-models/amazonka-lex-models.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-lex-models
 
 library

--- a/lib/services/amazonka-lex-runtime/amazonka-lex-runtime.cabal
+++ b/lib/services/amazonka-lex-runtime/amazonka-lex-runtime.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-lex-runtime
 
 library

--- a/lib/services/amazonka-lexv2-models/amazonka-lexv2-models.cabal
+++ b/lib/services/amazonka-lexv2-models/amazonka-lexv2-models.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-lexv2-models
 
 library

--- a/lib/services/amazonka-license-manager-linux-subscriptions/amazonka-license-manager-linux-subscriptions.cabal
+++ b/lib/services/amazonka-license-manager-linux-subscriptions/amazonka-license-manager-linux-subscriptions.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-license-manager-linux-subscriptions
 
 library

--- a/lib/services/amazonka-license-manager-user-subscriptions/amazonka-license-manager-user-subscriptions.cabal
+++ b/lib/services/amazonka-license-manager-user-subscriptions/amazonka-license-manager-user-subscriptions.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-license-manager-user-subscriptions
 
 library

--- a/lib/services/amazonka-license-manager/amazonka-license-manager.cabal
+++ b/lib/services/amazonka-license-manager/amazonka-license-manager.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-license-manager
 
 library

--- a/lib/services/amazonka-lightsail/amazonka-lightsail.cabal
+++ b/lib/services/amazonka-lightsail/amazonka-lightsail.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-lightsail
 
 library

--- a/lib/services/amazonka-location/amazonka-location.cabal
+++ b/lib/services/amazonka-location/amazonka-location.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-location
 
 library

--- a/lib/services/amazonka-lookoutequipment/amazonka-lookoutequipment.cabal
+++ b/lib/services/amazonka-lookoutequipment/amazonka-lookoutequipment.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-lookoutequipment
 
 library

--- a/lib/services/amazonka-lookoutmetrics/amazonka-lookoutmetrics.cabal
+++ b/lib/services/amazonka-lookoutmetrics/amazonka-lookoutmetrics.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-lookoutmetrics
 
 library

--- a/lib/services/amazonka-lookoutvision/amazonka-lookoutvision.cabal
+++ b/lib/services/amazonka-lookoutvision/amazonka-lookoutvision.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-lookoutvision
 
 library

--- a/lib/services/amazonka-m2/amazonka-m2.cabal
+++ b/lib/services/amazonka-m2/amazonka-m2.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-m2
 
 library

--- a/lib/services/amazonka-macie/amazonka-macie.cabal
+++ b/lib/services/amazonka-macie/amazonka-macie.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-macie
 
 library

--- a/lib/services/amazonka-maciev2/amazonka-maciev2.cabal
+++ b/lib/services/amazonka-maciev2/amazonka-maciev2.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-maciev2
 
 library

--- a/lib/services/amazonka-managedblockchain/amazonka-managedblockchain.cabal
+++ b/lib/services/amazonka-managedblockchain/amazonka-managedblockchain.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-managedblockchain
 
 library

--- a/lib/services/amazonka-marketplace-analytics/amazonka-marketplace-analytics.cabal
+++ b/lib/services/amazonka-marketplace-analytics/amazonka-marketplace-analytics.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-marketplace-analytics
 
 library

--- a/lib/services/amazonka-marketplace-catalog/amazonka-marketplace-catalog.cabal
+++ b/lib/services/amazonka-marketplace-catalog/amazonka-marketplace-catalog.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-marketplace-catalog
 
 library

--- a/lib/services/amazonka-marketplace-entitlement/amazonka-marketplace-entitlement.cabal
+++ b/lib/services/amazonka-marketplace-entitlement/amazonka-marketplace-entitlement.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-marketplace-entitlement
 
 library

--- a/lib/services/amazonka-marketplace-metering/amazonka-marketplace-metering.cabal
+++ b/lib/services/amazonka-marketplace-metering/amazonka-marketplace-metering.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-marketplace-metering
 
 library

--- a/lib/services/amazonka-mechanicalturk/amazonka-mechanicalturk.cabal
+++ b/lib/services/amazonka-mechanicalturk/amazonka-mechanicalturk.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-mechanicalturk
 
 library

--- a/lib/services/amazonka-mediaconnect/amazonka-mediaconnect.cabal
+++ b/lib/services/amazonka-mediaconnect/amazonka-mediaconnect.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-mediaconnect
 
 library

--- a/lib/services/amazonka-mediaconvert/amazonka-mediaconvert.cabal
+++ b/lib/services/amazonka-mediaconvert/amazonka-mediaconvert.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-mediaconvert
 
 library

--- a/lib/services/amazonka-medialive/amazonka-medialive.cabal
+++ b/lib/services/amazonka-medialive/amazonka-medialive.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-medialive
 
 library

--- a/lib/services/amazonka-mediapackage-vod/amazonka-mediapackage-vod.cabal
+++ b/lib/services/amazonka-mediapackage-vod/amazonka-mediapackage-vod.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-mediapackage-vod
 
 library

--- a/lib/services/amazonka-mediapackage/amazonka-mediapackage.cabal
+++ b/lib/services/amazonka-mediapackage/amazonka-mediapackage.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-mediapackage
 
 library

--- a/lib/services/amazonka-mediastore-dataplane/amazonka-mediastore-dataplane.cabal
+++ b/lib/services/amazonka-mediastore-dataplane/amazonka-mediastore-dataplane.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-mediastore-dataplane
 
 library

--- a/lib/services/amazonka-mediastore/amazonka-mediastore.cabal
+++ b/lib/services/amazonka-mediastore/amazonka-mediastore.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-mediastore
 
 library

--- a/lib/services/amazonka-mediatailor/amazonka-mediatailor.cabal
+++ b/lib/services/amazonka-mediatailor/amazonka-mediatailor.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-mediatailor
 
 library

--- a/lib/services/amazonka-memorydb/amazonka-memorydb.cabal
+++ b/lib/services/amazonka-memorydb/amazonka-memorydb.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-memorydb
 
 library

--- a/lib/services/amazonka-mgn/amazonka-mgn.cabal
+++ b/lib/services/amazonka-mgn/amazonka-mgn.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-mgn
 
 library

--- a/lib/services/amazonka-migration-hub-refactor-spaces/amazonka-migration-hub-refactor-spaces.cabal
+++ b/lib/services/amazonka-migration-hub-refactor-spaces/amazonka-migration-hub-refactor-spaces.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-migration-hub-refactor-spaces
 
 library

--- a/lib/services/amazonka-migrationhub-config/amazonka-migrationhub-config.cabal
+++ b/lib/services/amazonka-migrationhub-config/amazonka-migrationhub-config.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-migrationhub-config
 
 library

--- a/lib/services/amazonka-migrationhub/amazonka-migrationhub.cabal
+++ b/lib/services/amazonka-migrationhub/amazonka-migrationhub.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-migrationhub
 
 library

--- a/lib/services/amazonka-migrationhuborchestrator/amazonka-migrationhuborchestrator.cabal
+++ b/lib/services/amazonka-migrationhuborchestrator/amazonka-migrationhuborchestrator.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-migrationhuborchestrator
 
 library

--- a/lib/services/amazonka-migrationhubstrategy/amazonka-migrationhubstrategy.cabal
+++ b/lib/services/amazonka-migrationhubstrategy/amazonka-migrationhubstrategy.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-migrationhubstrategy
 
 library

--- a/lib/services/amazonka-ml/amazonka-ml.cabal
+++ b/lib/services/amazonka-ml/amazonka-ml.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-ml
 
 library

--- a/lib/services/amazonka-mobile/amazonka-mobile.cabal
+++ b/lib/services/amazonka-mobile/amazonka-mobile.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-mobile
 
 library

--- a/lib/services/amazonka-mq/amazonka-mq.cabal
+++ b/lib/services/amazonka-mq/amazonka-mq.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-mq
 
 library

--- a/lib/services/amazonka-mwaa/amazonka-mwaa.cabal
+++ b/lib/services/amazonka-mwaa/amazonka-mwaa.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-mwaa
 
 library

--- a/lib/services/amazonka-neptune/amazonka-neptune.cabal
+++ b/lib/services/amazonka-neptune/amazonka-neptune.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-neptune
 
 library

--- a/lib/services/amazonka-network-firewall/amazonka-network-firewall.cabal
+++ b/lib/services/amazonka-network-firewall/amazonka-network-firewall.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-network-firewall
 
 library

--- a/lib/services/amazonka-networkmanager/amazonka-networkmanager.cabal
+++ b/lib/services/amazonka-networkmanager/amazonka-networkmanager.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-networkmanager
 
 library

--- a/lib/services/amazonka-nimble/amazonka-nimble.cabal
+++ b/lib/services/amazonka-nimble/amazonka-nimble.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-nimble
 
 library

--- a/lib/services/amazonka-oam/amazonka-oam.cabal
+++ b/lib/services/amazonka-oam/amazonka-oam.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-oam
 
 library

--- a/lib/services/amazonka-omics/amazonka-omics.cabal
+++ b/lib/services/amazonka-omics/amazonka-omics.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-omics
 
 library

--- a/lib/services/amazonka-opensearch/amazonka-opensearch.cabal
+++ b/lib/services/amazonka-opensearch/amazonka-opensearch.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-opensearch
 
 library

--- a/lib/services/amazonka-opensearchserverless/amazonka-opensearchserverless.cabal
+++ b/lib/services/amazonka-opensearchserverless/amazonka-opensearchserverless.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-opensearchserverless
 
 library

--- a/lib/services/amazonka-opsworks-cm/amazonka-opsworks-cm.cabal
+++ b/lib/services/amazonka-opsworks-cm/amazonka-opsworks-cm.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-opsworks-cm
 
 library

--- a/lib/services/amazonka-opsworks/amazonka-opsworks.cabal
+++ b/lib/services/amazonka-opsworks/amazonka-opsworks.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-opsworks
 
 library

--- a/lib/services/amazonka-organizations/amazonka-organizations.cabal
+++ b/lib/services/amazonka-organizations/amazonka-organizations.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-organizations
 
 library

--- a/lib/services/amazonka-outposts/amazonka-outposts.cabal
+++ b/lib/services/amazonka-outposts/amazonka-outposts.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-outposts
 
 library

--- a/lib/services/amazonka-panorama/amazonka-panorama.cabal
+++ b/lib/services/amazonka-panorama/amazonka-panorama.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-panorama
 
 library

--- a/lib/services/amazonka-personalize-events/amazonka-personalize-events.cabal
+++ b/lib/services/amazonka-personalize-events/amazonka-personalize-events.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-personalize-events
 
 library

--- a/lib/services/amazonka-personalize-runtime/amazonka-personalize-runtime.cabal
+++ b/lib/services/amazonka-personalize-runtime/amazonka-personalize-runtime.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-personalize-runtime
 
 library

--- a/lib/services/amazonka-personalize/amazonka-personalize.cabal
+++ b/lib/services/amazonka-personalize/amazonka-personalize.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-personalize
 
 library

--- a/lib/services/amazonka-pi/amazonka-pi.cabal
+++ b/lib/services/amazonka-pi/amazonka-pi.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-pi
 
 library

--- a/lib/services/amazonka-pinpoint-email/amazonka-pinpoint-email.cabal
+++ b/lib/services/amazonka-pinpoint-email/amazonka-pinpoint-email.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-pinpoint-email
 
 library

--- a/lib/services/amazonka-pinpoint-sms-voice-v2/amazonka-pinpoint-sms-voice-v2.cabal
+++ b/lib/services/amazonka-pinpoint-sms-voice-v2/amazonka-pinpoint-sms-voice-v2.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-pinpoint-sms-voice-v2
 
 library

--- a/lib/services/amazonka-pinpoint-sms-voice/amazonka-pinpoint-sms-voice.cabal
+++ b/lib/services/amazonka-pinpoint-sms-voice/amazonka-pinpoint-sms-voice.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-pinpoint-sms-voice
 
 library

--- a/lib/services/amazonka-pinpoint/amazonka-pinpoint.cabal
+++ b/lib/services/amazonka-pinpoint/amazonka-pinpoint.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-pinpoint
 
 library

--- a/lib/services/amazonka-pipes/amazonka-pipes.cabal
+++ b/lib/services/amazonka-pipes/amazonka-pipes.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-pipes
 
 library

--- a/lib/services/amazonka-polly/amazonka-polly.cabal
+++ b/lib/services/amazonka-polly/amazonka-polly.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-polly
 
 library

--- a/lib/services/amazonka-pricing/amazonka-pricing.cabal
+++ b/lib/services/amazonka-pricing/amazonka-pricing.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-pricing
 
 library

--- a/lib/services/amazonka-privatenetworks/amazonka-privatenetworks.cabal
+++ b/lib/services/amazonka-privatenetworks/amazonka-privatenetworks.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-privatenetworks
 
 library

--- a/lib/services/amazonka-proton/amazonka-proton.cabal
+++ b/lib/services/amazonka-proton/amazonka-proton.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-proton
 
 library

--- a/lib/services/amazonka-qldb-session/amazonka-qldb-session.cabal
+++ b/lib/services/amazonka-qldb-session/amazonka-qldb-session.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-qldb-session
 
 library

--- a/lib/services/amazonka-qldb/amazonka-qldb.cabal
+++ b/lib/services/amazonka-qldb/amazonka-qldb.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-qldb
 
 library

--- a/lib/services/amazonka-quicksight/amazonka-quicksight.cabal
+++ b/lib/services/amazonka-quicksight/amazonka-quicksight.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-quicksight
 
 library

--- a/lib/services/amazonka-ram/amazonka-ram.cabal
+++ b/lib/services/amazonka-ram/amazonka-ram.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-ram
 
 library

--- a/lib/services/amazonka-rbin/amazonka-rbin.cabal
+++ b/lib/services/amazonka-rbin/amazonka-rbin.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-rbin
 
 library

--- a/lib/services/amazonka-rds-data/amazonka-rds-data.cabal
+++ b/lib/services/amazonka-rds-data/amazonka-rds-data.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-rds-data
 
 library

--- a/lib/services/amazonka-rds/amazonka-rds.cabal
+++ b/lib/services/amazonka-rds/amazonka-rds.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-rds
 
 library

--- a/lib/services/amazonka-redshift-data/amazonka-redshift-data.cabal
+++ b/lib/services/amazonka-redshift-data/amazonka-redshift-data.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-redshift-data
 
 library

--- a/lib/services/amazonka-redshift-serverless/amazonka-redshift-serverless.cabal
+++ b/lib/services/amazonka-redshift-serverless/amazonka-redshift-serverless.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-redshift-serverless
 
 library

--- a/lib/services/amazonka-redshift/amazonka-redshift.cabal
+++ b/lib/services/amazonka-redshift/amazonka-redshift.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-redshift
 
 library

--- a/lib/services/amazonka-rekognition/amazonka-rekognition.cabal
+++ b/lib/services/amazonka-rekognition/amazonka-rekognition.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-rekognition
 
 library

--- a/lib/services/amazonka-resiliencehub/amazonka-resiliencehub.cabal
+++ b/lib/services/amazonka-resiliencehub/amazonka-resiliencehub.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-resiliencehub
 
 library

--- a/lib/services/amazonka-resource-explorer-v2/amazonka-resource-explorer-v2.cabal
+++ b/lib/services/amazonka-resource-explorer-v2/amazonka-resource-explorer-v2.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-resource-explorer-v2
 
 library

--- a/lib/services/amazonka-resourcegroups/amazonka-resourcegroups.cabal
+++ b/lib/services/amazonka-resourcegroups/amazonka-resourcegroups.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-resourcegroups
 
 library

--- a/lib/services/amazonka-resourcegroupstagging/amazonka-resourcegroupstagging.cabal
+++ b/lib/services/amazonka-resourcegroupstagging/amazonka-resourcegroupstagging.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-resourcegroupstagging
 
 library

--- a/lib/services/amazonka-robomaker/amazonka-robomaker.cabal
+++ b/lib/services/amazonka-robomaker/amazonka-robomaker.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-robomaker
 
 library

--- a/lib/services/amazonka-rolesanywhere/amazonka-rolesanywhere.cabal
+++ b/lib/services/amazonka-rolesanywhere/amazonka-rolesanywhere.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-rolesanywhere
 
 library

--- a/lib/services/amazonka-route53-autonaming/amazonka-route53-autonaming.cabal
+++ b/lib/services/amazonka-route53-autonaming/amazonka-route53-autonaming.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-route53-autonaming
 
 library

--- a/lib/services/amazonka-route53-domains/amazonka-route53-domains.cabal
+++ b/lib/services/amazonka-route53-domains/amazonka-route53-domains.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-route53-domains
 
 library

--- a/lib/services/amazonka-route53-recovery-cluster/amazonka-route53-recovery-cluster.cabal
+++ b/lib/services/amazonka-route53-recovery-cluster/amazonka-route53-recovery-cluster.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-route53-recovery-cluster
 
 library

--- a/lib/services/amazonka-route53-recovery-control-config/amazonka-route53-recovery-control-config.cabal
+++ b/lib/services/amazonka-route53-recovery-control-config/amazonka-route53-recovery-control-config.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-route53-recovery-control-config
 
 library

--- a/lib/services/amazonka-route53-recovery-readiness/amazonka-route53-recovery-readiness.cabal
+++ b/lib/services/amazonka-route53-recovery-readiness/amazonka-route53-recovery-readiness.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-route53-recovery-readiness
 
 library

--- a/lib/services/amazonka-route53/amazonka-route53.cabal
+++ b/lib/services/amazonka-route53/amazonka-route53.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-route53
 
 library

--- a/lib/services/amazonka-route53resolver/amazonka-route53resolver.cabal
+++ b/lib/services/amazonka-route53resolver/amazonka-route53resolver.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-route53resolver
 
 library

--- a/lib/services/amazonka-rum/amazonka-rum.cabal
+++ b/lib/services/amazonka-rum/amazonka-rum.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-rum
 
 library

--- a/lib/services/amazonka-s3/amazonka-s3.cabal
+++ b/lib/services/amazonka-s3/amazonka-s3.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-s3
 
 library

--- a/lib/services/amazonka-s3outposts/amazonka-s3outposts.cabal
+++ b/lib/services/amazonka-s3outposts/amazonka-s3outposts.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-s3outposts
 
 library

--- a/lib/services/amazonka-sagemaker-a2i-runtime/amazonka-sagemaker-a2i-runtime.cabal
+++ b/lib/services/amazonka-sagemaker-a2i-runtime/amazonka-sagemaker-a2i-runtime.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-sagemaker-a2i-runtime
 
 library

--- a/lib/services/amazonka-sagemaker-edge/amazonka-sagemaker-edge.cabal
+++ b/lib/services/amazonka-sagemaker-edge/amazonka-sagemaker-edge.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-sagemaker-edge
 
 library

--- a/lib/services/amazonka-sagemaker-featurestore-runtime/amazonka-sagemaker-featurestore-runtime.cabal
+++ b/lib/services/amazonka-sagemaker-featurestore-runtime/amazonka-sagemaker-featurestore-runtime.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-sagemaker-featurestore-runtime
 
 library

--- a/lib/services/amazonka-sagemaker-geospatial/amazonka-sagemaker-geospatial.cabal
+++ b/lib/services/amazonka-sagemaker-geospatial/amazonka-sagemaker-geospatial.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-sagemaker-geospatial
 
 library

--- a/lib/services/amazonka-sagemaker-metrics/amazonka-sagemaker-metrics.cabal
+++ b/lib/services/amazonka-sagemaker-metrics/amazonka-sagemaker-metrics.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-sagemaker-metrics
 
 library

--- a/lib/services/amazonka-sagemaker-runtime/amazonka-sagemaker-runtime.cabal
+++ b/lib/services/amazonka-sagemaker-runtime/amazonka-sagemaker-runtime.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-sagemaker-runtime
 
 library

--- a/lib/services/amazonka-sagemaker/amazonka-sagemaker.cabal
+++ b/lib/services/amazonka-sagemaker/amazonka-sagemaker.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-sagemaker
 
 library

--- a/lib/services/amazonka-savingsplans/amazonka-savingsplans.cabal
+++ b/lib/services/amazonka-savingsplans/amazonka-savingsplans.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-savingsplans
 
 library

--- a/lib/services/amazonka-scheduler/amazonka-scheduler.cabal
+++ b/lib/services/amazonka-scheduler/amazonka-scheduler.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-scheduler
 
 library

--- a/lib/services/amazonka-schemas/amazonka-schemas.cabal
+++ b/lib/services/amazonka-schemas/amazonka-schemas.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-schemas
 
 library

--- a/lib/services/amazonka-sdb/amazonka-sdb.cabal
+++ b/lib/services/amazonka-sdb/amazonka-sdb.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-sdb
 
 library

--- a/lib/services/amazonka-secretsmanager/amazonka-secretsmanager.cabal
+++ b/lib/services/amazonka-secretsmanager/amazonka-secretsmanager.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-secretsmanager
 
 library

--- a/lib/services/amazonka-securityhub/amazonka-securityhub.cabal
+++ b/lib/services/amazonka-securityhub/amazonka-securityhub.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-securityhub
 
 library

--- a/lib/services/amazonka-securitylake/amazonka-securitylake.cabal
+++ b/lib/services/amazonka-securitylake/amazonka-securitylake.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-securitylake
 
 library

--- a/lib/services/amazonka-serverlessrepo/amazonka-serverlessrepo.cabal
+++ b/lib/services/amazonka-serverlessrepo/amazonka-serverlessrepo.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-serverlessrepo
 
 library

--- a/lib/services/amazonka-service-quotas/amazonka-service-quotas.cabal
+++ b/lib/services/amazonka-service-quotas/amazonka-service-quotas.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-service-quotas
 
 library

--- a/lib/services/amazonka-servicecatalog-appregistry/amazonka-servicecatalog-appregistry.cabal
+++ b/lib/services/amazonka-servicecatalog-appregistry/amazonka-servicecatalog-appregistry.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-servicecatalog-appregistry
 
 library

--- a/lib/services/amazonka-servicecatalog/amazonka-servicecatalog.cabal
+++ b/lib/services/amazonka-servicecatalog/amazonka-servicecatalog.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-servicecatalog
 
 library

--- a/lib/services/amazonka-ses/amazonka-ses.cabal
+++ b/lib/services/amazonka-ses/amazonka-ses.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-ses
 
 library

--- a/lib/services/amazonka-sesv2/amazonka-sesv2.cabal
+++ b/lib/services/amazonka-sesv2/amazonka-sesv2.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-sesv2
 
 library

--- a/lib/services/amazonka-shield/amazonka-shield.cabal
+++ b/lib/services/amazonka-shield/amazonka-shield.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-shield
 
 library

--- a/lib/services/amazonka-signer/amazonka-signer.cabal
+++ b/lib/services/amazonka-signer/amazonka-signer.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-signer
 
 library

--- a/lib/services/amazonka-simspaceweaver/amazonka-simspaceweaver.cabal
+++ b/lib/services/amazonka-simspaceweaver/amazonka-simspaceweaver.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-simspaceweaver
 
 library

--- a/lib/services/amazonka-sms-voice/amazonka-sms-voice.cabal
+++ b/lib/services/amazonka-sms-voice/amazonka-sms-voice.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-sms-voice
 
 library

--- a/lib/services/amazonka-sms/amazonka-sms.cabal
+++ b/lib/services/amazonka-sms/amazonka-sms.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-sms
 
 library

--- a/lib/services/amazonka-snow-device-management/amazonka-snow-device-management.cabal
+++ b/lib/services/amazonka-snow-device-management/amazonka-snow-device-management.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-snow-device-management
 
 library

--- a/lib/services/amazonka-snowball/amazonka-snowball.cabal
+++ b/lib/services/amazonka-snowball/amazonka-snowball.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-snowball
 
 library

--- a/lib/services/amazonka-sns/amazonka-sns.cabal
+++ b/lib/services/amazonka-sns/amazonka-sns.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-sns
 
 library

--- a/lib/services/amazonka-sqs/amazonka-sqs.cabal
+++ b/lib/services/amazonka-sqs/amazonka-sqs.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-sqs
 
 library

--- a/lib/services/amazonka-ssm-contacts/amazonka-ssm-contacts.cabal
+++ b/lib/services/amazonka-ssm-contacts/amazonka-ssm-contacts.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-ssm-contacts
 
 library

--- a/lib/services/amazonka-ssm-incidents/amazonka-ssm-incidents.cabal
+++ b/lib/services/amazonka-ssm-incidents/amazonka-ssm-incidents.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-ssm-incidents
 
 library

--- a/lib/services/amazonka-ssm-sap/amazonka-ssm-sap.cabal
+++ b/lib/services/amazonka-ssm-sap/amazonka-ssm-sap.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-ssm-sap
 
 library

--- a/lib/services/amazonka-ssm/amazonka-ssm.cabal
+++ b/lib/services/amazonka-ssm/amazonka-ssm.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-ssm
 
 library

--- a/lib/services/amazonka-sso-admin/amazonka-sso-admin.cabal
+++ b/lib/services/amazonka-sso-admin/amazonka-sso-admin.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-sso-admin
 
 library

--- a/lib/services/amazonka-sso-oidc/amazonka-sso-oidc.cabal
+++ b/lib/services/amazonka-sso-oidc/amazonka-sso-oidc.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-sso-oidc
 
 library

--- a/lib/services/amazonka-sso/amazonka-sso.cabal
+++ b/lib/services/amazonka-sso/amazonka-sso.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-sso
 
 library

--- a/lib/services/amazonka-stepfunctions/amazonka-stepfunctions.cabal
+++ b/lib/services/amazonka-stepfunctions/amazonka-stepfunctions.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-stepfunctions
 
 library

--- a/lib/services/amazonka-storagegateway/amazonka-storagegateway.cabal
+++ b/lib/services/amazonka-storagegateway/amazonka-storagegateway.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-storagegateway
 
 library

--- a/lib/services/amazonka-sts/amazonka-sts.cabal
+++ b/lib/services/amazonka-sts/amazonka-sts.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-sts
 
 library

--- a/lib/services/amazonka-support-app/amazonka-support-app.cabal
+++ b/lib/services/amazonka-support-app/amazonka-support-app.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-support-app
 
 library

--- a/lib/services/amazonka-support/amazonka-support.cabal
+++ b/lib/services/amazonka-support/amazonka-support.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-support
 
 library

--- a/lib/services/amazonka-swf/amazonka-swf.cabal
+++ b/lib/services/amazonka-swf/amazonka-swf.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-swf
 
 library

--- a/lib/services/amazonka-synthetics/amazonka-synthetics.cabal
+++ b/lib/services/amazonka-synthetics/amazonka-synthetics.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-synthetics
 
 library

--- a/lib/services/amazonka-textract/amazonka-textract.cabal
+++ b/lib/services/amazonka-textract/amazonka-textract.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-textract
 
 library

--- a/lib/services/amazonka-timestream-query/amazonka-timestream-query.cabal
+++ b/lib/services/amazonka-timestream-query/amazonka-timestream-query.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-timestream-query
 
 library

--- a/lib/services/amazonka-timestream-write/amazonka-timestream-write.cabal
+++ b/lib/services/amazonka-timestream-write/amazonka-timestream-write.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-timestream-write
 
 library

--- a/lib/services/amazonka-transcribe/amazonka-transcribe.cabal
+++ b/lib/services/amazonka-transcribe/amazonka-transcribe.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-transcribe
 
 library

--- a/lib/services/amazonka-transfer/amazonka-transfer.cabal
+++ b/lib/services/amazonka-transfer/amazonka-transfer.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-transfer
 
 library

--- a/lib/services/amazonka-translate/amazonka-translate.cabal
+++ b/lib/services/amazonka-translate/amazonka-translate.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-translate
 
 library

--- a/lib/services/amazonka-voice-id/amazonka-voice-id.cabal
+++ b/lib/services/amazonka-voice-id/amazonka-voice-id.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-voice-id
 
 library

--- a/lib/services/amazonka-waf-regional/amazonka-waf-regional.cabal
+++ b/lib/services/amazonka-waf-regional/amazonka-waf-regional.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-waf-regional
 
 library

--- a/lib/services/amazonka-waf/amazonka-waf.cabal
+++ b/lib/services/amazonka-waf/amazonka-waf.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-waf
 
 library

--- a/lib/services/amazonka-wafv2/amazonka-wafv2.cabal
+++ b/lib/services/amazonka-wafv2/amazonka-wafv2.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-wafv2
 
 library

--- a/lib/services/amazonka-wellarchitected/amazonka-wellarchitected.cabal
+++ b/lib/services/amazonka-wellarchitected/amazonka-wellarchitected.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-wellarchitected
 
 library

--- a/lib/services/amazonka-wisdom/amazonka-wisdom.cabal
+++ b/lib/services/amazonka-wisdom/amazonka-wisdom.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-wisdom
 
 library

--- a/lib/services/amazonka-workdocs/amazonka-workdocs.cabal
+++ b/lib/services/amazonka-workdocs/amazonka-workdocs.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-workdocs
 
 library

--- a/lib/services/amazonka-worklink/amazonka-worklink.cabal
+++ b/lib/services/amazonka-worklink/amazonka-worklink.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-worklink
 
 library

--- a/lib/services/amazonka-workmail/amazonka-workmail.cabal
+++ b/lib/services/amazonka-workmail/amazonka-workmail.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-workmail
 
 library

--- a/lib/services/amazonka-workmailmessageflow/amazonka-workmailmessageflow.cabal
+++ b/lib/services/amazonka-workmailmessageflow/amazonka-workmailmessageflow.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-workmailmessageflow
 
 library

--- a/lib/services/amazonka-workspaces-web/amazonka-workspaces-web.cabal
+++ b/lib/services/amazonka-workspaces-web/amazonka-workspaces-web.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-workspaces-web
 
 library

--- a/lib/services/amazonka-workspaces/amazonka-workspaces.cabal
+++ b/lib/services/amazonka-workspaces/amazonka-workspaces.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-workspaces
 
 library

--- a/lib/services/amazonka-xray/amazonka-xray.cabal
+++ b/lib/services/amazonka-xray/amazonka-xray.cabal
@@ -34,7 +34,7 @@ description:
 
 source-repository head
   type:     git
-  location: git://github.com/brendanhay/amazonka.git
+  location: https://github.com/brendanhay/amazonka.git
   subdir:   amazonka-xray
 
 library


### PR DESCRIPTION
The `git` protocol is no longer supported in GitHub [1], and `cabal-install` (since v3.14.0.0 [2]) emits a warning message about its usage. Let's replace `git://` with `https://`.

[1] https://github.blog/security/application-security/improving-git-protocol-security-github/
[2] https://github.com/haskell/cabal/pull/10261
