### PR TITLE
Query string sorting in canonicalisation

### DIFF
--- a/lib/amazonka-core/src/Amazonka/Data/Query.hs
+++ b/lib/amazonka-core/src/Amazonka/Data/Query.hs
@@ -7,8 +7,8 @@
 -- Portability : non-portable (GHC extensions)
 module Amazonka.Data.Query where
 
-import Amazonka.Data.ByteString
-import Amazonka.Data.Text
+import Amazonka.Data.ByteString (ToByteString (..))
+import Amazonka.Data.Text (ToText (..))
 import Amazonka.Prelude
 import qualified Data.ByteString.Builder as Build
 import qualified Data.ByteString.Char8 as BS8
@@ -92,12 +92,12 @@ instance ToByteString QueryString where
       ksep = "&"
       vsep = "="
 
-pair :: ToQuery a => ByteString -> a -> QueryString -> QueryString
+pair :: (ToQuery a) => ByteString -> a -> QueryString -> QueryString
 pair k v = mappend (QPair k (toQuery v))
 
 infixr 7 =:
 
-(=:) :: ToQuery a => ByteString -> a -> QueryString
+(=:) :: (ToQuery a) => ByteString -> a -> QueryString
 k =: v = QPair k (toQuery v)
 
 toQueryList ::
@@ -107,7 +107,7 @@ toQueryList ::
   QueryString
 toQueryList k = QPair k . QList . zipWith f [1 ..] . toList
   where
-    f :: ToQuery a => Int -> a -> QueryString
+    f :: (ToQuery a) => Int -> a -> QueryString
     f n v = toBS n =: toQuery v
 
 toQueryMap ::
@@ -123,7 +123,7 @@ toQueryMap e k v = toQueryList e . map f . HashMap.toList
 
 class ToQuery a where
   toQuery :: a -> QueryString
-  default toQuery :: ToText a => a -> QueryString
+  default toQuery :: (ToText a) => a -> QueryString
   toQuery = toQuery . toText
 
 instance ToQuery QueryString where
@@ -149,7 +149,7 @@ instance ToQuery Double where toQuery = toQuery . toBS
 
 instance ToQuery Natural where toQuery = toQuery . toBS
 
-instance ToQuery a => ToQuery (Maybe a) where
+instance (ToQuery a) => ToQuery (Maybe a) where
   toQuery (Just x) = toQuery x
   toQuery Nothing = mempty
 

--- a/lib/amazonka-core/src/Amazonka/Data/Query.hs
+++ b/lib/amazonka-core/src/Amazonka/Data/Query.hs
@@ -10,12 +10,14 @@ module Amazonka.Data.Query where
 import Amazonka.Data.ByteString (ToByteString (..))
 import Amazonka.Data.Text (ToText (..))
 import Amazonka.Prelude
+import Control.Category ((>>>))
 import qualified Data.ByteString.Builder as Build
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.List as List
 import qualified Data.Text.Encoding as Text
+import Network.HTTP.Types (QueryItem)
 import qualified Network.HTTP.Types.URI as URI
 
 -- | Structured representation of a query string.
@@ -65,32 +67,42 @@ parseQueryString bs
         "=" -> QValue Nothing
         _ -> QValue (Just (URI.urlDecode True $ BS8.drop 1 x))
 
--- FIXME: use Builder
 instance ToByteString QueryString where
-  toBS = LBS.toStrict . Build.toLazyByteString . cat . List.sort . enc Nothing
+  toBS =
+    toQueryItems Nothing
+      >>> List.sortOn fst
+      >>> catQueryItems
+      >>> Build.toLazyByteString
+      >>> LBS.toStrict
     where
-      enc :: Maybe ByteString -> QueryString -> [ByteString]
-      enc p = \case
-        QList xs -> concatMap (enc p) xs
-        QPair (URI.urlEncode True -> k) x
-          | Just n <- p -> enc (Just (n <> kdelim <> k)) x -- <prev>.key <recur>
-          | otherwise -> enc (Just k) x -- key <recur>
-        QValue (Just (URI.urlEncode True -> v))
-          | Just n <- p -> [n <> vsep <> v] -- key=value
-          | otherwise -> [v <> vsep] -- value= -- note: required for signing.
-        _
-          | Just n <- p -> [n <> vsep] -- key=
-          -- note: this case required for request signing
-          | otherwise -> []
+      -- Carry the "key so far" as an accumulating parameter.
+      toQueryItems :: Maybe ByteString -> QueryString -> [QueryItem]
+      toQueryItems key = \case
+        QList xs ->
+          concatMap (toQueryItems key) xs
+        QValue (Just (URI.urlEncode True -> v)) ->
+          case key of
+            Just k -> [(k, Just v)]
+            Nothing -> [(v, Nothing)] -- Looks odd, required for signing.
+        QValue Nothing ->
+          case key of
+            Just k -> [(k, Nothing)]
+            Nothing -> []
+        QPair (URI.urlEncode True -> k) queryString ->
+          toQueryItems extendedKey queryString
+          where
+            extendedKey :: Maybe ByteString
+            extendedKey = Just $ maybe k (<> "." <> k) key
 
-      cat :: [ByteString] -> ByteStringBuilder
-      cat [] = mempty
-      cat [x] = Build.byteString x
-      cat (x : xs) = Build.byteString x <> ksep <> cat xs
-
-      kdelim = "."
-      ksep = "&"
-      vsep = "="
+      catQueryItems :: [QueryItem] -> ByteStringBuilder
+      catQueryItems = \case
+        [] -> mempty
+        [item] -> encode item
+        item : items -> encode item <> "&" <> catQueryItems items
+        where
+          encode :: QueryItem -> ByteStringBuilder
+          encode (k, mv) =
+            Build.byteString k <> "=" <> foldMap Build.byteString mv
 
 pair :: (ToQuery a) => ByteString -> a -> QueryString -> QueryString
 pair k v = mappend (QPair k (toQuery v))

--- a/lib/amazonka-core/test/Test/Amazonka/Data/Query.hs
+++ b/lib/amazonka-core/test/Test/Amazonka/Data/Query.hs
@@ -48,5 +48,34 @@ tests =
                   QPair "baz" (QValue Nothing),
                   QPair "qux" (QValue (Just "3"))
                 ]
+        ],
+      testGroup
+        "toBS"
+        [ testCase "SQS.DeleteMessageBatchRequestEntries" $
+            toBS
+              ( QPair
+                  "DeleteMessageBatchRequestEntry"
+                  ( QList
+                      [ QPair
+                          "1"
+                          ( QList
+                              [ QPair "Id" (QValue (Just "someId")),
+                                QPair "ReceiptHandle" (QValue (Just "someReceiptMessageHandle"))
+                              ]
+                          ),
+                        QPair
+                          "2"
+                          ( QList
+                              [ QPair "Id" (QValue (Just "anotherId")),
+                                QPair "ReceiptHandle" (QValue (Just "anotherReceiptMessageHandle"))
+                              ]
+                          )
+                      ]
+                  )
+              )
+              @?= "DeleteMessageBatchRequestEntry.1.Id=someId&\
+                  \DeleteMessageBatchRequestEntry.1.ReceiptHandle=someReceiptMessageHandle&\
+                  \DeleteMessageBatchRequestEntry.2.Id=anotherId&\
+                  \DeleteMessageBatchRequestEntry.2.ReceiptHandle=anotherReceiptMessageHandle"
         ]
     ]

--- a/lib/amazonka-core/test/Test/Amazonka/Data/Query.hs
+++ b/lib/amazonka-core/test/Test/Amazonka/Data/Query.hs
@@ -76,6 +76,15 @@ tests =
               @?= "DeleteMessageBatchRequestEntry.1.Id=someId&\
                   \DeleteMessageBatchRequestEntry.1.ReceiptHandle=someReceiptMessageHandle&\
                   \DeleteMessageBatchRequestEntry.2.Id=anotherId&\
-                  \DeleteMessageBatchRequestEntry.2.ReceiptHandle=anotherReceiptMessageHandle"
+                  \DeleteMessageBatchRequestEntry.2.ReceiptHandle=anotherReceiptMessageHandle",
+          -- Test for correct canonicalisation. We must sort the query
+          -- entries before joining them to the values, otherwise we
+          -- create incorrect canonical requests during signing.
+          --
+          -- See: https://github.com/brendanhay/amazonka/issues/965#issuecomment-2709868936
+          -- See: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html#:~:text=alphabetically%20by%20key%20name
+          testCase "S3.SelectObjectContent" $
+            toBS ("select&select-type=2" :: QueryString)
+              @?= "select=&select-type=2"
         ]
     ]

--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -32,6 +32,8 @@
 
 ### Fixed
 
+- `amazonka-core`: Fixed the sorting of query parameters during request canonicalisation. In rare cases, it could sort incorrectly, resulting in requests that failed signature verification.
+[\#1031](https://github.com/brendanhay/amazonka/pull/1031)
 - `amazonka`: Attempt to load credentials in the correct order. In particular, this means that the IMDS is queried last and is once again consistent with other SDKs.
 [\#1029](https://github.com/brendanhay/amazonka/pull/1029)
 - `.cabal` files name the source repository with a `https://` URL, not a `git://` one (thanks @marinelli)


### PR DESCRIPTION
@nitinprakash96 please check if this works for you.

This PR fixes the ordering of query parameters during request signing. They should now sort correctly in all instances. Although I've added tests, I really don't want to break anything here. If you use Amazonka with an API that uses query parameters in its request format (potentially: IAM, SNS, SimpleDB, CloudWatch, SES, RDS, STS, Elastic Load Balancing (v1 or v2), SQS, DocumentDB, CloudSearch, Redshift, Application Auto Scaling, CloudFormation, Neptune, Elasticache (control plane), Elastic Beanstalk, or Import/Export), I'd love to hear from you.

Partial fix for #965 