### PR TITLE
amazonka: Catch auth exceptions in the correct order

### DIFF
--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -32,6 +32,8 @@
 
 ### Fixed
 
+- `amazonka`: Attempt to load credentials in the correct order. In particular, this means that the IMDS is queried last and is once again consistent with other SDKs.
+[\#1029](https://github.com/brendanhay/amazonka/pull/1029)
 - `.cabal` files name the source repository with a `https://` URL, not a `git://` one (thanks @marinelli)
 [\#1026](https://github.com/brendanhay/amazonka/pull/1026)
 - `amazonka-*`: GHC 9.8 support


### PR DESCRIPTION
Previously, we were recursing through the provider list inside the exception handler, which resulted in authentication methods being tried back-to-front.

@matteoeghirotta @pbrisbin please confirm whether this fixes your issue.

Closes #1023 
Fixes #1018 

