### PR TITLE
Allow aeson 2.3

### DIFF
--- a/lib/amazonka-core/amazonka-core.cabal
+++ b/lib/amazonka-core/amazonka-core.cabal
@@ -102,7 +102,7 @@ library
     Amazonka.Waiter
 
   build-depends:
-    , aeson                 ^>=1.5.0.0  || ^>=2.0 || ^>=2.1   || ^>=2.2
+    , aeson                 ^>=1.5.0.0  || ^>=2.0 || ^>=2.1   || ^>=2.2 || ^>=2.3
     , attoparsec            >=0.11.3
     , bytestring            >=0.10.8
     , case-insensitive      >=1.2

--- a/lib/amazonka-dynamodb-attributevalue/amazonka-dynamodb-attributevalue.cabal
+++ b/lib/amazonka-dynamodb-attributevalue/amazonka-dynamodb-attributevalue.cabal
@@ -38,7 +38,7 @@ library
   hs-source-dirs:  src
   exposed-modules: Amazonka.DynamoDB.AttributeValue
   build-depends:
-    , aeson          ^>=1.5.0.0 || ^>=2.0 || ^>=2.1 || ^>=2.2
+    , aeson          ^>=1.5.0.0 || ^>=2.0 || ^>=2.1 || ^>=2.2 || ^>=2.3
     , amazonka-core  ^>=2.0
     , containers
     , hashable       >=1.3.4.0  && <1.6

--- a/lib/amazonka-s3-encryption/amazonka-s3-encryption.cabal
+++ b/lib/amazonka-s3-encryption/amazonka-s3-encryption.cabal
@@ -93,7 +93,7 @@ library
     Amazonka.S3.Encryption.Types
 
   build-depends:
-    , aeson                 ^>=1.5.0.0 || ^>=2.0 || ^>=2.1   || ^>=2.2
+    , aeson                 ^>=1.5.0.0 || ^>=2.0 || ^>=2.1   || ^>=2.2 || ^>=2.3
     , amazonka              ^>=2.0
     , amazonka-core         ^>=2.0
     , amazonka-kms          ^>=2.0

--- a/lib/amazonka/amazonka.cabal
+++ b/lib/amazonka/amazonka.cabal
@@ -101,7 +101,7 @@ library
     Amazonka.Data, Amazonka.Types, Amazonka.Bytes, Amazonka.Endpoint, Amazonka.Crypto
 
   build-depends:
-    , aeson                 ^>=1.5.0.0  || ^>=2.0 || ^>=2.1 || ^>=2.2
+    , aeson                 ^>=1.5.0.0  || ^>=2.0 || ^>=2.1 || ^>=2.2 || ^>=2.3
     , amazonka-core         ^>=2.0
     , amazonka-sso          ^>=2.0
     , amazonka-sts          ^>=2.0
@@ -122,17 +122,16 @@ library
     , uuid                  >=1.2.6     && <1.4
 
 test-suite tests
-  import:            base
-  type:              exitcode-stdio-1.0
-  hs-source-dirs:    test
-  main-is:           Main.hs
-  other-modules:
-    Test.Amazonka.Auth.Background
+  import:         base
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is:        Main.hs
+  other-modules:  Test.Amazonka.Auth.Background
   build-depends:
     , amazonka
     , amazonka-core
-    , tasty              >=0.10
-    , tasty-hunit        >=0.9
-    , time
     , http-client
     , http-types
+    , tasty          >=0.10
+    , tasty-hunit    >=0.9
+    , time


### PR DESCRIPTION
https://hackage.haskell.org/package/aeson-2.3.0.0/changelog https://haskell.github.io/security-advisories/advisory/HSEC-2026-0007.html

Built with

    cabal build all \
      --enable-tests --enable-benchmarks \
      --constraint=aeson==2.3.0.0 \
      --allow-newer=pandoc:aeson \
      --allow-newer=pandoc-types:aeson \
      --allow-newer=aeson-pretty:aeson

And tested with `cabal test` with the same flags