### PR TITLE
Allow containers-0.7

### DIFF
--- a/lib/amazonka-core/amazonka-core.cabal
+++ b/lib/amazonka-core/amazonka-core.cabal
@@ -108,7 +108,7 @@ library
     , case-insensitive      >=1.2
     , conduit               >=1.3
     , conduit-extra         >=1.3
-    , containers            >=0.5       && <0.7
+    , containers            >=0.5       && <0.8
     , crypton               >=0.32      && <0.35  || ^>=1.0.0
     , deepseq               >=1.4
     , hashable              >=1.2

--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -33,6 +33,8 @@
 
 ### Fixed
 
+- `amazonka-core`: `containers ^>= 0.7` is now supported. `containers-0.7` is shipped with GHC 9.10 and 9.12.
+[\#1036](https://github.com/brendanhay/amazonka/pull/1036)
 - `amazonka-core`: Accept single-digit days when parsing RFC822 dates
 [\#1032](https://github.com/brendanhay/amazonka/pull/1032)
 - `amazonka-core`: Fixed the sorting of query parameters during request canonicalisation. In rare cases, it could sort incorrectly, resulting in requests that failed signature verification.


### PR DESCRIPTION
Tested using

```
cabal build lib:amazonka-core -c 'containers>=0.7' -w ghc-9.12.2
```

Even though containers-0.8 is out, it isn't supported by other dependencies yet. So let's start with just allowing containers-0.7. This means that this PR *doesn't* address #1035.
