### PR TITLE
Fix CI config issues (actually build with different GHC versions)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
             extra-substituters = https://cache.iog.io
             experimental-features = nix-command flakes
+            accept-flake-config = true
 
       - uses: cachix/cachix-action@v17
         with:
@@ -72,6 +73,7 @@ jobs:
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
             extra-substituters = https://cache.iog.io
             experimental-features = nix-command flakes
+            accept-flake-config = true
 
       - uses: cachix/cachix-action@v17
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,13 +6,13 @@ concurrency:
 
 on:
   pull_request:
-    branches: main
+    branches: [ main ]
     types:
       - opened
       - synchronize
 
   push:
-    branches: main
+    branches: [ main ]
     paths-ignore:
       - "configs/**"
       - "scripts/**"
@@ -23,13 +23,10 @@ on:
 
 jobs:
   amazonka-gen:
-    strategy:
-      fail-fast: false
-
     runs-on: ubuntu-latest
 
     steps:
-      - uses: cachix/install-nix-action@v22
+      - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
@@ -37,12 +34,12 @@ jobs:
             extra-substituters = https://cache.iog.io
             experimental-features = nix-command flakes
 
-      - uses: cachix/cachix-action@v12
+      - uses: cachix/cachix-action@v17
         with:
           name: amazonka
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - run: nix build
 
@@ -68,7 +65,7 @@ jobs:
         run: |-
           sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt &
 
-      - uses: cachix/install-nix-action@v22
+      - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
@@ -76,19 +73,19 @@ jobs:
             extra-substituters = https://cache.iog.io
             experimental-features = nix-command flakes
 
-      - uses: cachix/cachix-action@v12
+      - uses: cachix/cachix-action@v17
         with:
           name: amazonka
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: cabal update && cabal freeze
         run: |
-          nix develop --print-build-logs --command \
-              bash -c 'cabal update && cabal freeze' '.#${{matrix.ghc}}'
+          nix develop '.#${{matrix.ghc}}' --print-build-logs --command \
+              bash -c 'cabal update && cabal freeze'
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v5
         with:
           key: v1-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
           restore-keys: |
@@ -99,15 +96,15 @@ jobs:
 
       - name: cabal build core
         run: |
-          nix develop --print-build-logs --command \
-              bash -c 'cabal build amazonka-core amazonka' '.#${{matrix.ghc}}'
+          nix develop '.#${{matrix.ghc}}' --print-build-logs --command \
+              bash -c 'cabal build amazonka-core amazonka'
 
       - name: cabal build s3-encryption
         run: |
-          nix develop --print-build-logs --command \
-              bash -c 'cabal build amazonka-s3-encryption' '.#${{matrix.ghc}}'
+          nix develop '.#${{matrix.ghc}}' --print-build-logs --command \
+              bash -c 'cabal build amazonka-s3-encryption'
 
       - name: cabal build all
         run: |
-          nix develop --print-build-logs --command \
-              bash -c 'cabal test all' '.#${{matrix.ghc}}'
+          nix develop '.#${{matrix.ghc}}' --print-build-logs --command \
+              bash -c 'cabal test all'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,6 @@ jobs:
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
             extra-substituters = https://cache.iog.io
             experimental-features = nix-command flakes
-            accept-flake-config = true
 
       - uses: cachix/cachix-action@v17
         with:
@@ -73,7 +72,6 @@ jobs:
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
             extra-substituters = https://cache.iog.io
             experimental-features = nix-command flakes
-            accept-flake-config = true
 
       - uses: cachix/cachix-action@v17
         with:

--- a/flake.nix
+++ b/flake.nix
@@ -61,9 +61,13 @@
             pkgs.cabal-install
 
             # Package Dependencies
+            pkgs.bzip2
+            pkgs.elfutils
             pkgs.gmp
             pkgs.ncurses
+            pkgs.xz
             pkgs.zlib
+            pkgs.zstd
 
             # Development Tools
             pkgs.haskellPackages.cabal-fmt
@@ -81,6 +85,8 @@
           shellHook = pre-commit.shellHook + ''
             export BOTOCORE=${botocore.outPath}
             echo "botocore: $BOTOCORE"
+            export PKG_CONFIG_PATH=${pkgs.lib.makeSearchPath "lib/pkgconfig" [ pkgs.bzip2.dev pkgs.elfutils.dev pkgs.xz.dev pkgs.zlib.dev pkgs.zstd.dev ]}
+            export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [ pkgs.bzip2 pkgs.elfutils pkgs.gmp pkgs.ncurses pkgs.xz pkgs.zlib pkgs.zstd ]}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
           '';
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -62,7 +62,6 @@
 
             # Package Dependencies
             pkgs.bzip2
-            pkgs.elfutils
             pkgs.gmp
             pkgs.ncurses
             pkgs.xz
@@ -80,13 +79,13 @@
             pkgs.gh
 
             pkgs.parallel
-          ];
+          ] ++ pkgs.lib.optional pkgs.stdenv.isLinux pkgs.elfutils;
 
           shellHook = pre-commit.shellHook + ''
             export BOTOCORE=${botocore.outPath}
             echo "botocore: $BOTOCORE"
-            export PKG_CONFIG_PATH=${pkgs.lib.makeSearchPath "lib/pkgconfig" [ pkgs.bzip2.dev pkgs.elfutils.dev pkgs.xz.dev pkgs.zlib.dev pkgs.zstd.dev ]}
-            export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [ pkgs.bzip2 pkgs.elfutils pkgs.gmp pkgs.ncurses pkgs.xz pkgs.zlib pkgs.zstd ]}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+            export PKG_CONFIG_PATH=${pkgs.lib.makeSearchPath "lib/pkgconfig" ([ pkgs.bzip2.dev pkgs.xz.dev pkgs.zlib.dev pkgs.zstd.dev ] ++ pkgs.lib.optional pkgs.stdenv.isLinux pkgs.elfutils.dev)}
+            export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath ([ pkgs.bzip2 pkgs.gmp pkgs.ncurses pkgs.xz pkgs.zlib pkgs.zstd ] ++ pkgs.lib.optional pkgs.stdenv.isLinux pkgs.elfutils)}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
           '';
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
 
         renameVersion = version: "ghc" + (pkgs.lib.replaceStrings [ "." ] [ "" ] version);
 
-        mkDevShell = hsPkgs: pkgs.mkShell {
+        mkDevShell = hsPkgs: pkgs.mkShell ({
           name = "amazonka-${renameVersion hsPkgs.ghc.version}";
 
           buildInputs = [
@@ -81,10 +81,10 @@
           shellHook = pre-commit.shellHook + ''
             export BOTOCORE=${botocore.outPath}
             echo "botocore: $BOTOCORE"
-          '' + pkgs.lib.optionalString pkgs.stdenv.isLinux ''
-            export PKG_CONFIG_PATH=${pkgs.lib.makeSearchPath "lib/pkgconfig" [ pkgs.zlib.dev ]}
           '';
-        };
+        } // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+          PKG_CONFIG_PATH = pkgs.lib.makeSearchPath "lib/pkgconfig" [ pkgs.zlib.dev ];
+        });
 
         amazonka-gen =
           # Use ghc92 because we want hashable ==1.3.* for actual

--- a/flake.nix
+++ b/flake.nix
@@ -61,12 +61,9 @@
             pkgs.cabal-install
 
             # Package Dependencies
-            pkgs.bzip2
             pkgs.gmp
             pkgs.ncurses
-            pkgs.xz
             pkgs.zlib
-            pkgs.zstd
 
             # Development Tools
             pkgs.haskellPackages.cabal-fmt
@@ -79,13 +76,13 @@
             pkgs.gh
 
             pkgs.parallel
-          ] ++ pkgs.lib.optional pkgs.stdenv.isLinux pkgs.elfutils;
+          ];
 
           shellHook = pre-commit.shellHook + ''
             export BOTOCORE=${botocore.outPath}
             echo "botocore: $BOTOCORE"
-            export PKG_CONFIG_PATH=${pkgs.lib.makeSearchPath "lib/pkgconfig" ([ pkgs.bzip2.dev pkgs.xz.dev pkgs.zlib.dev pkgs.zstd.dev ] ++ pkgs.lib.optional pkgs.stdenv.isLinux pkgs.elfutils.dev)}
-            export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath ([ pkgs.bzip2 pkgs.gmp pkgs.ncurses pkgs.xz pkgs.zlib pkgs.zstd ] ++ pkgs.lib.optional pkgs.stdenv.isLinux pkgs.elfutils)}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+          '' + pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+            export PKG_CONFIG_PATH=${pkgs.lib.makeSearchPath "lib/pkgconfig" [ pkgs.zlib.dev ]}
           '';
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,8 @@
             echo "botocore: $BOTOCORE"
           '';
         } // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+          # Fix build failure of Haskell zlib package ("error: *** stack smashing detected ***: terminated").
+          # Without this, pkg-config resolves zlib to whatever zlib is installed on ubuntu GitHub action runners
           PKG_CONFIG_PATH = pkgs.lib.makeSearchPath "lib/pkgconfig" [ pkgs.zlib.dev ];
         });
 

--- a/lib/amazonka/CHANGELOG.md
+++ b/lib/amazonka/CHANGELOG.md
@@ -96,6 +96,8 @@
 
 ### Fixed
 
+- Fix GitHub actions CI config issues (not following schema, actually building with different GHC version on ubuntu runners), bump to latest gh action dependencies (fixing deprecated nodejs runtime warnings).
+[\#1057](https://github.com/brendanhay/amazonka/pull/1057)
 - `amazonka`: `Amazonka.Auth.SSO.relativeCachedTokenFile` is now pure
 [\#1056](https://github.com/brendanhay/amazonka/pull/1056)
 - `amazonka-core`: `containers ^>= 0.7` is now supported. `containers-0.7` is shipped with GHC 9.10 and 9.12.


### PR DESCRIPTION
Hello,
I'm potentially interested in helping contributing some work towards unblocking https://github.com/brendanhay/amazonka/issues/1037

But first things first, looking at latest CI run on main https://github.com/brendanhay/amazonka/actions/runs/25209453900
it seems that CI is not in a very good shape.

This PR aims to fix some of that and hopefully unblock bumping the flake.lock dependencies so we could test with more recent versions of GHC.

Together, these changes fix 3 of the 4 CI jobs currently broken on master (see this same PR in my fork: https://github.com/jhrcek/amazonka/pull/2).
What's left is a failure in macOS build, which seems to fail when building the GHC 9.0 bootstrap compiler - not sure how to fix that yet..

Heads up: I'm not very skilled with nix (just know some basics)..