### PR TITLE
Update crypton deps to support v1.1.x and migrate from memory to ram

### DIFF
--- a/lib/amazonka-core/amazonka-core.cabal
+++ b/lib/amazonka-core/amazonka-core.cabal
@@ -109,16 +109,16 @@ library
     , conduit               >=1.3
     , conduit-extra         >=1.3
     , containers            >=0.5       && <0.8
-    , crypton               >=0.32      && <0.35  || ^>=1.0.0
+    , crypton               >=0.32      && <0.35  || >=1.0 && <1.2
     , deepseq               >=1.4
     , hashable              >=1.2
     , http-client           >=0.5       && <0.8
     , http-conduit          >=2.3       && <3
     , http-types            >=0.12
-    , memory                >=0.6
     , microlens             ^>=0.4.13.1
     , microlens-contra      ^>=0.1.0.3
     , microlens-pro         ^>=0.2.0
+    , ram                   ^>=0.22
     , regex-posix           >=0.96
     , resourcet             >=1.1
     , scientific            >=0.3

--- a/lib/amazonka-s3-encryption/amazonka-s3-encryption.cabal
+++ b/lib/amazonka-s3-encryption/amazonka-s3-encryption.cabal
@@ -101,12 +101,12 @@ library
     , bytestring            >=0.10.8
     , case-insensitive      >=1.2
     , conduit               >=1.3
-    , crypton               >=0.32     && <0.35  || ^>=1.0.0
+    , crypton               >=0.32     && <0.35  || >=1.0 && <1.2
     , http-client           >=0.5      && <0.8
-    , memory                >=0.6
     , microlens
     , microlens-pro
     , mtl                   >=2.1.3.1
+    , ram                   ^>=0.22
     , text                  >=1.1
     , unordered-containers  >=0.2.5
 
@@ -128,7 +128,7 @@ test-suite amazonka-s3-encryption-test
     , base
     , bytestring
     , conduit
-    , crypton
+    , crypton                >=0.32     && <0.35  || >=1.0 && <1.2
     , mtl
     , QuickCheck
     , quickcheck-instances    >=0.3.25.2


### PR DESCRIPTION
- Relax crypton upper bound from ^>=1.0.0 (i.e. <1.1) to <1.2 to support crypton 1.1.x
- Replace 'memory' package dependency with 'ram' (>=0.22), an API-compatible fork required by latest crypton
- Update both amazonka-core and amazonka-s3-encryption cabal files