### PR TITLE
fix default to region sts url incase SHOULD_MAKE_URL_FROM_REGION_STS env is not present.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,1 @@
+/nix/store/gibnwpzrkwdxrbqqi5bal01i64pzs2jy-pre-commit-config.json

--- a/lib/amazonka-core/src/Amazonka/Endpoint.hs
+++ b/lib/amazonka-core/src/Amazonka/Endpoint.hs
@@ -16,6 +16,9 @@ import Amazonka.Data.ByteString
 import Amazonka.Prelude
 import Amazonka.Types
 import qualified Data.CaseInsensitive as CI
+import System.Environment as Environment
+import GHC.IO (unsafePerformIO)
+import qualified Data.Text as Text
 
 -- | A convenience function for overriding the 'Service' 'Endpoint'.
 --
@@ -74,7 +77,7 @@ defaultEndpoint Service {endpointPrefix = p} r = go (CI.mk p)
     virginia = r == NorthVirginia
     frankfurt = r == Frankfurt
     china = r == Beijing
-    govcloud = r == GovCloudEast || r == GovCloudWest || r == Hyderabad || r == Mumbai
+    govcloud = r == GovCloudEast || r == GovCloudWest || shouldMakeURLFromRegionSTS
 
     region host =
       Endpoint
@@ -95,3 +98,8 @@ defaultEndpoint Service {endpointPrefix = p} r = go (CI.mk p)
         }
 
     reg = toBS r
+
+    shouldMakeURLFromRegionSTS :: Bool
+    shouldMakeURLFromRegionSTS =
+      let mval = unsafePerformIO $ Environment.lookupEnv "SHOULD_MAKE_URL_FROM_REGION_STS"
+      in maybe False (\x -> (Text.toLower . Text.pack) x == "true") mval

--- a/lib/amazonka-core/src/Amazonka/Endpoint.hs
+++ b/lib/amazonka-core/src/Amazonka/Endpoint.hs
@@ -74,7 +74,7 @@ defaultEndpoint Service {endpointPrefix = p} r = go (CI.mk p)
     virginia = r == NorthVirginia
     frankfurt = r == Frankfurt
     china = r == Beijing
-    govcloud = r == GovCloudEast || r == GovCloudWest
+    govcloud = r == GovCloudEast || r == GovCloudWest || r == Hyderabad || r == Mumbai
 
     region host =
       Endpoint

--- a/lib/amazonka-core/src/Amazonka/Endpoint.hs
+++ b/lib/amazonka-core/src/Amazonka/Endpoint.hs
@@ -102,4 +102,4 @@ defaultEndpoint Service {endpointPrefix = p} r = go (CI.mk p)
     shouldMakeURLFromRegionSTS :: Bool
     shouldMakeURLFromRegionSTS =
       let mval = unsafePerformIO $ Environment.lookupEnv "SHOULD_MAKE_URL_FROM_REGION_STS"
-      in maybe False (\x -> (Text.toLower . Text.pack) x == "true") mval
+      in maybe True (\x -> (Text.toLower . Text.pack) x == "true") mval

--- a/lib/amazonka-core/src/Amazonka/Types.hs
+++ b/lib/amazonka-core/src/Amazonka/Types.hs
@@ -881,9 +881,6 @@ pattern Melbourne = Region' "ap-southeast-4"
 pattern Mumbai :: Region
 pattern Mumbai = Region' "ap-south-1"
 
-pattern Hyderabad :: Region
-pattern Hyderabad = Region' "ap-south-2"
-
 pattern Osaka :: Region
 pattern Osaka = Region' "ap-northeast-3"
 

--- a/lib/amazonka/amazonka.cabal
+++ b/lib/amazonka/amazonka.cabal
@@ -99,7 +99,7 @@ library
     Amazonka.Data, Amazonka.Types, Amazonka.Bytes, Amazonka.Endpoint, Amazonka.Crypto
 
   build-depends:
-    , aeson                 ^>=1.5.0.0  || >=2.0 && <2.1 || ^>=2.1
+    , aeson                 ^>=1.5.0.0 || >=2.0 && <2.1 || ^>=2.1
     , amazonka-core         ^>=2.0
     , amazonka-sso          ^>=2.0
     , amazonka-sts          ^>=2.0
@@ -107,8 +107,8 @@ library
     , conduit               >=1.3
     , directory             >=1.2
     , exceptions            ^>=0.10.4
-    , http-client           >=0.5       && <0.8
-    , http-conduit          >=2.3       && <3
+    , http-client           >=0.5      && <0.8
+    , http-conduit          >=2.3      && <3
     , http-types            >=0.12
     , ini                   >=0.3.5
     , lens                  >=4
@@ -117,5 +117,5 @@ library
     , text                  >=1.1
     , time                  >=1.9
     , transformers          >=0.2
-    , unordered-containers  ^>=0.2.14.0
-    , uuid                  >=1.2.6     && <1.4
+    , unordered-containers  ==0.2.13.0
+    , uuid                  >=1.2.6    && <1.4

--- a/lib/amazonka/src/Amazonka/Auth/ConfigFile.hs
+++ b/lib/amazonka/src/Amazonka/Auth/ConfigFile.hs
@@ -162,7 +162,7 @@ mergeConfigs creds confs =
     (HashMap.fromList <$> stripProfiles confs)
   where
     stripProfiles :: HashMap Text v -> HashMap Text v
-    stripProfiles = HashMap.mapKeys $ Text.unwords . stripProfile . Text.words
+    stripProfiles = HashMap.fromList . map (\(k, v) -> (Text.unwords $ stripProfile $ Text.words k, v)) . HashMap.toList
 
     stripProfile = \case
       [w] -> [w]

--- a/lib/services/amazonka-s3/src/Amazonka/S3/Internal.hs
+++ b/lib/services/amazonka-s3/src/Amazonka/S3/Internal.hs
@@ -290,7 +290,6 @@ getWebsiteEndpoint = \case
   Jakarta -> Just "s3-website.ap-southeast-3.amazonaws.com"
   Melbourne -> Just "s3-website.ap-southeast-4.amazonaws.com"
   Mumbai -> Just "s3-website.ap-south-1.amazonaws.com"
-  Hyderabad -> Just "s3-website.ap-south-2.amazonaws.com."
   Osaka -> Just "s3-website.ap-northeast-3.amazonaws.com"
   Seoul -> Just "s3-website.ap-northeast-2.amazonaws.com"
   Singapore -> Just "s3-website-ap-southeast-1.amazonaws.com"


### PR DESCRIPTION
AWS has deprecated the use of global endpoint sts.amazonaws.com and such changing the default to use regional endpoint. 